### PR TITLE
fix: use tcp probes for citrus

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -34,26 +34,14 @@ spec:
                 name: {{ .Values.application.secretName }}
                 optional: true
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.service.targetPort }}
-              {{- if .Values.healthCheck.hostHeader }}
-              httpHeaders:
-                - name: Host
-                  value: {{ .Values.healthCheck.hostHeader | quote }}
-              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.service.targetPort }}
-              {{- if .Values.healthCheck.hostHeader }}
-              httpHeaders:
-                - name: Host
-                  value: {{ .Values.healthCheck.hostHeader | quote }}
-              {{- end }}
             initialDelaySeconds: 20
             periodSeconds: 15
             timeoutSeconds: 3

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -23,8 +23,6 @@ application:
     DJANGO_DEBUG: "False"
     ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
 
-healthCheck:
-  hostHeader: dev.citrus-grace.com
 
 service:
   name: citrus-service


### PR DESCRIPTION
Switches Citrus readiness/liveness probes to TCP socket checks on port 8000 because the root HTTP route returns application-level 500s while gunicorn is healthy.