### PR TITLE
[codex] Add SkyQuiet server deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
             path: helm/splattop-teams
             release: splattop-teams
             prod_values: helm/splattop-teams/values-prod.yaml
+          - name: skyquiet-server
+            path: helm/skyquiet-server
+            release: skyquiet-server
+            prod_values: helm/skyquiet-server/values.yaml
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -22,6 +22,9 @@ creation_rules:
   - path_regex: ^secrets/spotify-hot-100/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+  - path_regex: ^secrets/skyquiet-server/.*\.enc\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
   - path_regex: ^secrets/bots/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt

--- a/argocd/applications/skyquiet-server-secrets.yaml
+++ b/argocd/applications/skyquiet-server-secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: skyquiet-server-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: secrets/skyquiet-server
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/applications/skyquiet-server.yaml
+++ b/argocd/applications/skyquiet-server.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: skyquiet-server
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: helm/skyquiet-server
+    helm:
+      releaseName: skyquiet-server
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/helm/skyquiet-server/Chart.yaml
+++ b/helm/skyquiet-server/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: skyquiet-server
+description: SkyQuiet aircraft alert backend
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/skyquiet-server/templates/_helpers.tpl
+++ b/helm/skyquiet-server/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "skyquiet-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "skyquiet-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Runtime environment variables.
+*/}}
+{{- define "skyquiet-server.env" -}}
+{{- range $key := .Values.secretKeys }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.global.runtimeSecretName }}
+      key: {{ $key }}
+{{- end }}
+{{- range $key := .Values.optionalSecretKeys }}
+- name: {{ $key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.global.runtimeSecretName }}
+      key: {{ $key }}
+      optional: true
+{{- end }}
+{{- range $key, $value := .Values.env }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "skyquiet-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "skyquiet-server.labels" -}}
+helm.sh/chart: {{ include "skyquiet-server.chart" . }}
+{{ include "skyquiet-server.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "skyquiet-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "skyquiet-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image pull secrets.
+*/}}
+{{- define "skyquiet-server.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/skyquiet-server/templates/api-deployment.yaml
+++ b/helm/skyquiet-server/templates/api-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "skyquiet-server.fullname" . }}-api
+  labels:
+    {{- include "skyquiet-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "skyquiet-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "skyquiet-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      {{- include "skyquiet-server.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- include "skyquiet-server.env" . | nindent 12 }}
+          {{- if .Values.health.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.health.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.health.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.health.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.health.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.health.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.health.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.health.readiness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/helm/skyquiet-server/templates/certificate.yaml
+++ b/helm/skyquiet-server/templates/certificate.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled .Values.ingress.tls.certificate.enabled }}
+{{- $dnsNames := .Values.ingress.tls.certificate.dnsNames | default .Values.ingress.hosts -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "skyquiet-server.fullname" . }}-cert
+  labels:
+    {{- include "skyquiet-server.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.ingress.tls.secretName }}
+  issuerRef:
+    name: {{ .Values.ingress.tls.certificate.issuerName | default "letsencrypt-prod" }}
+    kind: ClusterIssuer
+  dnsNames:
+    {{- range $dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/helm/skyquiet-server/templates/ingress.yaml
+++ b/helm/skyquiet-server/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "skyquiet-server.fullname" . }}
+  labels:
+    {{- include "skyquiet-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "skyquiet-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/helm/skyquiet-server/templates/service.yaml
+++ b/helm/skyquiet-server/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "skyquiet-server.fullname" . }}
+  labels:
+    {{- include "skyquiet-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "skyquiet-server.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/helm/skyquiet-server/templates/worker-deployment.yaml
+++ b/helm/skyquiet-server/templates/worker-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "skyquiet-server.fullname" . }}-worker
+  labels:
+    {{- include "skyquiet-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "skyquiet-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "skyquiet-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      {{- include "skyquiet-server.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - node
+            - dist/server/worker.js
+          env:
+            {{- include "skyquiet-server.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/helm/skyquiet-server/values.yaml
+++ b/helm/skyquiet-server/values.yaml
@@ -5,7 +5,7 @@ global:
 
 image:
   repository: registry.digitalocean.com/sendouq/skyquiet-server
-  tag: sha-placeholder
+  tag: sha-204b812eed03e6a15c6b27407d610dbd1e85b401
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/skyquiet-server/values.yaml
+++ b/helm/skyquiet-server/values.yaml
@@ -1,0 +1,82 @@
+global:
+  imagePullSecrets:
+    - regcred
+  runtimeSecretName: skyquiet-server-secrets
+
+image:
+  repository: registry.digitalocean.com/sendouq/skyquiet-server
+  tag: sha-placeholder
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+api:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+worker:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+secretKeys:
+  - DATABASE_URL
+  - DEVICE_SECRET_PEPPER
+
+optionalSecretKeys:
+  - EXPO_ACCESS_TOKEN
+
+env:
+  PORT: "8080"
+  DATABASE_SCHEMA: "skyquiet"
+  CURRENT_LOCATION_MAX_AGE_SECONDS: "600"
+  WORKER_POLL_INTERVAL_MS: "60000"
+  LOG_LEVEL: "info"
+
+health:
+  enabled: true
+  liveness:
+    path: /healthz
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    path: /readyz
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - skyquiet.garz.ai
+  tls:
+    enabled: true
+    secretName: skyquiet-server-tls
+    certificate:
+      enabled: true
+      issuerName: letsencrypt-prod
+      dnsNames: []

--- a/secrets/skyquiet-server/README.md
+++ b/secrets/skyquiet-server/README.md
@@ -1,0 +1,16 @@
+# skyquiet-server Secrets
+
+Runtime secret planned for the `skyquiet-server` Helm release.
+
+Create a SOPS-encrypted `app-secret.enc.yaml` before enabling the deployment in
+production. The secret must be named `skyquiet-server-secrets` in the `default`
+namespace and include:
+
+- `DATABASE_URL`: shared managed Postgres connection string for the dedicated
+  `skyquiet` schema.
+- `DEVICE_SECRET_PEPPER`: high-entropy secret used to hash per-install device
+  bearer tokens.
+- `EXPO_ACCESS_TOKEN`: optional Expo push access token. Omit it unless Expo
+  push requests need to use an authenticated Expo access token.
+
+The app reuses the existing `regcred` pull secret in the `default` namespace.

--- a/secrets/skyquiet-server/app-secret.enc.yaml
+++ b/secrets/skyquiet-server/app-secret.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: skyquiet-server-secrets
+    namespace: default
+type: Opaque
+stringData:
+    DATABASE_URL: ENC[AES256_GCM,data:pGTBCM3B1k7qYA7fwi4v1Audj8DHvjMg9ddJMAJKgwhnL6zqCxWUcUp0I3vJnO+Swu6C1+660HVbAqYbn46Yiddc5GNpaCI7KhNAURanYFfXSYyNERj74sA6NzGOW1yNSw0sx2djG/BRXKgV8E4MZbbvWV0Woate5FEh9fS4V7BQTycnnuPnzsuwqe1K+NDb3GP/CcDpWQt2ExEDW4pDYWQawYAblQZnHHl9Bu4=,iv:Af6SABQ8prvTHAr3H/sqhyVs67iGg1BN78CcxY/NEd8=,tag:qmvZ0YgTj8WZEXBhWXT3Ew==,type:str]
+    DEVICE_SECRET_PEPPER: ENC[AES256_GCM,data:5dZRue2IQWP2b/iZ1i0jypE6/rvnRqndwz7xYOYD/Qmi65E6s4UBf8Q1Kd/qLDDIMhcjIF3JaoJiAlo6XJIlPQ==,iv:M/PCSxPNXzUn6BAjY/w7RZOYHkncn5mPkBe/c4eDcXY=,tag:pwBmYlOKRS4bmXaCCRJ9Cg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvZks1Yko1KzVkTlhJTGlt
+            YzJqUnFqRE8rVWltVVpQOS9KcW0xZGJVTjNNClBUWXhQYXl6L1k2eEZ2cG12Sms5
+            dlg0Z0JPMGRqR0JzWk5ld1llZ2ZIblUKLS0tIHRkeDBvNnJsTGlxSE1hajdrL3lm
+            VlhsMTBiSkVrU2srMUhMcTJnN2JCWUEKbhivyfUn4f29ry7fUkH1oyezldC0dP5L
+            e7/+VBSlpyNzbLii1ALQxpzd5YaiESvp4s+qAghHo7W0T97At4ExOw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-16T18:24:03Z"
+    mac: ENC[AES256_GCM,data:6bA68gHFjueLluleqRptEiM35gvvpgPMwr/REFBNHiLlneveKKZsWweGEZVLqny44k5KXV6Rtjk9EFKHPIy7iC68wsx8Xq7rBhtdigeOGQz4lQX3rLFtWvmY+qx7BF/kDWBnDqxT7LXBpZah97rsZvnXI1FjXa34jH5YjpVHQr0=,iv:seQbOYTkrPEs0BYR0dZ+Dlvb37fZUsFKGOeS2C0XcdE=,tag:mdqmSWt3hNgHrDCVFGvDjw==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/skyquiet-server/ksops.yaml
+++ b/secrets/skyquiet-server/ksops.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: skyquiet-server-secrets
+files:
+  - app-secret.enc.yaml

--- a/secrets/skyquiet-server/kustomization.yaml
+++ b/secrets/skyquiet-server/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+generators:
+  - ksops.yaml


### PR DESCRIPTION
## Summary
- Add the SkyQuiet server Helm chart with API and worker deployments.
- Add Argo CD applications for the SkyQuiet server and its KSOPS-backed runtime secrets.
- Add the SkyQuiet SOPS rule and CI chart validation entry.
- Point the chart at the published immutable image tag `sha-204b812eed03e6a15c6b27407d610dbd1e85b401`.

## Notes
- Runtime secrets are stored as `secrets/skyquiet-server/app-secret.enc.yaml` and reference the shared Postgres database with the dedicated SkyQuiet schema/user.
- The SkyQuiet image publish workflow now gets past the broker credential step and published the server image successfully; its config-bump job failed only because this chart is not on `SplatTopConfig/main` yet.

## Validation
- `helm lint helm/skyquiet-server`
- `helm template skyquiet-server helm/skyquiet-server`