### PR TITLE
CES-94: repin OpenCode workload release

### DIFF
--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -23,10 +23,10 @@ The ConfigMap mounts registry overlay files into the Mandate pod:
   capability to the private admin Discord actor/channel binding.
 
 The current pins come from the latest successful `agent-workloads` main release
-artifact (`sha-85e8efb8d8e2`). That release includes the CES-34 worker-loop
-hardening, the OpenCode proposer image, and the OpenCode apply executor image,
-and this overlay uses the
-machine-generated manifest/image/code digests from the release artifact.
+artifact (`sha-4489ed92101c`). That release includes the CES-92 OpenCode
+proposer reliability fixes, the OpenCode proposer image, and the OpenCode apply
+executor image, and this overlay uses the machine-generated
+manifest/image/code digests from the release artifact.
 
 The Agent Control Plane is pinned to agent-platform
 `77925be310da0753175c8b5024e66c913df81930` / image tag

--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
       - id: data.workspace_probe
         manifest_path: registries/imports/agent-data.workspace_probe.json
-        manifest_digest: sha256:9202e308303b197f5979b4f59f797d582b64dd17a99d23fb282033d3bd868d4a
-        image_digest: sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb
+        manifest_digest: sha256:1ca6170efdc740a74c3900fcf9837bb5363b2e40fb8d13363bcd5bb5fdf8dbac
+        image_digest: sha256:cb73d7112d60d137925e741dc630973697a747953c19afab15ec20a2fbd3eb07
         expected_source:
           repo: agent-workloads
           repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
               session_taint: prod_authority
       - id: opencode.proposer
         manifest_path: registries/imports/agent-opencode.proposer.json
-        manifest_digest: sha256:99a20b0fb445ecdbd35efd779926c9cd0006f38be2d2e0e78952972b27e7a8d8
-        image_digest: sha256:2278b7c4d55e42788825fb3bce5d2ae3bb675d285f913558de586cc7ba389646
+        manifest_digest: sha256:77ec408c5950f5b6bb46ef4ab947e1ee4f982a28fe947bffb64ad05ccddfe0a4
+        image_digest: sha256:9bdf1fc1efb762fec027be2cf75dd8a6f28dbda3cc7b3e70c72ca82aed579e97
         expected_source:
           repo: agent-workloads
           repo_url: https://github.com/cesaregarza/agent-workloads
@@ -77,7 +77,7 @@ data:
               max_total_tokens: 34000
               max_cost_usd: 0.25
             session_authority_budget:
-              max_operations: 1
+              max_operations: 8
               session_taint: prod_authority
             disclosure:
               raw_inputs_returnable: false
@@ -95,8 +95,8 @@ data:
               broker_required: false
       - id: opencode.apply_executor
         manifest_path: registries/imports/agent-opencode.apply_executor.json
-        manifest_digest: sha256:2bcab60d70a8e6fc693c590e8621f74f42f34b6bc4e95fa78dc2e635fc27b3aa
-        image_digest: sha256:92ca9f53912c56bd680f214eeba73feacc56b339b66c58f0ff42ed4876600312
+        manifest_digest: sha256:41b22e533a51b160f84b9d3a361cc49dfba626963458e9f139a9bcfc6b80e6ff
+        image_digest: sha256:7db3062f3a97fb584606e05484136f4d62b16b1f6072f18a1341e5c64da83353
         expected_source:
           repo: agent-workloads
           repo_url: https://github.com/cesaregarza/agent-workloads
@@ -292,8 +292,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:5910fef362dc4b88fd992e29999fe32eb035e64e3dde02f41471fcd9deabe1de",
-      "digest": "sha256:9202e308303b197f5979b4f59f797d582b64dd17a99d23fb282033d3bd868d4a",
+      "code_digest": "sha256:ed6ea8ccccfa74cf0a47c27d7d755efa58cf343b0808e464c204fc631ba9431f",
+      "digest": "sha256:1ca6170efdc740a74c3900fcf9837bb5363b2e40fb8d13363bcd5bb5fdf8dbac",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -303,7 +303,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb",
+        "digest": "sha256:cb73d7112d60d137925e741dc630973697a747953c19afab15ec20a2fbd3eb07",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -329,8 +329,8 @@ data:
           "consequence_class": "reversible_staging"
         }
       },
