### PR TITLE
[bot] Update spotify-hot-100 image sha-be1a577aba3b78e99e8c28ab98301efce5198da2

### DIFF
--- a/helm/spotify-hot-100/values.yaml
+++ b/helm/spotify-hot-100/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/spotify-hot-100
-  tag: sha-ce9ba3c8237102e1015ec3cc104801db23429565
+  tag: sha-be1a577aba3b78e99e8c28ab98301efce5198da2
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Source: cesaregarza/spotify-hot-100@be1a577aba3b78e99e8c28ab98301efce5198da2

Image tag: sha-be1a577aba3b78e99e8c28ab98301efce5198da2
Image digest: sha256:18659e94111251fc4bdcb6259d48d1280de0ed8dde80615f59071331193f2c49