### PR TITLE
Add observability dashboards and alerts

### DIFF
--- a/docs/developer-cheat-sheet.md
+++ b/docs/developer-cheat-sheet.md
@@ -26,6 +26,18 @@ uv run python scripts/validate_prometheus_config.py --values helm/splattop/value
 trufflehog filesystem --no-update --only-verified --fail .
 ```
 
+## Observability Assets
+
+- Grafana dashboard JSON lives in `helm/splattop/files/grafana/dashboards/`.
+- Dashboard mounting is wired in `helm/splattop/templates/monitoring-grafana-configmaps.yaml`.
+- Alert rules live in `helm/splattop/templates/monitoring-prometheus-rules-configmap.yaml`.
+- The `Hot Paths & Snapshots` dashboard is the first place to look for:
+  - lookup snapshot freshness/build outcomes,
+  - main `/player/{id}` pipeline timings and payload sizes,
+  - public `comp.splat.top` player summary/history/results latency and cache behavior.
+- After touching alerts or dashboards, rerun:
+  - `uv run python scripts/validate_prometheus_config.py --values helm/splattop/values-prod.yaml`
+
 ## Coordinating with App Repo
 
 - Rebuild images only if you touch code/dockerfiles; config-only changes never trigger builds.

--- a/helm/splattop/files/grafana/dashboards/observability.json
+++ b/helm/splattop/files/grafana/dashboards/observability.json
@@ -1,0 +1,312 @@
+{
+  "uid": "hot-paths-snapshots",
+  "title": "Hot Paths & Snapshots",
+  "tags": ["splattop", "observability"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Lookup Snapshot Age",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1800},
+              {"color": "red", "value": 2700}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "time() - max(lookup_sqlite_snapshot_last_success_timestamp_seconds{kind=\"build\"})",
+          "legendFormat": "build age"
+        },
+        {
+          "expr": "time() - max(lookup_sqlite_snapshot_last_success_timestamp_seconds{kind=\"reload\"})",
+          "legendFormat": "reload age"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Lookup Snapshot Outcomes",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lookup_sqlite_snapshot_events_total[5m])) by (action, outcome)",
+          "legendFormat": "{{action}} {{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Lookup Snapshot Bytes",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 7},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "max(lookup_sqlite_snapshot_bytes) by (kind)",
+          "legendFormat": "{{kind}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Search Latency",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 7},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.25},
+              {"color": "red", "value": 0.5}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fastapi_request_duration_seconds_bucket{path=\"/api/search/{query}\"}[5m])))",
+          "legendFormat": "request P95"
+        },
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(fastapi_request_duration_seconds_bucket{path=\"/api/search/{query}\"}[5m])))",
+          "legendFormat": "request P50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (outcome, le) (rate(fastapi_search_duration_seconds_bucket[5m])))",
+          "legendFormat": "lookup {{outcome}} P95"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Main Player Detail Pipeline Duration",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 14},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 2}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (stage, le) (rate(player_detail_pipeline_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{stage}} P95"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Main Player Detail Rows",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 14},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (stage, le) (rate(player_detail_rows_bucket[15m])))",
+          "legendFormat": "{{stage}} P95 rows"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Main Player Detail Payload Bytes",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 21},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (kind, le) (rate(player_detail_payload_bytes_bucket[15m])))",
+          "legendFormat": "{{kind}} P95"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Competition Player Route Latency",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 21},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.5},
+              {"color": "red", "value": 0.75}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fastapi_request_duration_seconds_bucket{path=\"/api/ripple/public/player/{player_id}/summary\"}[5m])))",
+          "legendFormat": "summary P95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fastapi_request_duration_seconds_bucket{path=\"/api/ripple/public/player/{player_id}/history\"}[5m])))",
+          "legendFormat": "history P95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(fastapi_request_duration_seconds_bucket{path=\"/api/ripple/public/player/{player_id}/results\"}[5m])))",
+          "legendFormat": "results P95"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Competition Section Cache Outcomes",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 28},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ripple_player_section_cache_requests_total[5m])) by (section, status)",
+          "legendFormat": "{{section}} {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Competition Section Resolve vs Payload",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 28},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (section, le) (rate(ripple_player_section_resolve_seconds_bucket[5m])))",
+          "legendFormat": "{{section}} resolve P95 (s)"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (section, le) (rate(ripple_player_section_payload_bytes_bucket[15m])))",
+          "legendFormat": "{{section}} payload P95 (bytes)"
+        }
+      ]
+    }
+  ],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {"refresh_intervals": ["30s", "1m", "5m", "15m", "1h"]}
+}

--- a/helm/splattop/templates/monitoring-grafana-configmaps.yaml
+++ b/helm/splattop/templates/monitoring-grafana-configmaps.yaml
@@ -46,6 +46,7 @@ data:
 ---
 {{- $dashboardFiles := dict
       "core" (dict "file" "files/grafana/dashboards/core.json" "dataKey" "splattop-overview.json")
+      "observability" (dict "file" "files/grafana/dashboards/observability.json" "dataKey" "hot-paths-and-snapshots.json")
       "splatgpt" (dict "file" "files/grafana/dashboards/splatgpt.json" "dataKey" "splatgpt-operations.json")
       "auth-rate" (dict "file" "files/grafana/dashboards/auth-rate.json" "dataKey" "auth-and-rate.json")
       "realtime" (dict "file" "files/grafana/dashboards/realtime.json" "dataKey" "realtime-channels.json")

--- a/helm/splattop/templates/monitoring-prometheus-rules-configmap.yaml
+++ b/helm/splattop/templates/monitoring-prometheus-rules-configmap.yaml
@@ -46,6 +46,42 @@ data:
               summary: FastAPI P95 latency above 1s
               description: 95th percentile request latency is above 1 second for 10 minutes.
 
+          - alert: LookupSQLiteSnapshotStale
+            expr: |
+              time() - max(lookup_sqlite_snapshot_last_success_timestamp_seconds{kind="build"}) > 2700
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Lookup SQLite snapshot is stale
+              description: The lookup snapshot has not published a successful build for at least 45 minutes, so search and lookup-backed endpoints may drift stale.
+
+          - alert: CompetitionPlayerSummaryLatencyHigh
+            expr: |
+              histogram_quantile(
+                0.95,
+                sum by (le) (
+                  rate(
+                    fastapi_request_duration_seconds_bucket{
+                      path="/api/ripple/public/player/{player_id}/summary"
+                    }[5m]
+                  )
+                )
+              ) > 0.75
+                and sum(
+                  rate(
+                    fastapi_requests_total{
+                      path="/api/ripple/public/player/{player_id}/summary"
+                    }[5m]
+                  )
+                ) > 0.05
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Competition player summary latency is elevated
+              description: The public competition player summary endpoint has sustained P95 latency above 750ms for 15 minutes.
+
           - alert: CeleryTaskFailures
             expr: |
               sum(rate(celery_task_failures_total[5m]))

--- a/helm/splattop/values-prod.yaml
+++ b/helm/splattop/values-prod.yaml
@@ -206,6 +206,9 @@ monitoring:
     - name: core
       configMapName: grafana-dashboard-core
       dataKey: splattop-overview.json
+    - name: observability
+      configMapName: grafana-dashboard-observability
+      dataKey: hot-paths-and-snapshots.json
     - name: splatgpt
       configMapName: grafana-dashboard-splatgpt
       dataKey: splatgpt-operations.json


### PR DESCRIPTION
## Summary
- add a `Hot Paths & Snapshots` Grafana dashboard for lookup freshness, main player-detail pipelines, and competition player routes
- add targeted Prometheus alerts for stale lookup snapshots and slow competition summary latency
- document where observability assets live and how to validate them locally

## Testing
- `uv run python scripts/validate_prometheus_config.py --values helm/splattop/values-prod.yaml`
- `uv run python - <<'PY' ... json.loads(helm/splattop/files/grafana/dashboards/observability.json) ... PY`