-      "code_digest": "sha256:3b8af5d0d717e853c5eba1229a3410091de6211f8bbab78341ce1e8f7cb3adb3",
-      "digest": "sha256:99a20b0fb445ecdbd35efd779926c9cd0006f38be2d2e0e78952972b27e7a8d8",
+      "code_digest": "sha256:d5159ffe2f3ec5bd292840519aa62d02714bb11f046b69877a3552475e496ea8",
+      "digest": "sha256:77ec408c5950f5b6bb46ef4ab947e1ee4f982a28fe947bffb64ad05ccddfe0a4",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -340,7 +340,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:2278b7c4d55e42788825fb3bce5d2ae3bb675d285f913558de586cc7ba389646",
+        "digest": "sha256:9bdf1fc1efb762fec027be2cf75dd8a6f28dbda3cc7b3e70c72ca82aed579e97",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -366,8 +366,8 @@ data:
           "consequence_class": "consequential"
         }
       },
-      "code_digest": "sha256:a68f94ea12e81751fcbad8b64a05bf6fdc01d4360349c8e38badb2dbc7665bba",
-      "digest": "sha256:2bcab60d70a8e6fc693c590e8621f74f42f34b6bc4e95fa78dc2e635fc27b3aa",
+      "code_digest": "sha256:9a2db0c32c32a8508df90b3d1a77763de01ce9aee10bee95f7dcc882dc0569bd",
+      "digest": "sha256:41b22e533a51b160f84b9d3a361cc49dfba626963458e9f139a9bcfc6b80e6ff",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -377,7 +377,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:92ca9f53912c56bd680f214eeba73feacc56b339b66c58f0ff42ed4876600312",
+        "digest": "sha256:7db3062f3a97fb584606e05484136f4d62b16b1f6072f18a1341e5c64da83353",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -10,8 +10,8 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-5a6571fc7cb3
-  digest: sha256:c12fc7e698bd0833cd55934130be758a335586f69f1f38a8a956f8f761c23bdb
+  tag: sha-4489ed92101c
+  digest: sha256:cb73d7112d60d137925e741dc630973697a747953c19afab15ec20a2fbd3eb07
   pullPolicy: IfNotPresent
 
 env:
@@ -102,8 +102,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-85e8efb8d8e2
-    digest: sha256:2278b7c4d55e42788825fb3bce5d2ae3bb675d285f913558de586cc7ba389646
+    tag: sha-4489ed92101c
+    digest: sha256:9bdf1fc1efb762fec027be2cf75dd8a6f28dbda3cc7b3e70c72ca82aed579e97
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -159,8 +159,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-85e8efb8d8e2
-    digest: sha256:92ca9f53912c56bd680f214eeba73feacc56b339b66c58f0ff42ed4876600312
+    tag: sha-4489ed92101c
+    digest: sha256:7db3062f3a97fb584606e05484136f4d62b16b1f6072f18a1341e5c64da83353
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN


### PR DESCRIPTION
## Summary
- implements the CES-94 deployment-prep slice for the merged CES-92 OpenCode proposer reliability release
- pins `agent-workloads` release `sha-4489ed92101c` from successful publish run `27178753762`
- updates the prod workload import manifest/image digests for `data.workspace_probe`, `opencode.proposer`, and `opencode.apply_executor`
- updates the live agent-workloads image digests for the worker service, proposer, and apply executor
- raises the imported `agent_workloads.opencode_propose` session authority budget from 1 to 8, matching the CES-92 manifest

## Authority invariants preserved
- import remains data, not dispatch authority
- manifests still only feed the deployment overlay; Mandate registry/admission/policy/lease/output-gate remain authoritative
- no new provider keys, Git credentials, DB credentials, broad egress, or ambient worker authority introduced
- hosted harness remains proposal-only; consequential apply stays behind `admin_confirm` and the separate executor path
- existing SplatTopConfig deployment-owned model/disclosure/artifact policy fields are preserved

## Tests
- release artifact source: agent-workloads publish workflow `27178753762` completed successfully and uploaded `agent-workloads-release-artifacts`
- `helm lint helm/agent-workloads -f apps/agent-workloads/values.yaml` passed
- `helm template agent-workloads helm/agent-workloads -f apps/agent-workloads/values.yaml | kubeconform -strict -summary -skip CiliumNetworkPolicy,Certificate` passed: 5 valid resources
- `kubeconform -strict -summary apps/agent-control-plane-registry-overlay/configmap.yaml` passed: 1 valid resource
- custom registry-overlay consistency check passed: each import digest matches its embedded manifest and proposer max_operations is 8
- `git diff --check` passed
- no mutable `:latest` image/tag matches found under `helm`, `argocd`, or `apps`

## Docs
- updates the registry overlay README to point at release `sha-4489ed92101c` and CES-92 fixes

## Deferred
- operator still needs to merge this PR and manually sync the Argo applications
- live DB-side verification remains after sync: `opencode_propose` proposal artifact hash, then approved `opencode_apply` DesignatedAction/executor/audit chain
- no control-plane bump was made because agent-platform prod is already at `77925be3`, which CES-94 identifies as having the required OpenCode platform code