### PR TITLE
CES-34: wire first agent-workloads worker overlay

### DIFF
--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -1,0 +1,29 @@
+# Agent Control Plane Registry Overlay
+
+This app installs the prod deployment overlay for the first live
+`agent-workloads` worker-service path.
+
+The ConfigMap mounts three files into the Mandate pod:
+
+- `workload_imports.yaml` imports the deployment-pinned
+  `data.workspace_probe` workload manifest and image digest.
+- `agent-data.workspace_probe.json` is the generated `WorkloadManifestV1`
+  captured from the release artifact.
+- `policy.prod.yaml` grants only `agent_workloads.db_probe` to the private admin
+  Discord actor/channel binding.
+
+The current pins come from the latest successful `agent-workloads` main release
+artifact (`sha-5dd0c7e75e9e`). The CES-34 worker-loop hardening changes the
+future workload `code_digest`; after that source PR merges and publishes from
+main, refresh this overlay from the new release artifact before claiming the
+hardened loop is deployed.
+
+The imported manifest is data, not dispatch authority. Mandate still loads the
+overlay through the registry validators, and dispatch still requires the policy
+grant, admission, a matching workload identity claim, lease projection, output
+gate processing, and audit.
+
+`agent_workloads.readonly_query` remains declared in the manifest so the image
+and code digest match the generated release artifact, but it is not granted in
+prod in this first live path. That capability needs a separate rollout after
+the readonly database and model-call gates are explicitly reviewed.

--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -13,10 +13,9 @@ The ConfigMap mounts three files into the Mandate pod:
   Discord actor/channel binding.
 
 The current pins come from the latest successful `agent-workloads` main release
-artifact (`sha-5dd0c7e75e9e`). The CES-34 worker-loop hardening changes the
-future workload `code_digest`; after that source PR merges and publishes from
-main, refresh this overlay from the new release artifact before claiming the
-hardened loop is deployed.
+artifact (`sha-5a6571fc7cb3`). That release includes the CES-34 worker-loop
+hardening, and this overlay uses the machine-generated manifest/image/code
+digests from the release artifact.
 
 The imported manifest is data, not dispatch authority. Mandate still loads the
 overlay through the registry validators, and dispatch still requires the policy

--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
       - id: data.workspace_probe
         manifest_path: registries/imports/agent-data.workspace_probe.json
-        manifest_digest: sha256:1aec5e45812552f48127f82af9c68de2aa3017cf4ca8efc4ca60381a27489c64
-        image_digest: sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0
+        manifest_digest: sha256:9202e308303b197f5979b4f59f797d582b64dd17a99d23fb282033d3bd868d4a
+        image_digest: sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb
         expected_source:
           repo: agent-workloads
           repo_url: https://github.com/cesaregarza/agent-workloads
@@ -92,8 +92,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:3017975de59ee41535327a7cca7557ee7f8e7f8a3696b214321cd83424f52887",
-      "digest": "sha256:1aec5e45812552f48127f82af9c68de2aa3017cf4ca8efc4ca60381a27489c64",
+      "code_digest": "sha256:5910fef362dc4b88fd992e29999fe32eb035e64e3dde02f41471fcd9deabe1de",
+      "digest": "sha256:9202e308303b197f5979b4f59f797d582b64dd17a99d23fb282033d3bd868d4a",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -103,7 +103,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0",
+        "digest": "sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {

