### PR TITLE
Add teams production deployment config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,17 @@ permissions:
 jobs:
   helm-and-kubeconform:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chart:
+          - name: splattop
+            path: helm/splattop
+            release: splattop
+            prod_values: helm/splattop/values-prod.yaml
+          - name: splattop-teams
+            path: helm/splattop-teams
+            release: splattop-teams
+            prod_values: helm/splattop-teams/values-prod.yaml
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,13 +40,13 @@ jobs:
           kubeconform -v
 
       - name: Helm lint
-        run: helm lint helm/splattop
+        run: helm lint "${{ matrix.chart.path }}"
 
       - name: Render manifests (default + prod)
         run: |
           mkdir -p rendered
-          helm template splattop helm/splattop > rendered/default.yaml
-          helm template splattop helm/splattop -f helm/splattop/values-prod.yaml > rendered/prod.yaml
+          helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" > "rendered/${{ matrix.chart.name }}-default.yaml"
+          helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" -f "${{ matrix.chart.prod_values }}" > "rendered/${{ matrix.chart.name }}-prod.yaml"
 
       - name: Run kubeconform
         run: |
@@ -44,7 +55,7 @@ jobs:
             echo "Validating ${file}"
             kubeconform \
               -schema-location default \
-              -skip CiliumNetworkPolicy \
+              -skip CiliumNetworkPolicy,Certificate \
               -strict -summary -exit-on-error "$file"
           done
 
@@ -52,7 +63,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: rendered-manifests
+          name: rendered-manifests-${{ matrix.chart.name }}
           path: rendered
 
   prometheus-rules:

--- a/argocd/applications/splattop-teams-prod.yaml
+++ b/argocd/applications/splattop-teams-prod.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: splattop-teams-prod
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: helm/splattop-teams
+    helm:
+      releaseName: splattop-teams
+      valueFiles:
+        - values.yaml
+        - values-prod.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated: null
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/helm/splattop-teams/Chart.yaml
+++ b/helm/splattop-teams/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: splattop-teams
+description: Helm chart for SplatTopTeams team search and cluster explorer
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+maintainers:
+  - name: cesaregarza
+    url: https://github.com/cesaregarza

