### PR TITLE
fix: set citrus probe host header

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.targetPort }}
+              {{- if .Values.healthCheck.hostHeader }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.healthCheck.hostHeader | quote }}
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
@@ -44,6 +49,11 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.targetPort }}
+              {{- if .Values.healthCheck.hostHeader }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.healthCheck.hostHeader | quote }}
+              {{- end }}
             initialDelaySeconds: 20
             periodSeconds: 15
             timeoutSeconds: 3

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -23,6 +23,9 @@ application:
     DJANGO_DEBUG: "False"
     ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
 
+healthCheck:
+  hostHeader: dev.citrus-grace.com
+
 service:
   name: citrus-service
   type: ClusterIP


### PR DESCRIPTION
Adds a Host header to Citrus readiness/liveness probes so Django accepts kubelet health checks under ALLOWED_HOSTS.