### PR TITLE
CES-41: wire agent control plane alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 
 ## Quick links
 
-- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/developer-cheat-sheet.md`
+- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/agent-control-plane-alerting.md`, `docs/developer-cheat-sheet.md`
 - KSOPS deep dive and CMP recipe: `docs/ksops-llm-response.md`
 - Argo objects: `argocd/` (AppProjects, Applications, AppSets)
 - Charts/values: `helm/` and `apps/`

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -113,6 +113,7 @@ ingress:
   className: nginx
   annotations:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
     - agent-control-plane.garz.ai
@@ -148,6 +149,12 @@ networkPolicy:
           matchLabels:
             app.kubernetes.io/name: opencode-proposer
             app.kubernetes.io/instance: agent-workloads
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: prometheus
     ports:
       - port: 8000
         protocol: TCP

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,9 @@ Read them in roughly this order when contributing here:
    workload capability wiring.
 8. `runbooks/postgres-restore.md` – DigitalOcean managed Postgres restore
    procedure for the live Mandate `agent-control-plane` deployment.
-9. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-10. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+9. `agent-control-plane-alerting.md` – Mandate metrics scrape, Discord alert route, and live callback-daemon alert test.
+10. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+11. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/agent-control-plane-alerting.md
+++ b/docs/agent-control-plane-alerting.md
@@ -1,0 +1,84 @@
+# Agent Control Plane Alerting
+
+The cluster-level `helm/garz-observability` chart owns Mandate alerting.
+Prometheus discovers the control-plane API pod through the shared
+`kubernetes-pods` annotation scrape job; CES-113 adds the API pod annotations
+and makes `/metrics` scrapeable. This chart adds Prometheus egress to the
+`agent-control-plane` namespace, records stable target labels, renders the
+Mandate alert rules, and routes production alerts to Discord through
+Alertmanager.
+
+## Required Secrets
+
+Create the Discord webhook Secret for Alertmanager:
+
+```bash
+kubectl -n monitoring create secret generic alertmanager-discord-webhook \
+  --from-literal=webhook-url="$DISCORD_WEBHOOK_URL"
+```
+
+## Scrape Path
+
+`helm/garz-observability/values-prod.yaml` enables
+`monitoring.prometheus.agentControlPlane`. The rendered Prometheus config:
+
+- discovers annotated pods through the existing `kubernetes-pods` job;
+- scrapes the control-plane API pod at `/metrics` after CES-113's
+  `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path`
+  annotations land;
+- relabels `namespace`, `pod`, `app_kubernetes_io_name`,
+  `app_kubernetes_io_instance`, and `app_kubernetes_io_component` so Mandate
+  alerts can target the API pod without a static Prometheus job;
+- sends alerts to Alertmanager, which reads the Discord webhook from
+  `/etc/alertmanager/secrets/discord-webhook/webhook-url`.
+
+The `agent-control-plane` app values also allow ingress from Prometheus through
+the namespace NetworkPolicy and set the same 10 MiB ingress request body limit
+used by sibling apps.
+
+## Alert Thresholds
+
+Thresholds are documented next to the rendered rules in
+`helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml`.
+
+Named SLOs:
+
+- `metrics-observability`: the control-plane API must continuously expose one
+  healthy scrape target for live registry-digest and runtime verification.
+- `time-to-claim`: ready governed jobs should be claimed within 5 minutes at
+  this scale.
+- `callback-delivery-latency`: callback outbox events should drain before the
+  backlog exceeds 100 pending rows.
+- `journey-success-rate`: terminal job state and migration health must not
+  degrade host-visible completion.
+
+| Alert | SLO | Source | Threshold |
+| --- | --- | --- | --- |
+| `MandateAgentControlPlaneMetricsDown` | `metrics-observability` | Prometheus scrape health | annotated CP API target absent/down for 5m |
+| `MandateCallbackAdapterDown` | `callback-delivery-latency` | kube-state-metrics deployment availability | fewer than 1 available callback-adapter replica for 5m |
+| `MandateCallbackOutboxBacklog` | `callback-delivery-latency` | Mandate metrics | outbox rows > 100 for 10m |
+| `MandateOldestReadyJobAgeHigh` | `time-to-claim` | Mandate metrics | oldest ready job > 300 seconds for 10m |
+| `MandateDeadLetteredCallbackDeliveries` | `journey-success-rate` | Mandate metrics | dead-lettered delivery count increases in 15m |
+| `MandateMigrationJobFailed` | `journey-success-rate` | kube-state-metrics job status | failed migration job reported for 5m |
+
+The callback-adapter and migration-job alerts require kube-state-metrics. The
+callback daemon heartbeat remains enforced by the Mandate chart liveness probe;
+Prometheus alerts on the resulting Kubernetes deployment availability.
+
+## Test Window
+
+During a maintenance window, verify Discord delivery with a reversible scale test:
+
+```bash
+kubectl -n agent-control-plane scale deployment agent-control-plane-callback-adapter --replicas=0
+```
+
+Wait for `MandateCallbackAdapterDown` to fire and confirm the Discord alert, then
+restore the daemon:
+
+```bash
+kubectl -n agent-control-plane scale deployment agent-control-plane-callback-adapter --replicas=1
+```
+
+The alert should resolve after kube-state-metrics and Alertmanager observe the
+restored replica.