--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-control-plane-registry-overlay
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay
+data:
+  workload_imports.yaml: |
+    schema_version: workload-imports.v1
+    imports:
+      - id: data.workspace_probe
+        manifest_path: registries/imports/agent-data.workspace_probe.json
+        manifest_digest: sha256:1aec5e45812552f48127f82af9c68de2aa3017cf4ca8efc4ca60381a27489c64
+        image_digest: sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0
+        expected_source:
+          repo: agent-workloads
+          repo_url: https://github.com/cesaregarza/agent-workloads
+          path: agents/db-workspace-probe/agent.yaml
+        agent:
+          execution_posture: capability_worker
+          network_access: database_only
+          service_account_ref: agent-workloads-worker
+          identity_audience: mandate-api
+          capacity_tier: 4
+          concurrency: 1
+          max_runtime_seconds: 120
+          model_call: true
+        capabilities:
+          agent_workloads.db_probe:
+            description: Imported reversible staging database workspace probe.
+            output_schema: agent_workloads_db_probe_result_v1
+          agent_workloads.readonly_query:
+            description: Imported governed readonly SQL query worker.
+            output_schema: agent_workloads_readonly_query_result_v1
+            model_lease:
+              required: true
+              allowed_tier: fast
+              allowed_profiles:
+                - openai.gpt-5.4-mini
+              max_prompt_tokens: 12000
+              max_completion_tokens: 1200
+              max_total_tokens: 13200
+              max_cost_usd: 0.05
+            session_authority_budget:
+              max_operations: 4
+              session_taint: prod_authority
+  policy.prod.yaml: |
+    defaults:
+      max_cost_usd_per_job: 0.0
+      max_runtime_seconds_per_job: 60
+      aggregate_budget:
+        platform_daily_usd: 25.0
+        per_capability_daily_usd_default: 5.0
+        per_capability_daily_usd: {}
+        per_user_daily_tokens: 200000
+
+    bindings:
+      - id: private-admin-controlled-capabilities
+        description: Production-safe private admin binding for no-key probes,
+          bounded read-only SQL, and the first imported worker-service probe.
+        guild_id: "614277943706910722"
+        channel_id: "1480483954694819940"
+        users:
+          admins:
+            - "94265880216612864"
+          authorized:
+            - "94265880216612864"
+        capabilities:
+          allow:
+            - task.echo
+            - approval.probe
+            - readonly_sql
+            - audit.digest
+            - mandate.ops.inspect
+            - mandate.deploy.smoke
+            - agent_workloads.db_probe
+          approval_overrides:
+            approval.probe: admin_confirm
+  agent-data.workspace_probe.json: |
+    {
+      "capabilities": [
+        "agent_workloads.db_probe",
+        "agent_workloads.readonly_query"
+      ],
+      "capability_metadata": {
+        "agent_workloads.db_probe": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.readonly_query": {
+          "consequence_class": "read_only"
+        }
+      },
+      "code_digest": "sha256:3017975de59ee41535327a7cca7557ee7f8e7f8a3696b214321cd83424f52887",
+      "digest": "sha256:1aec5e45812552f48127f82af9c68de2aa3017cf4ca8efc4ca60381a27489c64",
+      "display_name": "Agent Workloads Data Worker",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.test_agent_probes"
+        ]
+      },
+      "id": "data.workspace_probe",
+      "image": {
+        "digest": "sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0",
+        "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/db-workspace-probe/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -11,6 +11,9 @@ Mandate.
 Required before activation:
 
 - `registry.digitalocean.com/sendouq/agent-platform:<tag>` exists.
+  The current pin is a known main image with workload-import support; after the
+  CES-34 platform auth hardening merges, bump this tag/revision again so missing
+  prod issuer or subject allowlist configuration fails closed in the live API.
 - `agent-control-plane-secrets` has created `regcred` in the
   `agent-control-plane` namespace for DOCR image pulls.
 - `agent-control-plane-secrets` has created `agent-control-plane-secrets` in the
@@ -20,10 +23,20 @@ Required before activation:
 - `AGENT_PLATFORM_ENVIRONMENT=prod` so the live visible capability set is
   limited to the production-safe private-admin `task.echo`, `approval.probe`,
   `readonly_sql`, `audit.digest`, `mandate.ops.inspect`, and
-  `mandate.deploy.smoke` bindings.
+  `mandate.deploy.smoke` bindings plus any capability explicitly granted by the
+  deployment registry overlay.
+- `apps/agent-control-plane-registry-overlay/` is synced before the control
+  plane. It mounts the deployment-pinned `workload_imports.yaml`, generated
+  workload manifest, and prod policy grant overlay into `/app/registries`.
+  Importing the manifest only makes the worker-service agent visible to the
+  registry; dispatch still requires the prod policy grant and Mandate admission.
 - `AGENT_PLATFORM_READONLY_SQL_DATABASE_URL` is present when `readonly_sql` is
   enabled. It must point at a separate weak read-only role, not the platform
   state writer role.
+- `AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER` and
+  `AGENT_PLATFORM_WORKLOAD_IDENTITY_ALLOWED_SUBJECTS_JSON` are explicitly set in
+  prod. Missing issuer or subject allowlist fails closed for HMAC workload
+  identity claims.
 - The OpenClaw droplet has an MCP server entry pointing at the public control
   API URL with the matching OpenClaw service token.
 - The callback adapter deployment uses the same Postgres state as the API and

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -10,10 +10,10 @@ Mandate.
 
 Required before activation:
 
-- `registry.digitalocean.com/sendouq/agent-platform:<tag>` exists.
-  The current pin is a known main image with workload-import support; after the
-  CES-34 platform auth hardening merges, bump this tag/revision again so missing
-  prod issuer or subject allowlist configuration fails closed in the live API.
+- `registry.digitalocean.com/sendouq/agent-platform:<tag>` exists. The current
+  pin is a published main image that includes workload-import support and the
+  CES-34 platform auth hardening, so missing prod issuer or subject allowlist
+  configuration fails closed in the live API.
 - `agent-control-plane-secrets` has created `regcred` in the
   `agent-control-plane` namespace for DOCR image pulls.
 - `agent-control-plane-secrets` has created `agent-control-plane-secrets` in the

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-caefcded7554
+  tag: sha-b2d040432ea3
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-3b0a32bec6a0
+  tag: sha-caefcded7554
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -160,3 +160,21 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+
+extraVolumes:
+  - name: registry-overlay
+    configMap:
+      name: agent-control-plane-registry-overlay
+
+extraVolumeMounts:
+  - name: registry-overlay
+    mountPath: /app/registries/workload_imports.yaml
+    subPath: workload_imports.yaml
+    readOnly: true
+  - name: registry-overlay
+    mountPath: /app/registries/policy.prod.yaml
+    subPath: policy.prod.yaml
+    readOnly: true
+  - name: registry-overlay
+    mountPath: /app/registries/imports
+    readOnly: true

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -10,8 +10,8 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-5dd0c7e75e9e
-  digest: sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0
+  tag: sha-5a6571fc7cb3
+  digest: sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb
   pullPolicy: IfNotPresent
 
 env:
@@ -107,8 +107,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-5dd0c7e75e9e
-    digest: sha256:cfa37adf8e136985c3ad5a90d5d8616f5d1100e5bb6a858d832268255a796e93
+    tag: sha-5a6571fc7cb3
+    digest: sha256:afcdd7b36aff7bca91d23f90683fb2b3db5226b2a6c8b1616f345db2d1f55579
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -10,13 +10,16 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-29cfce71ff32
+  tag: sha-5dd0c7e75e9e
+  digest: sha256:9b7f7d8d71c4d95cf171bf3c519a05c41dcc01c1fcca6a262491d978fbe3e7f0
   pullPolicy: IfNotPresent
 
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
   AGENT_WORKLOADS_WORKER_ID: data.workspace_probe
-  AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.db_probe,agent_workloads.readonly_query
+  AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.db_probe
+  MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE: /var/run/mandate/workload-identity/token
+  AGENT_WORKLOADS_ENVIRONMENT: production
   AGENT_WORKLOADS_SCHEMA: agent_workloads
   AGENT_WORKLOADS_POLL_SECONDS: "2"
   AGENT_WORKLOADS_READONLY_QUERY_MAX_PASSES: "3"
@@ -27,13 +30,22 @@ env:
   OPENAI_SQL_BROKER_TIMEOUT_SECONDS: "45"
 
 secretKeys:
-  - MANDATE_WORKER_TOKEN
   - AGENT_WORKLOADS_DATABASE_URL
-  - OPENAI_CODEX_AUTH_JSON
-  - XSCRAPER_READONLY_DATABASE_URL
 
-secretEnv:
-  MANDATE_WORKLOAD_IDENTITY_TOKEN: DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN
+secretEnv: {}
+
+extraVolumes:
+  - name: workload-identity-token
+    secret:
+      secretName: agent-workloads-secrets
+      items:
+        - key: DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN
+          path: token
+
+extraVolumeMounts:
+  - name: workload-identity-token
+    mountPath: /var/run/mandate/workload-identity
+    readOnly: true
 
 resources:
   requests:
@@ -95,7 +107,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-29cfce71ff32
+    tag: sha-5dd0c7e75e9e
+    digest: sha256:cfa37adf8e136985c3ad5a90d5d8616f5d1100e5bb6a858d832268255a796e93
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN

--- a/argocd/applications/agent-control-plane-registry-overlay.yaml
+++ b/argocd/applications/agent-control-plane-registry-overlay.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-control-plane-registry-overlay
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "9"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: apps/agent-control-plane-registry-overlay
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agent-control-plane
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 3b0a32bec6a070560bc47d4a0bf60621116c3243
+      targetRevision: caefcded75542d8e8254eb05606e6e98ef1a9e35
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: caefcded75542d8e8254eb05606e6e98ef1a9e35
+      targetRevision: b2d040432ea34a1138a4f76a36617ae7cf1f9be8
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/helm/agent-workloads/templates/_helpers.tpl
+++ b/helm/agent-workloads/templates/_helpers.tpl
@@ -46,6 +46,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Image reference for a values image subtree.
+*/}}
+{{- define "agent-workloads.imageRef" -}}
+{{- if .digest -}}
+{{- printf "%s@%s" .repository .digest -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Image pull secrets.
 */}}
 {{- define "agent-workloads.imagePullSecrets" -}}

