### PR TITLE
fix: route citrus through legacy ingress

### DIFF
--- a/helm/citrus/templates/ingress.yaml
+++ b/helm/citrus/templates/ingress.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -2,7 +2,7 @@ global:
   imagePullSecrets:
     - regcred
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/citrus
@@ -41,10 +41,12 @@ persistence:
 ingress:
   enabled: true
   name: citrus-ingress
-  className: nginx
+  className: ""
   annotations:
     external-dns.alpha.kubernetes.io/controller: "manual"
+    kubernetes.io/ingress.class: "legacy-nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    acme.cert-manager.io/http01-ingress-class: "legacy-nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - citrus-grace.com


### PR DESCRIPTION
Updates Citrus GitOps config to run one replica with the RWO media PVC and route both the app ingress and cert-manager HTTP-01 solver through the legacy-nginx controller behind 143.244.222.41.