### PR TITLE
[bot] Update splattop-blog image to v1.0.32

### DIFF
--- a/helm/splattop-blog/values-prod.yaml
+++ b/helm/splattop-blog/values-prod.yaml
@@ -5,7 +5,7 @@ global:
 blog:
   replicas: 1
   image:
-    tag: v1.0.30
+    tag: v1.0.32
     pullPolicy: IfNotPresent
   health:
     hostHeader: blog.splat.top


### PR DESCRIPTION
Automated update from SplatTopBlog repository.

**Source commit:** cesaregarza/SplatTopBlog@866497b3cad2b966e0b7c9dea824d5fe3c9e14d8
**Image tag:** v1.0.32

This PR was created automatically by the CI/CD pipeline.