--- a/helm/agent-workloads/templates/deployment.yaml
+++ b/helm/agent-workloads/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: worker
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "agent-workloads.imageRef" .Values.image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             {{- toYaml .Values.command | nindent 12 }}
@@ -44,6 +44,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
+++ b/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- if .Values.opencodeProposer.initWorkspace.enabled }}
       initContainers:
         - name: init-workspace
-          image: "{{ .Values.opencodeProposer.image.repository }}:{{ .Values.opencodeProposer.image.tag }}"
+          image: "{{ include "agent-workloads.imageRef" .Values.opencodeProposer.image }}"
           imagePullPolicy: {{ .Values.opencodeProposer.image.pullPolicy }}
           command:
             {{- toYaml .Values.opencodeProposer.initWorkspace.command | nindent 12 }}
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
         - name: opencode-proposer
-          image: "{{ .Values.opencodeProposer.image.repository }}:{{ .Values.opencodeProposer.image.tag }}"
+          image: "{{ include "agent-workloads.imageRef" .Values.opencodeProposer.image }}"
           imagePullPolicy: {{ .Values.opencodeProposer.image.pullPolicy }}
           command:
             {{- toYaml .Values.opencodeProposer.command | nindent 12 }}

--- a/helm/agent-workloads/values.yaml
+++ b/helm/agent-workloads/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
   tag: dev