--- a/helm/garz-observability/templates/alertmanager-deployment.yaml
+++ b/helm/garz-observability/templates/alertmanager-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.monitoring.alertmanager.enabled }}
 {{- $monitoringNamespace := include "garzObservability.monitoringNamespace" . -}}
+{{- $discord := .Values.monitoring.alertmanager.discord -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,6 +39,11 @@ spec:
               mountPath: /etc/alertmanager
             - name: data
               mountPath: /alertmanager
+            {{- if $discord.enabled }}
+            - name: discord-webhook
+              mountPath: {{ $discord.webhookMountPath }}
+              readOnly: true
+            {{- end }}
             - name: tmp
               mountPath: /tmp
           readinessProbe:
@@ -69,6 +75,14 @@ spec:
             secretName: {{ .Values.monitoring.alertmanager.configSecret }}
         - name: data
           emptyDir: {}
+        {{- if $discord.enabled }}
+        - name: discord-webhook
+          secret:
+            secretName: {{ $discord.webhookSecretName }}
+            items:
+              - key: {{ $discord.webhookSecretKey }}
+                path: {{ $discord.webhookSecretKey }}
+        {{- end }}
         - name: tmp
           emptyDir: {}
 {{- end }}

--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -86,4 +86,19 @@ data:
             target_label: __address__
             regex: (.+);(\d+)
             replacement: ${1}:${2}
+          - action: replace
+            source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            target_label: app_kubernetes_io_name
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+            target_label: app_kubernetes_io_instance
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+            target_label: app_kubernetes_io_component
 {{- end }}

--- a/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.monitoring.prometheus.enabled .Values.monitoring.prometheus.rules.enabled }}
 {{- $fullName := include "garzObservability.fullname" . -}}
 {{- $rulesConfigMapName := default (printf "%s-prometheus-rules" $fullName) .Values.monitoring.prometheus.rules.configMapName -}}
