### PR TITLE
fix: use recreate rollout for citrus

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "citrus.labels" . | nindent 4 }}
     app: citrus-web
 spec:
+  strategy:
+    type: Recreate
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
Sets the Citrus Deployment strategy to Recreate so rollouts do not deadlock on the single ReadWriteOnce media PVC.