+  digest: ""
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -19,6 +20,8 @@ serviceAccount:
 
 podAnnotations: {}
 podLabels: {}
+extraVolumes: []
+extraVolumeMounts: []
 
 podSecurityContext:
   runAsNonRoot: true
@@ -88,6 +91,7 @@ opencodeProposer:
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
     tag: dev
+    digest: ""
     pullPolicy: IfNotPresent
   podAnnotations: {}
   podLabels:

--- a/secrets/agent-workloads/README.md
+++ b/secrets/agent-workloads/README.md
@@ -2,12 +2,17 @@
 
 Encrypted secrets consumed by the `agent-workloads-secrets` Argo CD app.
 
-- `runtime-secret.enc.yaml`: Mandate worker-service token and the dedicated
-  Agent Workloads Postgres workspace URL. It can also hold either
-  `OPENAI_API_KEY` or `OPENAI_CODEX_AUTH_JSON` for broker workloads that call
-  the OpenAI/Codex Responses API. The XScraper/X Power readonly query profile
-  also requires `XSCRAPER_READONLY_DATABASE_URL`. The OpenCode proposer uses a
-  separate `OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN`; expose it only to the
+- `runtime-secret.enc.yaml`: the dedicated Agent Workloads Postgres workspace
+  URL and workload-identity tokens. The first live `data.workspace_probe`
+  deployment mounts `DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN` as a file at
+  `MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE`; do not expose the shared
+  `MANDATE_WORKER_TOKEN` to that long-running prod worker. It can also hold
+  either `OPENAI_API_KEY` or `OPENAI_CODEX_AUTH_JSON` for separate trusted
+  broker workloads that call the OpenAI/Codex Responses API. The XScraper/X
+  Power readonly query profile also requires `XSCRAPER_READONLY_DATABASE_URL`,
+  but `agent_workloads.readonly_query` is not granted in the first live
+  `db_probe` rollout. The OpenCode proposer uses a separate
+  `OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN`; expose it only to the
   `opencode.proposer` deployment as `MANDATE_WORKLOAD_IDENTITY_TOKEN`.
 - `regcred.enc.yaml`: DOCR pull credentials for
   `registry.digitalocean.com/sendouq/agent-workloads-worker`.
