### PR TITLE
[codex] Prep multi-zone domain support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,10 @@ These documents capture the canonical workflows for the SplatTop config reposito
 1. `bootstrap.md` – bring-up steps for a fresh cluster + Argo that points to this repo.
 2. `release-workflow.md` – how images flow from the app repo into environment value bumps, including hotfixes/rollbacks.
 3. `argo-operations.md` – AppProject guardrails, policy enforcement, and day-to-day Argo duties.
-4. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
-5. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-6. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+4. `domains-and-hostnames.md` – public hostname rollout checklist, including multi-zone external-dns changes.
+5. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
+6. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+7. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/domains-and-hostnames.md
+++ b/docs/domains-and-hostnames.md
@@ -1,0 +1,27 @@
+# Domains and Hostnames
+
+Use this checklist when adding a new public hostname or rolling out another DNS zone/TLD.
+
+## external-dns scope
+
+- `external-dns` only manages zones that are explicitly listed in `infra/external-dns/deployment.yaml`.
+- Add one `--domain-filter=<zone>` entry per public zone/TLD that this cluster should manage.
+- Keep the filter list tight. Do not remove the filters entirely unless you intentionally want this cluster to manage every zone available to the Cloudflare token.
+- Make sure the Cloudflare token in `infra/external-dns/cloudflare-api-token.enc.yaml` can edit every added zone.
+
+## App ingress and TLS
+
+- Add the hostname to the app's `ingress.hosts` list.
+- For charts with explicit `Certificate` resources, `ingress.tls.certificate.dnsNames` now falls back to the ingress hostnames when left empty. Set `dnsNames` only when you need a custom override.
+- For redirect-only hostnames, prefer `apps/vanity-hosts/values.yaml` instead of making the target app serve multiple canonical domains.
+
+## App-specific follow-up
+
+- `helm/splattop-blog/values-prod.yaml`: update `blog.health.hostHeader`, `blog.env.ALLOWED_HOSTS`, and `blog.env.CSRF_TRUSTED_ORIGINS` when the new hostname is canonical.
+- `helm/splattop/values-prod.yaml`: update `monitoring.grafana.serverDomain` and `monitoring.grafana.serverRootUrl` only if the new Grafana host becomes canonical. If it should just redirect, use vanity hosts.
+
+## Rollout checks
+
+- Sync the `external-dns` Argo app after changing domain filters.
+- Confirm the new hostname resolves to the nginx ingress load balancer before expecting ACME issuance to succeed.
+- Run chart lint for every chart you touched before opening a PR.

--- a/helm/splattop-blog/templates/certificate.yaml
+++ b/helm/splattop-blog/templates/certificate.yaml
@@ -1,4 +1,12 @@
 {{- if and .Values.ingress.enabled .Values.ingress.tls.enabled .Values.ingress.tls.certificate.enabled }}