+{{- $agentControlPlane := .Values.monitoring.prometheus.agentControlPlane -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -63,6 +64,143 @@ data:
             annotations:
               summary: Grafana is unreachable
               description: Grafana metrics endpoint has been unreachable for 5 minutes.
+
+      {{ if $agentControlPlane.enabled }}
+      - name: mandate-agent-control-plane
+        rules:
+          # SLO: metrics observability. The control-plane API should emit one
+          # scrapeable /metrics target continuously; missing samples for 5m
+          # mean operators lose the live signal used by CES-108/CES-113.
+          - alert: MandateAgentControlPlaneMetricsDown
+            expr: |
+              (
+                sum(
+                  up{
+                    job="kubernetes-pods",
+                    namespace={{ $agentControlPlane.namespace | quote }},
+                    app_kubernetes_io_name={{ $agentControlPlane.serviceName | quote }},
+                    app_kubernetes_io_component={{ $agentControlPlane.component | quote }}
+                  }
+                )
+                or vector(0)
+              ) == 0
+            for: 5m
+            labels:
+              severity: critical
+              service: mandate
+              slo: metrics-observability
+            annotations:
+              summary: Mandate control-plane metrics are unreachable
+              description: Prometheus has no healthy annotated scrape target for the Mandate API pod for 5 minutes. Check CES-113 pod annotations, monitoring egress, and API readiness.
+
+          # SLO: callback delivery latency. Callback events should leave the
+          # outbox quickly; no callback-adapter replica for 5m means delivery
+          # cannot make progress.
+          - alert: MandateCallbackAdapterDown
+            expr: |
+              (
+                max(
+                  kube_deployment_status_replicas_available{
+                    namespace={{ $agentControlPlane.namespace | quote }},
+                    deployment=~"{{ $agentControlPlane.serviceName }}-callback-adapter"
+                  }
+                )
+                or vector(0)
+              ) < {{ $agentControlPlane.alerts.callbackAdapterMinAvailableReplicas }}
+            for: 5m
+            labels:
+              severity: critical
+              service: mandate
+              slo: callback-delivery-latency
+            annotations:
+              summary: Mandate callback adapter has no available replica
+              description: The callback adapter deployment has fewer than {{ $agentControlPlane.alerts.callbackAdapterMinAvailableReplicas }} available replica for 5 minutes; callback delivery is stalled.
+
+          # SLO: callback delivery latency. Warn when pending callback work
+          # exceeds the configured backlog threshold for 10m.
+          - alert: MandateCallbackOutboxBacklog
+            expr: |
+              max(
+                mandate_callback_outbox_events_total{
+                  namespace={{ $agentControlPlane.namespace | quote }}
+                }
+              ) > {{ $agentControlPlane.alerts.outboxDepthThreshold }}
+            for: 10m
+            labels:
+              severity: warning
+              service: mandate
+              slo: callback-delivery-latency
+            annotations:
+              summary: Mandate callback outbox backlog is elevated
+              description: Callback outbox rows exceeded {{ $agentControlPlane.alerts.outboxDepthThreshold }} for 10 minutes; the callback adapter may be stalled or downstream delivery may be failing.
+
+          # SLO: time-to-claim. Ready jobs should be claimed within 5 minutes
+          # at this scale; older ready jobs indicate dispatch or worker health
+          # has regressed.
+          - alert: MandateOldestReadyJobAgeHigh
+            expr: |
+              max(
+                mandate_control_oldest_ready_job_age_seconds{
+                  namespace={{ $agentControlPlane.namespace | quote }}
+                }
+              ) > {{ $agentControlPlane.alerts.oldestReadyJobAgeSecondsThreshold }}
+            for: 10m
+            labels:
+              severity: warning
+              service: mandate
+              slo: time-to-claim
+            annotations:
+              summary: Mandate ready job age is high
+              description: The oldest ready job has been ready for more than {{ $agentControlPlane.alerts.oldestReadyJobAgeSecondsThreshold }} seconds for 10 minutes; workers may be down, under-provisioned, or blocked by admission.
+
+          # SLO: journey success rate. Dead-lettered callback delivery growth
+          # means a released or failed terminal state did not reliably reach
+          # the host surface.
+          - alert: MandateDeadLetteredCallbackDeliveries
+            expr: |
+              (
+                max_over_time(
+                  mandate_callback_deliveries_by_status{
+                    namespace={{ $agentControlPlane.namespace | quote }},
+                    status="dead_lettered"
+                  }[15m]
+                )
+                  -
+                min_over_time(
+                  mandate_callback_deliveries_by_status{
+                    namespace={{ $agentControlPlane.namespace | quote }},
+                    status="dead_lettered"
+                  }[15m]
+                )
+              ) > {{ $agentControlPlane.alerts.deadLetteredDeliveryGrowthThreshold }}
+            for: 0m
+            labels:
+              severity: critical
+              service: mandate
+              slo: journey-success-rate
+            annotations:
+              summary: Mandate callback deliveries are dead-lettering
+              description: Dead-lettered callback deliveries increased over 15 minutes; released or failed terminal state delivery may be missing from the host channel.
+
+          # SLO: journey success rate. Failed migrations can leave runtime code
+          # and storage contracts incompatible before jobs can complete.
+          - alert: MandateMigrationJobFailed
+            expr: |
+              max(
+                kube_job_status_failed{
+                  namespace={{ $agentControlPlane.namespace | quote }},
+                  job_name=~"{{ $agentControlPlane.serviceName }}-migrate.*"
+                }
+              ) > 0
+            for: 5m
+            labels:
+              severity: critical
+              service: mandate
+              slo: journey-success-rate
+            annotations:
+              summary: Mandate migration job failed
+              description: A Mandate migration job in {{ $agentControlPlane.namespace }} reported failure for 5 minutes; stop promotion until the schema state is understood.
+      {{ end }}
 
   splattop-app-alerts.yaml: |
     groups:

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -21,6 +21,7 @@ monitoring:
       - monitoring
       - default
       - ingress-nginx
+      - agent-control-plane
       - splattop-bot-agent-8s
       - splattop-bot-agent-8s-dev
   cilium:
@@ -30,6 +31,16 @@ monitoring:
     enabled: true
     rules:
       enabled: true
+    agentControlPlane:
+      enabled: true
+      namespace: agent-control-plane
+      serviceName: agent-control-plane
+      component: api
+      alerts:
+        callbackAdapterMinAvailableReplicas: 1
+        outboxDepthThreshold: 100
+        oldestReadyJobAgeSecondsThreshold: 300
+        deadLetteredDeliveryGrowthThreshold: 0
     service:
       extraServices:
       - name: prometheus
@@ -110,6 +121,29 @@ monitoring:
           app.kubernetes.io/name: splattop
   alertmanager:
     enabled: true
+    config:
+      create: true
+      content: |
+        global:
+          resolve_timeout: 5m
+
+        route:
+          receiver: discord-ops
+          group_by: ["alertname", "namespace"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 4h
+
+        receivers:
+          - name: discord-ops
+            discord_configs:
+              - webhook_url_file: /etc/alertmanager/secrets/discord-webhook/webhook-url
+                send_resolved: true
+    discord:
+      enabled: true
+      webhookSecretName: alertmanager-discord-webhook
+      webhookSecretKey: webhook-url
+      webhookMountPath: /etc/alertmanager/secrets/discord-webhook
     service:
       extraServices:
       - name: alertmanager

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -78,6 +78,16 @@ monitoring:
     rules:
       enabled: false
       configMapName: prometheus-rules
+    agentControlPlane:
+      enabled: false
+      namespace: agent-control-plane
+      serviceName: agent-control-plane
+      component: api
+      alerts:
+        callbackAdapterMinAvailableReplicas: 1
+        outboxDepthThreshold: 100
+        oldestReadyJobAgeSecondsThreshold: 300
+        deadLetteredDeliveryGrowthThreshold: 0
 
   # Grafana configuration
   grafana:
@@ -190,6 +200,11 @@ monitoring:
 
         receivers:
           - name: dev-log
+    discord:
+      enabled: false
+      webhookSecretName: alertmanager-discord-webhook
+      webhookSecretKey: webhook-url
+      webhookMountPath: /etc/alertmanager/secrets/discord-webhook
     resources:
       requests:
         cpu: 50m

--- a/scripts/validate_prometheus_config.py
+++ b/scripts/validate_prometheus_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,10 @@ DEFAULT_RELEASE_NAME = "garz-observability"
 DEFAULT_VALUES_FILE = "helm/garz-observability/values-prod.yaml"
 PROMTOOL_IMAGE = "prom/prometheus:v2.52.0"
 INDENT = "  "
+SECRET_FILE_RE = re.compile(
+    r"^\s*(?:credentials_file|bearer_token_file|password_file|ca_file|cert_file|key_file):\s*['\"]?([^'\"\s]+)['\"]?\s*$",
+    re.MULTILINE,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -186,6 +191,8 @@ def run_promtool_config(config_text: str) -> None:
         cfg_dir = Path(tempdir)
         config_path = cfg_dir / "prometheus.yml"
         config_path.write_text(config_text)
+        secrets_dir = cfg_dir / "secrets"
+        _write_placeholder_secret_files(config_text, secrets_dir)
 
         subprocess.run(
             [
@@ -197,6 +204,8 @@ def run_promtool_config(config_text: str) -> None:
                 "--entrypoint=promtool",
                 "-v",
                 f"{cfg_dir}:/etc/prometheus/conf",
+                "-v",
+                f"{secrets_dir}:/etc/prometheus/secrets:ro",
                 PROMTOOL_IMAGE,
                 "check",
                 "config",
@@ -204,6 +213,18 @@ def run_promtool_config(config_text: str) -> None:
             ],
             check=True,
         )
+
+
+def _write_placeholder_secret_files(config_text: str, secrets_dir: Path) -> None:
+    """Create placeholder files for promtool checks of secret-file references."""
+
+    for raw_path in SECRET_FILE_RE.findall(config_text):
+        if not raw_path.startswith("/etc/prometheus/secrets/"):
+            continue
+        relative_path = Path(raw_path).relative_to("/etc/prometheus/secrets")
+        target = secrets_dir / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("placeholder\n")
 
 
 def run_promtool_rules(rule_files: dict[str, str]) -> None:

--- a/tests/test_agent_control_plane_alerting.py
+++ b/tests/test_agent_control_plane_alerting.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+
+def _render_observability_prod() -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "garz-observability",
+            str(REPO_ROOT / "helm/garz-observability"),
+            "-f",
+            str(REPO_ROOT / "helm/garz-observability/values-prod.yaml"),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    docs = [
+        doc
+        for doc in YAML_PARSER.load_all(result.stdout)
+        if isinstance(doc, dict) and doc
+    ]
+    if not docs:
+        raise AssertionError("helm rendered no Kubernetes documents")
+    return docs
+
+
+def _find_doc(
+    docs: list[dict[str, Any]],
+    *,
+    kind: str,
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    for doc in docs:
+        metadata = doc.get("metadata", {})
+        if doc.get("kind") != kind or metadata.get("name") != name:
+            continue
+        if namespace is not None and metadata.get("namespace") != namespace:
+            continue
+        return doc
+    raise AssertionError(f"{kind}/{name} not rendered")
+
+
+class AgentControlPlaneAlertingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.docs = _render_observability_prod()
+
+    def test_prometheus_annotation_scrape_keeps_control_plane_target_labels(self) -> None:
+        config_map = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-config",
+            namespace="monitoring",
+        )
+        prometheus_config = YAML_PARSER.load(config_map["data"]["prometheus.yml"])
+
+        scrape_configs = prometheus_config["scrape_configs"]
+        pod_job = next(
+            config
+            for config in scrape_configs
+            if config["job_name"] == "kubernetes-pods"
+        )
+        self.assertNotIn(
+            "agent-control-plane",
+            {config["job_name"] for config in scrape_configs},
+        )
+        self.assertNotIn("authorization", pod_job)
+
+        relabel_targets = {
+            tuple(config.get("source_labels", [])): config.get("target_label")
+            for config in pod_job["relabel_configs"]
+        }
+        self.assertEqual(
+            relabel_targets[("__meta_kubernetes_namespace",)],
+            "namespace",
+        )
+        self.assertEqual(
+            relabel_targets[("__meta_kubernetes_pod_name",)],
+            "pod",
+        )
+        self.assertEqual(
+            relabel_targets[("__meta_kubernetes_pod_label_app_kubernetes_io_name",)],
+            "app_kubernetes_io_name",
+        )
+        self.assertEqual(
+            relabel_targets[
+                ("__meta_kubernetes_pod_label_app_kubernetes_io_component",)
+            ],
+            "app_kubernetes_io_component",
+        )
+        rendered_config = config_map["data"]["prometheus.yml"]
+        self.assertNotIn("AGENT_PLATFORM_AUDIT_READ_TOKEN", rendered_config)
+        self.assertNotIn("agent-control-plane-metrics-token", rendered_config)
+
+    def test_prometheus_does_not_mount_control_plane_metrics_token_secret(self) -> None:
+        stateful_set = _find_doc(
+            self.docs,
+            kind="StatefulSet",
+            name="splattop-prod-prometheus",
+            namespace="monitoring",
+        )
+        pod_spec = stateful_set["spec"]["template"]["spec"]
+        container = pod_spec["containers"][0]
+
+        volume_mounts = {mount["name"]: mount for mount in container["volumeMounts"]}
+        self.assertNotIn("agent-control-plane-metrics-token", volume_mounts)
+
+        volumes = {volume["name"]: volume for volume in pod_spec["volumes"]}
+        self.assertNotIn("agent-control-plane-metrics-token", volumes)
+
+    def test_agent_control_plane_alert_rules_render_expected_alerts_and_slos(self) -> None:
+        rules_config_map = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-rules",
+            namespace="monitoring",
+        )
+        rule_file = YAML_PARSER.load(
+            rules_config_map["data"]["cluster-mandate-alerts.yaml"]
+        )
+        groups = {group["name"]: group for group in rule_file["groups"]}
+        mandate_group = groups["mandate-agent-control-plane"]
+        rules = {rule["alert"]: rule for rule in mandate_group["rules"]}
+
+        self.assertEqual(
+            set(rules),
+            {
+                "MandateAgentControlPlaneMetricsDown",
+                "MandateCallbackAdapterDown",
+                "MandateCallbackOutboxBacklog",
+                "MandateOldestReadyJobAgeHigh",
+                "MandateDeadLetteredCallbackDeliveries",
+                "MandateMigrationJobFailed",
+            },
+        )
+        self.assertEqual(
+            rules["MandateAgentControlPlaneMetricsDown"]["labels"]["slo"],
+            "metrics-observability",
+        )
+        self.assertEqual(
+            rules["MandateOldestReadyJobAgeHigh"]["labels"]["slo"],
+            "time-to-claim",
+        )
+        self.assertEqual(
+            {
+                rules["MandateCallbackAdapterDown"]["labels"]["slo"],
+                rules["MandateCallbackOutboxBacklog"]["labels"]["slo"],
+            },
+            {"callback-delivery-latency"},
+        )
+        self.assertEqual(
+            {
+                rules["MandateDeadLetteredCallbackDeliveries"]["labels"]["slo"],
+                rules["MandateMigrationJobFailed"]["labels"]["slo"],
+            },
+            {"journey-success-rate"},
+        )
+        rendered_rules = rules_config_map["data"]["cluster-mandate-alerts.yaml"]
+        self.assertIn('job="kubernetes-pods"', rendered_rules)
+        self.assertIn('namespace="agent-control-plane"', rendered_rules)
+        self.assertIn('app_kubernetes_io_component="api"', rendered_rules)
+        self.assertIn("mandate_callback_outbox_events_total", rendered_rules)
+        self.assertIn("mandate_control_oldest_ready_job_age_seconds", rendered_rules)
+        self.assertIn("kube_deployment_status_replicas_available", rendered_rules)
+        self.assertIn("kube_job_status_failed", rendered_rules)
+
+    def test_alertmanager_routes_to_discord_webhook_file(self) -> None:
+        alertmanager_config = _find_doc(
+            self.docs,
+            kind="Secret",
+            name="alertmanager-config",
+            namespace="monitoring",
+        )
+        config = YAML_PARSER.load(alertmanager_config["stringData"]["alertmanager.yaml"])
+        self.assertEqual(config["route"]["receiver"], "discord-ops")
+        self.assertEqual(
+            config["receivers"][0]["discord_configs"][0]["webhook_url_file"],
+            "/etc/alertmanager/secrets/discord-webhook/webhook-url",
+        )
+
+        deployment = _find_doc(
+            self.docs,
+            kind="Deployment",
+            name="splattop-prod-alertmanager",
+            namespace="monitoring",
+        )
+        pod_spec = deployment["spec"]["template"]["spec"]
+        container = pod_spec["containers"][0]
+        volume_mounts = {mount["name"]: mount for mount in container["volumeMounts"]}
+        self.assertEqual(
+            volume_mounts["discord-webhook"]["mountPath"],
+            "/etc/alertmanager/secrets/discord-webhook",
+        )
+        self.assertTrue(volume_mounts["discord-webhook"]["readOnly"])
+
+        volumes = {volume["name"]: volume for volume in pod_spec["volumes"]}
+        self.assertEqual(
+            volumes["discord-webhook"]["secret"]["secretName"],
+            "alertmanager-discord-webhook",
+        )
+        self.assertEqual(
+            volumes["discord-webhook"]["secret"]["items"],
+            [{"key": "webhook-url", "path": "webhook-url"}],
+        )
+
+    def test_prometheus_network_policy_allows_agent_control_plane_egress(self) -> None:
+        policy = _find_doc(
+            self.docs,
+            kind="NetworkPolicy",
+            name="prometheus-ingress-egress",
+            namespace="monitoring",
+        )
+        egress_namespaces = {
+            selector["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"]
+            for rule in policy["spec"]["egress"]
+            for selector in rule.get("to", [])
+            if "namespaceSelector" in selector
+        }
+        self.assertIn("agent-control-plane", egress_namespaces)
+
+    def test_agent_control_plane_values_allow_prometheus_and_body_limit(self) -> None:
+        values = YAML_PARSER.load(
+            (REPO_ROOT / "apps/agent-control-plane/values.yaml").read_text()
+        )
+        self.assertEqual(
+            values["ingress"]["annotations"]["nginx.ingress.kubernetes.io/proxy-body-size"],
+            "10m",
+        )
+
+        ingress_sources = values["networkPolicy"]["ingress"]["sources"]
+        self.assertIn(
+            {
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": "monitoring",
+                    },
+                },
+                "podSelector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/component": "prometheus",
+                    },
+                },
+            },
+            ingress_sources,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_observability_content_scope.py
+++ b/tests/test_observability_content_scope.py
@@ -15,6 +15,12 @@ CLUSTER_ALERTS = {
     "PrometheusTSDBCapacityHigh",
     "AlertmanagerDown",
     "MandateSyntheticLiveVerifyFailed",
+    "MandateAgentControlPlaneMetricsDown",
+    "MandateCallbackAdapterDown",
+    "MandateCallbackOutboxBacklog",
+    "MandateOldestReadyJobAgeHigh",
+    "MandateDeadLetteredCallbackDeliveries",
+    "MandateMigrationJobFailed",
     "GrafanaDown",
 }
 SPLATTOP_APP_ALERTS = {


### PR DESCRIPTION
## Summary

- Add agent-control-plane alerting on top of the extracted observability chart.
- Wire Prometheus scrape configuration and Alertmanager routing for the CP health signals.
- Add docs and tests for the alerting contracts.

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 69 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `helm lint helm/garz-observability -f helm/garz-observability/values-prod.yaml`
- `helm template garz-observability helm/garz-observability -n monitoring -f helm/garz-observability/values-prod.yaml`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/validate_prometheus_config.py --chart-dir helm/garz-observability -f helm/garz-observability/values-prod.yaml --namespace monitoring --label prod`
- `git diff --check origin/codex/ces-258-observability-content...HEAD`
- Stacked PR scan check is green on head `d3641a2`.

## Notes

Stacked on #230. Still draft/operator-gated until the observability extraction/content stack is accepted and the live monitoring migration is coordinated.
