### PR TITLE
feat(citrus): add dev GitOps deployment for citrus-grace

### DIFF
--- a/argocd/applications/citrus.yaml
+++ b/argocd/applications/citrus.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citrus
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: helm/citrus
+    helm:
+      releaseName: citrus
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/argocd/projects/splattop-project.yaml
+++ b/argocd/projects/splattop-project.yaml
@@ -16,6 +16,8 @@ spec:
   destinations:
     - namespace: default
       server: https://kubernetes.default.svc
+    - namespace: citrus
+      server: https://kubernetes.default.svc
     - namespace: splatvote-prod
       server: https://kubernetes.default.svc
     - namespace: monitoring

--- a/docs/domains-and-hostnames.md
+++ b/docs/domains-and-hostnames.md
@@ -21,6 +21,10 @@ Use this checklist when adding a new public hostname or rolling out another DNS 
 - `helm/splattop-blog/values-prod.yaml`: update `blog.health.hostHeader`, `blog.env.ALLOWED_HOSTS`, and `blog.env.CSRF_TRUSTED_ORIGINS` when the new hostname is canonical.
 - `helm/splattop/values-prod.yaml`: update `monitoring.grafana.serverDomain` and `monitoring.grafana.serverRootUrl` only if the new Grafana host becomes canonical. If it should just redirect, use vanity hosts.
 - `helm/garz-ai`: serves FastAPI-backed garz.ai pages, including JustFlip/Habit Taper legal pages at `justflip.garz.ai` and `habit-taper.garz.ai`.
+- Citrus (new): DNS is outside Cloudflare for this cluster, so update app ingress and application settings only (do not change `external-dns` filters) and provision the following records manually:
+  - `citrus-grace.com` A 143.244.222.41
+  - `www.citrus-grace.com` A 143.244.222.41
+  - `dev.citrus-grace.com` A 143.244.222.41
 
 ## Rollout checks
 

--- a/helm/citrus/Chart.yaml
+++ b/helm/citrus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: citrus
+description: Django app for Citrus Grace
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/citrus/templates/_helpers.tpl
+++ b/helm/citrus/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "citrus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "citrus.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "citrus.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}
+{{ include "citrus.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "citrus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "citrus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image pull secrets.
+*/}}
+{{- define "citrus.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/citrus/templates/configmap.yaml
+++ b/helm/citrus/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.application.configMapName }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.application.configData }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "citrus.fullname" . }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app: citrus-web
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: citrus-web
+  template:
+    metadata:
+      labels:
+        app: citrus-web
+    spec:
+      {{- include "citrus.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: django
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+          command: ["sh", "-c"]
+          args:
+            - {{ .Values.application.command | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.application.configMapName }}
+            - secretRef:
+                name: {{ .Values.application.secretName }}
+                optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 3
+          volumeMounts:
+            - name: media-volume
+              mountPath: {{ .Values.persistence.mountPath }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: media-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.name }}

--- a/helm/citrus/templates/ingress.yaml
+++ b/helm/citrus/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/helm/citrus/templates/pvc.yaml
+++ b/helm/citrus/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.persistence.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm/citrus/templates/service.yaml
+++ b/helm/citrus/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: citrus-web
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -1,0 +1,63 @@
+global:
+  imagePullSecrets:
+    - regcred
+
+replicaCount: 2
+
+image:
+  repository: registry.digitalocean.com/sendouq/citrus
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+application:
+  configMapName: django-config
+  secretName: django-secrets
+  command: >
+    python manage.py migrate --noinput &&
+    python manage.py collectstatic --noinput &&
+    gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
+  configData:
+    DJANGO_DEBUG: "False"
+    ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
+
+service:
+  name: citrus-service
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+
+persistence:
+  enabled: true
+  name: django-media-pvc
+  storageClassName: ""
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  mountPath: /citrus/media
+
+ingress:
+  enabled: true
+  name: citrus-ingress
+  className: nginx
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: "manual"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hosts:
+    - citrus-grace.com
+    - www.citrus-grace.com
+    - dev.citrus-grace.com
+  tls:
+    enabled: true
+    secretName: citrus-grace-tls
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: registry.digitalocean.com/sendouq/citrus
-  tag: latest
+  tag: latest # allow-latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Adds helm/citrus chart and argocd application for Citrus. First rollout targets dev.citrus-grace.com; prod hosts can be added in values when ready.