+{{- $dnsNames := .Values.ingress.tls.certificate.dnsNames | default (list) -}}
+{{- if eq (len $dnsNames) 0 -}}
+{{- range .Values.ingress.hosts -}}
+{{- if .host -}}
+{{- $dnsNames = append $dnsNames .host -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -10,8 +18,10 @@ spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
+  {{- if gt (len $dnsNames) 0 }}
   dnsNames:
-    {{- range .Values.ingress.tls.certificate.dnsNames }}
-    - {{ . }}
+    {{- range $dnsNames }}
+    - {{ . | quote }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/splattop-blog/values-prod.yaml
+++ b/helm/splattop-blog/values-prod.yaml
@@ -36,5 +36,3 @@ ingress:
     secretName: blog-tls-secret
     certificate:
       enabled: true
-      dnsNames:
-      - blog.splat.top

--- a/helm/splattop-blog/values.yaml
+++ b/helm/splattop-blog/values.yaml
@@ -74,4 +74,5 @@ ingress:
     secretName: blog-tls-secret
     certificate:
       enabled: false
+      # Defaults to ingress hostnames when empty.
       dnsNames: []

--- a/helm/splattop/templates/certificate.yaml
+++ b/helm/splattop/templates/certificate.yaml
@@ -1,4 +1,16 @@
 {{- if and .Values.ingress.enabled .Values.ingress.tls.enabled .Values.ingress.tls.certificate.enabled }}
+{{- $dnsNames := .Values.ingress.tls.certificate.dnsNames | default (list) -}}
+{{- if eq (len $dnsNames) 0 -}}
+{{- range .Values.ingress.hosts -}}
+{{- if .host -}}
+{{- $dnsNames = append $dnsNames .host -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $commonName := .Values.ingress.tls.certificate.commonName | default "" -}}
+{{- if and (eq $commonName "") (gt (len $dnsNames) 0) -}}
+{{- $commonName = first $dnsNames -}}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -11,9 +23,13 @@ spec:
   issuerRef:
     name: {{ .Values.ingress.tls.certificate.issuerName }}
     kind: {{ .Values.ingress.tls.certificate.issuerKind }}
-  commonName: {{ .Values.ingress.tls.certificate.commonName }}
+  {{- if $commonName }}
+  commonName: {{ $commonName | quote }}
+  {{- end }}
+  {{- if gt (len $dnsNames) 0 }}
   dnsNames:
-    {{- range .Values.ingress.tls.certificate.dnsNames }}
-    - {{ . }}
+    {{- range $dnsNames }}
+    - {{ . | quote }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/splatvote/templates/certificate.yaml
+++ b/helm/splatvote/templates/certificate.yaml
@@ -1,4 +1,12 @@
 {{- if and .Values.ingress.enabled .Values.ingress.tls.enabled (default false .Values.ingress.tls.certificate.enabled) }}
+{{- $dnsNames := .Values.ingress.tls.certificate.dnsNames | default (list) -}}
+{{- if eq (len $dnsNames) 0 -}}
+{{- range .Values.ingress.hosts -}}
+{{- if .host -}}
+{{- $dnsNames = append $dnsNames .host -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -10,8 +18,10 @@ spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
+  {{- if gt (len $dnsNames) 0 }}
   dnsNames:
-    {{- range .Values.ingress.tls.certificate.dnsNames }}
+    {{- range $dnsNames }}
     - {{ . | quote }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/splatvote/values-prod.yaml
+++ b/helm/splatvote/values-prod.yaml
@@ -62,5 +62,3 @@ ingress:
     secretName: vote-tls-secret
     certificate:
       enabled: true
-      dnsNames:
-      - vote.splat.top

--- a/helm/splatvote/values.yaml
+++ b/helm/splatvote/values.yaml
@@ -102,3 +102,7 @@ ingress:
   tls:
     enabled: false
     secretName: vote-tls-secret
+    certificate:
+      enabled: false
+      # Defaults to ingress hostnames when empty.
+      dnsNames: []

--- a/infra/external-dns/deployment.yaml
+++ b/infra/external-dns/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           args:
             - --source=ingress
             - --source=service
+            # Add one domain filter per public zone/TLD that this cluster should manage.
             - --domain-filter=splat.top
             - --provider=cloudflare
             - --policy=sync


### PR DESCRIPTION
## What changed
- added a domain rollout checklist for public hostnames and multi-zone `external-dns` changes
- documented the `external-dns` domain filter behavior in the deployment manifest
- updated the tracked `Certificate` templates so `dnsNames` fall back to the configured ingress hostnames
- removed redundant hostname duplication from the tracked blog and vote production values

## Why
The repo could already serve more hostnames, but adding another TLD still involved a lot of repeated hostname edits. This change reduces that duplication and makes the zone-level `external-dns` requirement explicit before we start adding additional domains.

## Impact
- adding a new hostname to the tracked blog and vote charts no longer requires a second `dnsNames` edit when the certificate should match the ingress hosts
- the main chart can now derive certificate `dnsNames` and `commonName` from ingress hosts when explicit values are omitted
- operators now have a single checklist for adding another public zone/TLD safely

## Validation
- `helm lint helm/splattop -f helm/splattop/values-prod.yaml`
- `helm lint helm/splatvote -f helm/splatvote/values-prod.yaml`
- `helm lint helm/splattop-blog -f helm/splattop-blog/values-prod.yaml`
- `kubectl kustomize infra/external-dns` could not be run here because `kubectl` is not installed in this environment