@@ -51,3 +56,8 @@ The OpenCode proposer must not receive `OPENAI_CODEX_AUTH_JSON`,
 `OPENAI_API_KEY`, database URLs, or the shared `MANDATE_WORKER_TOKEN`. It
 authenticates to Mandate with `OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN`, then
 Mandate returns a job-scoped model-gateway token in the claim response.
+
+The `data.workspace_probe` worker should receive only
+`AGENT_WORKLOADS_DATABASE_URL` plus its mounted workload-identity token for the
+first live path. Provider credentials and readonly source-database credentials
+belong in later, separately granted worker or broker rollouts.


### PR DESCRIPTION
## Summary
- Implements the remaining CES-34 live GitOps wiring for the first external agent-workloads worker.
- Adds the agent-control-plane registry overlay ConfigMap and Argo Application.
- Imports only `data.workspace_probe` from the deployment-pinned workload manifest and grants only `agent_workloads.db_probe` in prod policy.
- Deploys the long-running `data.workspace_probe` worker with digest-pinned image, file-mounted workload identity token, and no static worker-token fallback.
- Refreshes pins to post-merge main artifacts:
  - agent-platform: `sha-b2d040432ea3` / targetRevision `b2d040432ea34a1138a4f76a36617ae7cf1f9be8`
  - agent-workloads: `sha-5a6571fc7cb3`
  - data worker image digest: `sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb`
  - data worker manifest digest: `sha256:9202e308303b197f5979b4f59f797d582b64dd17a99d23fb282033d3bd868d4a`
  - data worker code digest: `sha256:5910fef362dc4b88fd992e29999fe32eb035e64e3dde02f41471fcd9deabe1de`

## Authority invariants preserved
- Import is not dispatch: the imported manifest alone is not enough to run.
- Packs/manifests are not authority.
- Admission still validates dispatch against the generated overlay and prod policy grant.
- Leases, brokers, and output gates remain authoritative.
- No ambient provider/Git/cloud/model credentials were introduced for the first data worker.
- Task/model/workload inputs do not become authority.

## Tests
- `helm lint helm/agent-workloads -f apps/agent-workloads/values.yaml` passed.
- `helm template agent-workloads helm/agent-workloads -f apps/agent-workloads/values.yaml` passed.
- `helm lint /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml` passed.
- `helm template agent-control-plane /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml` passed.
- `kubeconform -strict -summary -skip Application apps/agent-control-plane-registry-overlay/configmap.yaml argocd/applications/agent-control-plane-registry-overlay.yaml` passed with schema network access.
- Static Mandate overlay validation passed with `RegistrySnapshot.from_repo(..., environment="prod")` using the ConfigMap data exactly:
  - `agent_workloads.db_probe` is imported and admitted for the prod private-admin actor.
  - `data.workspace_probe` lease loop carries the refreshed manifest `code_digest`.
  - `agent_workloads.readonly_query` remains imported metadata but not prod policy-granted.
- `git diff --check` passed.

## Docs
- Added the registry overlay README with import-not-dispatch notes and release pin provenance.
- Updated agent-control-plane docs for the mounted overlay and explicit workload identity posture.
- Updated agent-workloads secret docs for the file-mounted data-worker workload identity token and first-worker constraints.

## Security review notes
- The data worker does not receive `MANDATE_WORKER_TOKEN` and does not use the static token fallback.
- The data worker claims only `agent_workloads.db_probe`.
- `readonly_query` is imported as manifest metadata but is not prod policy-granted here.
- The overlay pins immutable image and manifest digests from the successful `agent-workloads` main release artifact.
- The control plane values set explicit issuer and subject allowlist; missing prod issuer/allowlist now fails closed in the pinned platform image.

## Deferred
- No live Argo sync or deployed submit -> external pod claim -> result -> output gate -> callback -> audit drill was run from this PR.
- No rollout of `agent_workloads.readonly_query`.
- No OpenCode/opencode policy grant or consequential action path.
