### PR TITLE
fix: avoid duplicate citrus http01 overrides

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -47,7 +47,6 @@ ingress:
     external-dns.alpha.kubernetes.io/controller: "manual"
     kubernetes.io/ingress.class: "legacy-nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    acme.cert-manager.io/http01-ingress-class: "legacy-nginx"
     acme.cert-manager.io/http01-edit-in-place: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:


### PR DESCRIPTION
Removes the HTTP-01 ingress class override now that Citrus uses cert-manager edit-in-place. cert-manager rejects having both an ingress-name override and ingress-class override on the same Order.