### PR TITLE
fix: solve citrus http01 on app ingress

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -48,6 +48,7 @@ ingress:
     kubernetes.io/ingress.class: "legacy-nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     acme.cert-manager.io/http01-ingress-class: "legacy-nginx"
+    acme.cert-manager.io/http01-edit-in-place: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - citrus-grace.com


### PR DESCRIPTION
Adds cert-manager's HTTP-01 edit-in-place annotation so Citrus challenges are served by the legacy-nginx app ingress at 143.244.222.41 instead of separate nginx solver ingresses at 152.42.155.167.