--- a/helm/splattop-teams/README.md
+++ b/helm/splattop-teams/README.md
@@ -1,0 +1,14 @@
+# splattop-teams Helm Chart
+
+Deploys the SplatTopTeams API, frontend, and daily embedding refresh CronJob.
+
+## Production host
+
+- `teams-int.splat.top`
+
+## Required secret
+
+`global.databaseSecretName` (default `db-secrets`) must provide either:
+
+- `RANKINGS_DATABASE_URL` or `DATABASE_URL`, or
+- DB parts (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`).

--- a/helm/splattop-teams/templates/_helpers.tpl
+++ b/helm/splattop-teams/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{- define "splattop-teams.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "splattop-teams.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "splattop-teams.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "splattop-teams.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "splattop-teams.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "splattop-teams.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "splattop-teams.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/helm/splattop-teams/templates/certificate.yaml
+++ b/helm/splattop-teams/templates/certificate.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled (default false .Values.ingress.tls.certificate.enabled) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-tls
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.ingress.tls.secretName }}
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    {{- range .Values.ingress.tls.certificate.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/helm/splattop-teams/templates/ingress.yaml
+++ b/helm/splattop-teams/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ .host | quote }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "splattop-teams.fullname" $ }}-{{ .serviceName }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/splattop-teams/templates/teams-api-deployment.yaml
+++ b/helm/splattop-teams/templates/teams-api-deployment.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.teamsApi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-api
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-api
+spec:
+  replicas: {{ .Values.teamsApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "splattop-teams.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: teams-api
+  template:
+    metadata:
+      labels:
+        {{- include "splattop-teams.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: teams-api
+    spec:
+      {{- include "splattop-teams.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: teams-api
+          image: "{{ .Values.teamsApi.image.repository }}:{{ .Values.teamsApi.image.tag | default .Values.global.appImageTag }}"
+          imagePullPolicy: {{ .Values.teamsApi.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.teamsApi.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.global.databaseSecretName }}
+          {{- if .Values.teamsApi.health.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.teamsApi.health.livenessPath }}
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.teamsApi.health.readinessPath }}
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          {{- end }}
+          resources:
+            {{- toYaml .Values.teamsApi.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/helm/splattop-teams/templates/teams-api-service.yaml
+++ b/helm/splattop-teams/templates/teams-api-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.teamsApi.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-api
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-api
+spec:
+  type: {{ .Values.teamsApi.service.type }}
+  ports:
+    - port: {{ .Values.teamsApi.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "splattop-teams.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-api
+{{- end }}

--- a/helm/splattop-teams/templates/teams-frontend-deployment.yaml
+++ b/helm/splattop-teams/templates/teams-frontend-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.teamsFrontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-frontend
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-frontend
+spec:
+  replicas: {{ .Values.teamsFrontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "splattop-teams.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: teams-frontend
+  template:
+    metadata:
+      labels:
+        {{- include "splattop-teams.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: teams-frontend
+    spec:
+      {{- include "splattop-teams.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: teams-frontend
+          image: "{{ .Values.teamsFrontend.image.repository }}:{{ .Values.teamsFrontend.image.tag | default .Values.global.appImageTag }}"
+          imagePullPolicy: {{ .Values.teamsFrontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.teamsFrontend.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.teamsFrontend.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.teamsFrontend.containerPort }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.teamsFrontend.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            capabilities:
+              drop:
+                - ALL
+{{- end }}

--- a/helm/splattop-teams/templates/teams-frontend-service.yaml
+++ b/helm/splattop-teams/templates/teams-frontend-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.teamsFrontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-frontend
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-frontend
+spec:
+  type: {{ .Values.teamsFrontend.service.type }}
+  ports:
+    - port: {{ .Values.teamsFrontend.service.port }}
+      targetPort: {{ .Values.teamsFrontend.containerPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "splattop-teams.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-frontend
+{{- end }}

--- a/helm/splattop-teams/templates/teams-refresh-cronjob.yaml
+++ b/helm/splattop-teams/templates/teams-refresh-cronjob.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.teamsApi.enabled .Values.refresh.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "splattop-teams.fullname" . }}-refresh
+  labels:
+    {{- include "splattop-teams.labels" . | nindent 4 }}
+    app.kubernetes.io/component: teams-refresh
+spec:
+  schedule: {{ .Values.refresh.schedule | quote }}
+  concurrencyPolicy: {{ .Values.refresh.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.refresh.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.refresh.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "splattop-teams.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: teams-refresh
+        spec:
+          {{- include "splattop-teams.imagePullSecrets" . | nindent 10 }}
+          restartPolicy: {{ .Values.refresh.restartPolicy }}
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: refresh
+              image: "{{ .Values.teamsApi.image.repository }}:{{ .Values.teamsApi.image.tag | default .Values.global.appImageTag }}"
+              imagePullPolicy: {{ .Values.teamsApi.image.pullPolicy }}
+              command:
+                {{- toYaml .Values.refresh.command | nindent 16 }}
+              env:
+                {{- range $key, $value := .Values.teamsApi.env }}
+                - name: {{ $key }}
+                  value: {{ $value | quote }}
+                {{- end }}
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.global.databaseSecretName }}
+              resources:
+                {{- toYaml .Values.refresh.resources | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 10001
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/helm/splattop-teams/values-prod.yaml
+++ b/helm/splattop-teams/values-prod.yaml
@@ -1,0 +1,50 @@
+global:
+  environment: production
+  appImageTag: v0.1.0
+
+teamsApi:
+  replicas: 1
+  image:
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
+  env:
+    ENV: production
+    API_RL_PER_MIN: "180"
+    CORS_ORIGINS: "https://teams-int.splat.top"
+    RANKINGS_DB_SCHEMA: "comp_rankings"
+
+teamsFrontend:
+  replicas: 1
+  image:
+    tag: v0.1.0
+    pullPolicy: IfNotPresent
+
+refresh:
+  enabled: true
+  schedule: "15 3 * * *"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - host: teams-int.splat.top
+      paths:
+        - path: /api
+          pathType: Prefix
+          serviceName: api
+          servicePort: 8000
+        - path: /
+          pathType: Prefix
+          serviceName: frontend
+          servicePort: 80
+  tls:
+    enabled: true
+    secretName: teams-int-tls-secret
+    certificate:
+      enabled: true
+      dnsNames:
+        - teams-int.splat.top

--- a/helm/splattop-teams/values.yaml
+++ b/helm/splattop-teams/values.yaml
@@ -1,0 +1,90 @@
+global:
+  environment: development
+  imagePullSecrets:
+    - regcred
+  databaseSecretName: db-secrets
+  appImageTag: v0.1.0
+
+teamsApi:
+  enabled: true
+  replicas: 1
+  image:
+    repository: registry.digitalocean.com/sendouq/teams-api
+    tag: v0.1.0
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    port: 8000
+  env:
+    ENV: development
+    API_RL_PER_MIN: "120"
+    CORS_ORIGINS: "*"
+    RANKINGS_DB_SCHEMA: "comp_rankings"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 600m
+      memory: 768Mi
+  health:
+    enabled: true
+    livenessPath: /api/health
+    readinessPath: /api/ready
+
+teamsFrontend:
+  enabled: true
+  replicas: 1
+  containerPort: 8080
+  image:
+    repository: registry.digitalocean.com/sendouq/teams-frontend
+    tag: v0.1.0
+    pullPolicy: Always
+  service:
+    type: ClusterIP
+    port: 80
+  resources:
+    requests:
+      cpu: 50m
+      memory: 96Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+refresh:
+  enabled: true
+  schedule: "15 3 * * *"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  restartPolicy: Never
+  command:
+    - python
+    - -m
+    - team_jobs.refresh_embeddings
+    - --days
+    - "540"
+    - --keep-runs
+    - "5"
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts: []
+  tls:
+    enabled: false
+    secretName: teams-tls-secret
+    certificate:
+      enabled: false
+      dnsNames: []


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying the SplatTopTeams application, along with updates to the CI workflow to support multiple charts. The changes include the addition of Kubernetes manifests, Helm templates, and configuration files for the new chart, as well as improvements to the CI pipeline for better scalability and artifact management.

**Helm Chart Addition: SplatTopTeams**

* Added a new Helm chart in `helm/splattop-teams` for deploying the SplatTopTeams API, frontend, and CronJob for embedding refresh, including all necessary templates, configuration, and documentation. [[1]](diffhunk://#diff-e92485b8840417d14ee00124a8545d76c7e2bee53fa851d5ff1ab45c6c68a648R1-R9) [[2]](diffhunk://#diff-fabcc1cc214877fe312f860158049200634326758cb457e9f9ae653a6497e5a4R1-R14) [[3]](diffhunk://#diff-7c3013d1dce058e076421d6204c128d9764bc756abb67bc698cf981a5c09d3faR1-R38) [[4]](diffhunk://#diff-e544d0849d510648d3e6e4ac1be89432d2fae5e9d1175126d420f92ecc9096c5R1-R17) [[5]](diffhunk://#diff-591e907834dc843e34603724858ff9b164791b810e7ec6bc9b2f39bc891e31daR1-R37) [[6]](diffhunk://#diff-ed4ded4347e52e426fb9115f0f41cfaf4461bb97430f9286deb74ff31a6caed2R1-R73) [[7]](diffhunk://#diff-086f2754d33de0fc8b867d9a91e2c56dfdec5dba2f5b75d803094f15cd8c1ecfR1-R19) [[8]](diffhunk://#diff-9c7eac3efd311a8a9b0a9f8fdeef629e7bd6af51304f4a9a698de86364349f0fR1-R58) [[9]](diffhunk://#diff-24eb8fef069d604ae8e59718c07ea71b4dd400ab5c33f77a2784e7402ee683d8R1-R19) [[10]](diffhunk://#diff-b90e687363eebe31509b3719e3d5ca2a384deae74947ca6504e9cef9d4dccb71R1-R57) [[11]](diffhunk://#diff-fb48ce75699fbbd4f761c0c9311bf2fc3f1a6056dd8f126998df18bd8549ad7cR1-R90) [[12]](diffhunk://#diff-f2722c9cc0dae42f3caec06495110bc15276f46a85bdefc1f7d841aa3b2e9417R1-R50)

* Added production ArgoCD application manifest for `splattop-teams-prod` to enable automated deployment of the new chart.

**CI/CD Pipeline Improvements**

* Updated `.github/workflows/ci.yaml` to use a matrix strategy for Helm and Kubeconform jobs, allowing validation and manifest rendering for both `splattop` and `splattop-teams` charts. Improved artifact naming and expanded Kubeconform skip list to include `Certificate` resources. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR15-R25) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL32-R49) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL47-R66)