### PR TITLE
CES-96: gate agent-workloads identity digest drift

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,23 @@ jobs:
       - name: Run Python contract tests
         run: uv run python -m unittest discover -s tests
 
+  agent-workloads-identity-digest-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
       - name: Install sops
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ jobs:
 
   agent-workloads-identity-digest-drift:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,9 +59,18 @@ jobs:
           sudo install -m 0755 /tmp/sops /usr/local/bin/sops
           sops --version
 
+      - name: Fetch drift-gate SOPS age key
+        id: drift-gate-broker
+        uses: cesaregarza/.github/actions/fetch-broker-credentials@main
+        with:
+          broker-url: https://credentials.garz.ai
+          audience: https://credentials.garz.ai/v1
+          capability: sops-drift-gate-decrypt
+          export-env: true
+
       - name: Check agent-workloads identity digest drift
         env:
-          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+          SOPS_AGE_KEY: ${{ env.SOPS_DRIFT_GATE_AGE_KEY }}
         run: uv run python scripts/check_agent_workloads_identity_digests.py
 
   helm-and-kubeconform:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,40 @@ permissions:
   contents: read
 
 jobs:
+  python-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run Python contract tests
+        run: uv run python -m unittest discover -s tests
+
+      - name: Install sops
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+            --output /tmp/sops \
+            https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
+          sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+          sops --version
+
+      - name: Check agent-workloads identity digest drift
+        env:
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: uv run python scripts/check_agent_workloads_identity_digests.py
+
   helm-and-kubeconform:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/no-latest.yaml
+++ b/.github/workflows/no-latest.yaml
@@ -3,6 +3,7 @@ name: no-latest
 on:
   pull_request:
     paths:
+      - 'apps/**'
       - 'helm/**'
       - 'argocd/**'
 
@@ -19,7 +20,7 @@ jobs:
       - name: Block :latest tags (allow override with # allow-latest)
         run: |
           set -euo pipefail
-          matches=$(git grep -nE '(^\s*tag:\s*"?latest"?\s*$)|(image:\s*[^\s]+:latest)' -- 'helm' 'argocd' || true)
+          matches=$(git grep -nE '(^\s*tag:\s*"?latest"?\s*$)|(image:\s*[^\s]+:latest)' -- 'apps' 'helm' 'argocd' || true)
           if [ -z "$matches" ]; then
             exit 0
           fi

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,5 +1,5 @@
 # SOPS configuration for this repo.
-# Public key lives in keys/age-public.txt; private key is stored in GitHub Actions secret / cluster secret.
+# Public key lives in keys/age-public.txt; private key is stored in the operator vault.
 creation_rules:
   - path_regex: ^k8s/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
@@ -28,6 +28,11 @@ creation_rules:
   - path_regex: ^secrets/agent-control-plane/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+  - path_regex: ^secrets/agent-workloads/runtime-secret\.enc\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: >-
+      age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt,
+      age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau
   - path_regex: ^secrets/agent-workloads/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt

--- a/scripts/check_agent_workloads_identity_digests.py
+++ b/scripts/check_agent_workloads_identity_digests.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Fail closed when agent-workloads release pins drift from identity tokens."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALUES_PATH = Path("apps/agent-workloads/values.yaml")
+OVERLAY_CONFIGMAP_PATH = Path("apps/agent-control-plane-registry-overlay/configmap.yaml")
+RUNTIME_SECRET_PATH = Path("secrets/agent-workloads/runtime-secret.enc.yaml")
+SHA256_DIGEST_RE = re.compile(r"^sha256:[a-fA-F0-9]{64}$")
+TOKEN_PREFIX = "mwit_v1"
+TOKEN_KEYS_BY_AGENT_ID = {
+    "data.workspace_probe": "DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN",
+    "opencode.proposer": "OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN",
+    "opencode.apply_executor": "OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN",
+}
+
+YAML_PARSER = YAML(typ="safe")
+
+
+class DriftGateError(RuntimeError):
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare agent-workloads mandateReleasePins and registry overlay "
+            "code digests to SOPS-managed workload identity token claims."
+        )
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--values-path", type=Path, default=VALUES_PATH)
+    parser.add_argument("--overlay-configmap-path", type=Path, default=OVERLAY_CONFIGMAP_PATH)
+    parser.add_argument("--runtime-secret-path", type=Path, default=RUNTIME_SECRET_PATH)
+    args = parser.parse_args()
+
+    try:
+        result = check_agent_workloads_identity_digests(
+            repo_root=args.repo_root,
+            values_path=args.values_path,
+            overlay_configmap_path=args.overlay_configmap_path,
+            runtime_secret_path=args.runtime_secret_path,
+        )
+    except DriftGateError as exc:
+        print(f"agent-workloads identity digest gate failed: {exc}", file=sys.stderr)
+        return 1
+    print(result)
+    return 0
+
+
+def check_agent_workloads_identity_digests(
+    *,
+    repo_root: Path,
+    values_path: Path,
+    overlay_configmap_path: Path,
+    runtime_secret_path: Path,
+) -> str:
+    values = _load_yaml(repo_root / values_path)
+    release_pins = values.get("mandateReleasePins")
+    if release_pins in (None, {}):
+        return "agent-workloads mandateReleasePins absent; identity digest gate inactive."
+    if not isinstance(release_pins, dict):
+        raise DriftGateError("mandateReleasePins must be a mapping")
+
+    expected_agents = set(TOKEN_KEYS_BY_AGENT_ID)
+    pinned_agents = set(release_pins)
+    if pinned_agents != expected_agents:
+        raise DriftGateError(
+            "mandateReleasePins must cover exactly "
+            f"{', '.join(sorted(expected_agents))}; got {', '.join(sorted(pinned_agents))}"
+        )
+
+    overlay_pins = _load_overlay_pins(repo_root / overlay_configmap_path)
+    for agent_id in sorted(expected_agents):
+        _assert_pin_matches_overlay(agent_id, release_pins[agent_id], overlay_pins[agent_id])
+
+    secret = _load_runtime_secret(repo_root / runtime_secret_path, cwd=repo_root)
+    for agent_id in sorted(expected_agents):
+        token_key = TOKEN_KEYS_BY_AGENT_ID[agent_id]
+        token = _secret_value(secret, token_key)
+        token_code_digest = _workload_identity_code_digest(token, token_key)
+        expected_code_digest = overlay_pins[agent_id]["codeDigest"]
+        if token_code_digest != expected_code_digest:
+            raise DriftGateError(
+                f"{token_key} code_digest mismatch: expected {expected_code_digest}, "
+                f"got {token_code_digest}"
+            )
+
+    return "agent-workloads workload identity code_digests match release pins."
+
+
+def _load_overlay_pins(configmap_path: Path) -> dict[str, dict[str, str]]:
+    configmap = _load_yaml(configmap_path)
+    data = configmap.get("data")
+    if not isinstance(data, dict):
+        raise DriftGateError("registry overlay ConfigMap must contain data")
+    imports = YAML_PARSER.load(data.get("workload_imports.yaml") or "")
+    if not isinstance(imports, dict) or not isinstance(imports.get("imports"), list):
+        raise DriftGateError("registry overlay workload_imports.yaml must contain imports")
+
+    imports_by_id = {entry["id"]: entry for entry in imports["imports"]}
+    pins: dict[str, dict[str, str]] = {}
+    for agent_id in TOKEN_KEYS_BY_AGENT_ID:
+        import_entry = imports_by_id.get(agent_id)
+        if not isinstance(import_entry, dict):
+            raise DriftGateError(f"registry overlay missing import for {agent_id}")
+        manifest_key = Path(_required_str(import_entry, "manifest_path", agent_id)).name
+        manifest = json.loads(_required_str(data, manifest_key, "registry overlay data"))
+        code_digest = _required_str(manifest, "code_digest", agent_id)
+        manifest_digest = _required_str(manifest, "digest", agent_id)
+        image = manifest.get("image")
+        if not isinstance(image, dict):
+            raise DriftGateError(f"{agent_id} manifest image must be a mapping")
+        image_digest = _required_str(image, "digest", agent_id)
+        _validate_digest(code_digest, f"{agent_id} codeDigest")
+        _validate_digest(manifest_digest, f"{agent_id} manifestDigest")
+        _validate_digest(image_digest, f"{agent_id} imageDigest")
+        if import_entry.get("manifest_digest") != manifest_digest:
+            raise DriftGateError(f"{agent_id} import manifest_digest differs from manifest")
+        if import_entry.get("image_digest") != image_digest:
+            raise DriftGateError(f"{agent_id} import image_digest differs from manifest")
+        pins[agent_id] = {
+            "codeDigest": code_digest,
+            "manifestDigest": manifest_digest,
+            "imageDigest": image_digest,
+        }
+    return pins
+
+
+def _assert_pin_matches_overlay(
+    agent_id: str,
+    release_pin: Any,
+    overlay_pin: dict[str, str],
+) -> None:
+    if not isinstance(release_pin, dict):
+        raise DriftGateError(f"{agent_id} mandateReleasePins entry must be a mapping")
+    for key, expected in overlay_pin.items():
+        actual = release_pin.get(key)
+        if actual != expected:
+            raise DriftGateError(
+                f"{agent_id} mandateReleasePins.{key} differs from registry overlay: "
+                f"expected {expected}, got {actual}"
+            )
+
+
+def _load_runtime_secret(secret_path: Path, *, cwd: Path) -> dict[str, Any]:
+    raw = secret_path.read_text(encoding="utf-8")
+    loaded = YAML_PARSER.load(raw)
+    if not isinstance(loaded, dict):
+        raise DriftGateError(f"runtime secret must be a YAML mapping: {secret_path}")
+    if "sops" not in loaded:
+        return loaded
+
+    env = os.environ.copy()
+    try:
+        result = subprocess.run(
+            ["sops", "--decrypt", str(secret_path)],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise DriftGateError("sops is required to decrypt runtime secret") from exc
+    if result.returncode != 0:
+        raise DriftGateError("could not decrypt runtime secret with sops")
+    decrypted = YAML_PARSER.load(result.stdout)
+    if not isinstance(decrypted, dict):
+        raise DriftGateError("decrypted runtime secret must be a YAML mapping")
+    return decrypted
+
+
+def _secret_value(secret: dict[str, Any], token_key: str) -> str:
+    string_data = secret.get("stringData")
+    if isinstance(string_data, dict):
+        value = string_data.get(token_key)
+        if isinstance(value, str) and value:
+            return value
+
+    data = secret.get("data")
+    if isinstance(data, dict):
+        encoded = data.get(token_key)
+        if isinstance(encoded, str) and encoded:
+            try:
+                return base64.b64decode(encoded, validate=True).decode()
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise DriftGateError(f"{token_key} data value is not valid base64") from exc
+
+    raise DriftGateError(f"runtime secret missing {token_key}")
+
+
+def _workload_identity_code_digest(token: str, token_key: str) -> str:
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != TOKEN_PREFIX:
+        raise DriftGateError(f"{token_key} is not an {TOKEN_PREFIX} token")
+    try:
+        payload = json.loads(_base64_url_decode(parts[1]).decode())
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise DriftGateError(f"{token_key} has malformed token payload") from exc
+    if not isinstance(payload, dict):
+        raise DriftGateError(f"{token_key} token payload must be a mapping")
+
+    for claim in ("iss", "sub", "aud", "exp"):
+        if claim not in payload:
+            raise DriftGateError(f"{token_key} token payload missing {claim}")
+    scopes = payload.get("scp")
+    if not isinstance(scopes, list) or "worker_service" not in scopes:
+        raise DriftGateError(f"{token_key} token payload missing worker_service scope")
+    code_digest = payload.get("code_digest")
+    _validate_digest(code_digest, f"{token_key} code_digest")
+    return str(code_digest)
+
+
+def _base64_url_decode(encoded: str) -> bytes:
+    padding = "=" * (-len(encoded) % 4)
+    return base64.urlsafe_b64decode(f"{encoded}{padding}")
+
+
+def _required_str(mapping: dict[str, Any], key: str, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise DriftGateError(f"{label} missing non-empty {key}")
+    return value
+
+
+def _validate_digest(raw: Any, label: str) -> None:
+    if not isinstance(raw, str) or SHA256_DIGEST_RE.fullmatch(raw) is None:
+        raise DriftGateError(f"{label} must be sha256:<64 hex>")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise DriftGateError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/secrets/agent-workloads/README.md
+++ b/secrets/agent-workloads/README.md
@@ -64,6 +64,13 @@ credentials, database URLs, or the shared `MANDATE_WORKER_TOKEN`. It
 authenticates to Mandate with `OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN`
 and consumes only claim-projected approval/designated-action state.
 
+When `apps/agent-workloads/values.yaml` contains `mandateReleasePins`, CI
+decrypts `runtime-secret.enc.yaml` and checks that each workload identity
+token's `code_digest` claim matches the release pin and the embedded registry
+overlay manifest. The gate does not mint tokens; rotate them with the
+operator-held HMAC signing seed whenever a release changes a workload
+`code_digest`.
+
 The `data.workspace_probe` worker should receive only
 `AGENT_WORKLOADS_DATABASE_URL` plus its mounted workload-identity token for the
 first live path. Provider credentials and readonly source-database credentials

--- a/secrets/agent-workloads/runtime-secret.enc.yaml
+++ b/secrets/agent-workloads/runtime-secret.enc.yaml
@@ -20,11 +20,20 @@ sops:
         - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZNDNFa0lnU1VNcUZ6TzBl
-            VWFYNk9Xem9WNERyWHpCYWMxdXUzNXJoamdzCnJSTEN0ZGNhd21veVRqWHNiaVU1
-            V2U4RDRIUmp5d01hUllOQ2JuMUMwNHMKLS0tIDVRUEhCdUV1UGgrZzh1bDNnQk1x
-            dlNLNHpsZ1c5Y1JsVEYwSUNjL3FaQTAKT8jjCi7k7otloPGjlvBoxsZvSX/cIViL
-            YvP8mjnBFxGu70opEcFO3d/qka6lO9KnlLCX+pm6uOLMnNqi4QQmoA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHa0NMN0U4azBaazkvL0Vw
+            aXM3TUdkMi9kbHFuaXovTUo4Zkhybm1iV0NjCjlNT3BrUzdoVE81YUx5OUczamla
+            SExua1UvSHp2NzRiZ3hBTUZDOVpiME0KLS0tIFJLd1BPL0R2MEFnQ0pwREVFTTlJ
+            UXR6VUI1STBPdk40RnZSN1gzZ2FLem8KYIej0Rgka4qEpt6DjMJE8yG1ELjOHfh3
+            5WzVw2n85e+OmZFYycgvcqKWv4o7XhOwzLUP+3e2/9b1SI3OIv0wYA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4VVdHYm5XK2pscmM1SU9j
+            MjhPbTVHOVU3WUtsZjlpcDVBYzJaa2preWxJCjgvdlpMU1VZbGVKb05vSEFzQ2k1
+            M0RUNTVCNjBOZWJLeEk1SGVMSGMvMG8KLS0tIHN0UitKK2tTdjUvWS96WTlBSmlG
+            UEwvQm1TRnRRUkRlUnRXMmU1VUFxVkUK85HNxWNH7hpM6Cgz6iSsAGZ7WkGAKsey
+            n5RnjaImapz0ha5uSEFMvJ02pTJMJi33ebQnnOnrdCSdBKGcmB4rQA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-06-08T14:58:57Z"
     mac: ENC[AES256_GCM,data:JueJkO9lqOvw33HDdcFG3P733DgumhjKo+r9lWCakZgi361sTzyDoNOGguXYIYdlbcKJjR8PiD5LeZ3pWW1/C0se5eObvdfF7+DRHELQaQwa5D6ICvWSoOhUlYQFue+NETDyuk/sGt33f8B2/9Jn5KNHY+fcsESTDG2443K8cQY=,iv:LtblRqq/mFuD11aIakuzYykvr8bXp0/lGZNJIbXDTmQ=,tag:NELDXBCjA6nchTgm+LVo5g==,type:str]

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -43,11 +43,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             opencode["manifest_digest"],
-            "sha256:99a20b0fb445ecdbd35efd779926c9cd0006f38be2d2e0e78952972b27e7a8d8",
+            "sha256:77ec408c5950f5b6bb46ef4ab947e1ee4f982a28fe947bffb64ad05ccddfe0a4",
         )
         self.assertEqual(
             opencode["image_digest"],
-            "sha256:2278b7c4d55e42788825fb3bce5d2ae3bb675d285f913558de586cc7ba389646",
+            "sha256:9bdf1fc1efb762fec027be2cf75dd8a6f28dbda3cc7b3e70c72ca82aed579e97",
         )
         self.assertEqual(opencode["agent"]["execution_posture"], "hosted_harness")
         self.assertIs(opencode["agent"]["model_gateway_token"], True)
@@ -60,7 +60,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ["openai.gpt-5.3-codex-spark"],
         )
         self.assertEqual(capability["model_lease"]["max_cost_usd"], 0.25)
-        self.assertEqual(capability["session_authority_budget"]["max_operations"], 1)
+        self.assertEqual(capability["session_authority_budget"]["max_operations"], 8)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_proposal"],
@@ -74,11 +74,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(manifest["id"], "opencode.proposer")
         self.assertEqual(
             manifest["digest"],
-            "sha256:99a20b0fb445ecdbd35efd779926c9cd0006f38be2d2e0e78952972b27e7a8d8",
+            "sha256:77ec408c5950f5b6bb46ef4ab947e1ee4f982a28fe947bffb64ad05ccddfe0a4",
         )
         self.assertEqual(
             manifest["code_digest"],
-            "sha256:3b8af5d0d717e853c5eba1229a3410091de6211f8bbab78341ce1e8f7cb3adb3",
+            "sha256:d5159ffe2f3ec5bd292840519aa62d02714bb11f046b69877a3552475e496ea8",
         )
         self.assertEqual(
             manifest["capability_metadata"]["agent_workloads.opencode_propose"],
@@ -96,11 +96,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             opencode_apply["manifest_digest"],
-            "sha256:2bcab60d70a8e6fc693c590e8621f74f42f34b6bc4e95fa78dc2e635fc27b3aa",
+            "sha256:41b22e533a51b160f84b9d3a361cc49dfba626963458e9f139a9bcfc6b80e6ff",
         )
         self.assertEqual(
             opencode_apply["image_digest"],
-            "sha256:92ca9f53912c56bd680f214eeba73feacc56b339b66c58f0ff42ed4876600312",
+            "sha256:7db3062f3a97fb584606e05484136f4d62b16b1f6072f18a1341e5c64da83353",
         )
         self.assertEqual(
             opencode_apply["agent"]["execution_posture"],
@@ -126,7 +126,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(manifest["id"], "opencode.apply_executor")
         self.assertEqual(
             manifest["code_digest"],
-            "sha256:a68f94ea12e81751fcbad8b64a05bf6fdc01d4360349c8e38badb2dbc7665bba",
+            "sha256:9a2db0c32c32a8508df90b3d1a77763de01ce9aee10bee95f7dcc882dc0569bd",
         )
         self.assertEqual(
             manifest["capability_metadata"]["agent_workloads.opencode_apply"],

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import base64
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from scripts.check_agent_workloads_identity_digests import (
+    DriftGateError,
+    check_agent_workloads_identity_digests,
+)
+
+
+YAML_PARSER = YAML(typ="safe")
+
+DIGESTS = {
+    "data.workspace_probe": {
+        "codeDigest": "sha256:" + "a" * 64,
+        "manifestDigest": "sha256:" + "b" * 64,
+        "imageDigest": "sha256:" + "c" * 64,
+    },
+    "opencode.proposer": {
+        "codeDigest": "sha256:" + "d" * 64,
+        "manifestDigest": "sha256:" + "e" * 64,
+        "imageDigest": "sha256:" + "f" * 64,
+    },
+    "opencode.apply_executor": {
+        "codeDigest": "sha256:" + "1" * 64,
+        "manifestDigest": "sha256:" + "2" * 64,
+        "imageDigest": "sha256:" + "3" * 64,
+    },
+}
+
+TOKEN_KEYS = {
+    "data.workspace_probe": "DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN",
+    "opencode.proposer": "OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN",
+    "opencode.apply_executor": "OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN",
+}
+
+
+class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
+    def test_gate_skips_without_release_pins(self) -> None:
+        root = _fixture_repo(include_pins=False)
+
+        result = check_agent_workloads_identity_digests(
+            repo_root=root,
+            values_path=Path("apps/agent-workloads/values.yaml"),
+            overlay_configmap_path=Path(
+                "apps/agent-control-plane-registry-overlay/configmap.yaml"
+            ),
+            runtime_secret_path=Path("secrets/agent-workloads/runtime-secret.enc.yaml"),
+        )
+
+        self.assertIn("gate inactive", result)
+
+    def test_gate_accepts_matching_release_pins_overlay_and_tokens(self) -> None:
+        root = _fixture_repo()
+
+        result = check_agent_workloads_identity_digests(
+            repo_root=root,
+            values_path=Path("apps/agent-workloads/values.yaml"),
+            overlay_configmap_path=Path(
+                "apps/agent-control-plane-registry-overlay/configmap.yaml"
+            ),
+            runtime_secret_path=Path("secrets/agent-workloads/runtime-secret.enc.yaml"),
+        )
+
+        self.assertIn("match release pins", result)
+
+    def test_gate_rejects_values_overlay_code_digest_mismatch(self) -> None:
+        root = _fixture_repo()
+        values_path = root / "apps" / "agent-workloads" / "values.yaml"
+        values = YAML_PARSER.load(values_path.read_text())
+        values["mandateReleasePins"]["opencode.proposer"]["codeDigest"] = (
+            "sha256:" + "9" * 64
+        )
+        _write_yaml(values_path, values)
+
+        with self.assertRaisesRegex(DriftGateError, "mandateReleasePins.codeDigest"):
+            check_agent_workloads_identity_digests(
+                repo_root=root,
+                values_path=Path("apps/agent-workloads/values.yaml"),
+                overlay_configmap_path=Path(
+                    "apps/agent-control-plane-registry-overlay/configmap.yaml"
+                ),
+                runtime_secret_path=Path(
+                    "secrets/agent-workloads/runtime-secret.enc.yaml"
+                ),
+            )
+
+    def test_gate_rejects_stale_workload_identity_token_code_digest(self) -> None:
+        root = _fixture_repo(
+            token_digests={
+                **{agent_id: pins["codeDigest"] for agent_id, pins in DIGESTS.items()},
+                "opencode.proposer": "sha256:" + "9" * 64,
+            }
+        )
+
+        with self.assertRaisesRegex(DriftGateError, "code_digest mismatch"):
+            check_agent_workloads_identity_digests(
+                repo_root=root,
+                values_path=Path("apps/agent-workloads/values.yaml"),
+                overlay_configmap_path=Path(
+                    "apps/agent-control-plane-registry-overlay/configmap.yaml"
+                ),
+                runtime_secret_path=Path(
+                    "secrets/agent-workloads/runtime-secret.enc.yaml"
+                ),
+            )
+
+    def test_gate_rejects_malformed_identity_token(self) -> None:
+        root = _fixture_repo()
+        secret_path = root / "secrets" / "agent-workloads" / "runtime-secret.enc.yaml"
+        secret = YAML_PARSER.load(secret_path.read_text())
+        secret["stringData"]["OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN"] = "not-a-token"
+        _write_yaml(secret_path, secret)
+
+        with self.assertRaisesRegex(DriftGateError, "not an mwit_v1 token"):
+            check_agent_workloads_identity_digests(
+                repo_root=root,
+                values_path=Path("apps/agent-workloads/values.yaml"),
+                overlay_configmap_path=Path(
+                    "apps/agent-control-plane-registry-overlay/configmap.yaml"
+                ),
+                runtime_secret_path=Path(
+                    "secrets/agent-workloads/runtime-secret.enc.yaml"
+                ),
+            )
+
+
+def _fixture_repo(
+    *,
+    include_pins: bool = True,
+    token_digests: dict[str, str] | None = None,
+) -> Path:
+    import tempfile
+
+    root = Path(tempfile.mkdtemp())
+    values_path = root / "apps" / "agent-workloads" / "values.yaml"
+    values_path.parent.mkdir(parents=True)
+    values: dict[str, Any] = {"image": {"tag": "sha-test"}}
+    if include_pins:
+        values["mandateReleasePins"] = DIGESTS
+    _write_yaml(values_path, values)
+
+    configmap_path = root / "apps" / "agent-control-plane-registry-overlay" / (
+        "configmap.yaml"
+    )
+    configmap_path.parent.mkdir(parents=True)
+    _write_yaml(configmap_path, _configmap())
+
+    secret_path = root / "secrets" / "agent-workloads" / "runtime-secret.enc.yaml"
+    secret_path.parent.mkdir(parents=True)
+    token_digests = token_digests or {
+        agent_id: pins["codeDigest"] for agent_id, pins in DIGESTS.items()
+    }
+    secret = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "agent-workloads-secrets"},
+        "stringData": {
+            TOKEN_KEYS[agent_id]: _mwit_token(code_digest)
+            for agent_id, code_digest in token_digests.items()
+        },
+    }
+    _write_yaml(secret_path, secret)
+    return root
+
+
+def _configmap() -> dict[str, Any]:
+    imports = []
+    data: dict[str, str] = {}
+    for agent_id, pins in DIGESTS.items():
+        manifest_key = f"agent-{agent_id}.json"
+        imports.append(
+            {
+                "id": agent_id,
+                "manifest_path": f"registries/imports/{manifest_key}",
+                "manifest_digest": pins["manifestDigest"],
+                "image_digest": pins["imageDigest"],
+            }
+        )
+        data[manifest_key] = json.dumps(
+            {
+                "id": agent_id,
+                "digest": pins["manifestDigest"],
+                "code_digest": pins["codeDigest"],
+                "image": {"digest": pins["imageDigest"]},
+            },
+            sort_keys=True,
+        )
+    data["workload_imports.yaml"] = _yaml_text(
+        {"schema_version": "workload-imports.v1", "imports": imports}
+    )
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "agent-control-plane-registry-overlay"},
+        "data": data,
+    }
+
+
+def _mwit_token(code_digest: str) -> str:
+    payload = {
+        "aud": "mandate-api",
+        "code_digest": code_digest,
+        "exp": 4102444800,
+        "iss": "kubernetes",
+        "scp": ["worker_service"],
+        "sub": "system:serviceaccount:agent-workloads:worker",
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    ).decode().rstrip("=")
+    return f"mwit_v1.{encoded}.signature"
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(_yaml_text(payload), encoding="utf-8")
+
+
+def _yaml_text(payload: dict[str, Any]) -> str:
+    from io import StringIO
+
+    stream = StringIO()
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(payload, stream)
+    return stream.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -15,6 +15,10 @@ from scripts.check_agent_workloads_identity_digests import (
 
 
 YAML_PARSER = YAML(typ="safe")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DRIFT_GATE_RECIPIENT = (
+    "age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau"
+)
 
 DIGESTS = {
     "data.workspace_probe": {
@@ -42,6 +46,77 @@ TOKEN_KEYS = {
 
 
 class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
+    def test_ci_drift_gate_uses_brokered_sops_key_not_repo_secret(self) -> None:
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+        workflow = YAML_PARSER.load(workflow_path.read_text())
+        workflow_text = workflow_path.read_text()
+        job = workflow["jobs"]["agent-workloads-identity-digest-drift"]
+
+        self.assertNotIn("secrets.SOPS_AGE_KEY", workflow_text)
+        self.assertEqual(job["permissions"]["contents"], "read")
+        self.assertEqual(job["permissions"]["id-token"], "write")
+
+        fetch_step = next(
+            step for step in job["steps"] if step.get("id") == "drift-gate-broker"
+        )
+        self.assertEqual(
+            fetch_step["uses"],
+            "cesaregarza/.github/actions/fetch-broker-credentials@main",
+        )
+        self.assertEqual(
+            fetch_step["with"]["capability"],
+            "sops-drift-gate-decrypt",
+        )
+        self.assertEqual(fetch_step["with"]["export-env"], True)
+
+        check_step = next(
+            step
+            for step in job["steps"]
+            if step.get("run")
+            == "uv run python scripts/check_agent_workloads_identity_digests.py"
+        )
+        self.assertEqual(
+            check_step["env"]["SOPS_AGE_KEY"],
+            "${{ env.SOPS_DRIFT_GATE_AGE_KEY }}",
+        )
+
+    def test_scoped_sops_recipient_only_decrypts_agent_workloads_runtime_secret(
+        self,
+    ) -> None:
+        sops_config = YAML_PARSER.load((REPO_ROOT / ".sops.yaml").read_text())
+        rules = sops_config["creation_rules"]
+        runtime_rule_index = next(
+            index
+            for index, rule in enumerate(rules)
+            if rule["path_regex"] == r"^secrets/agent-workloads/runtime-secret\.enc\.yaml$"
+        )
+        broad_agent_workloads_rule_index = next(
+            index
+            for index, rule in enumerate(rules)
+            if rule["path_regex"] == r"^secrets/agent-workloads/.*\.enc\.yaml$"
+        )
+
+        self.assertLess(runtime_rule_index, broad_agent_workloads_rule_index)
+        self.assertIn(DRIFT_GATE_RECIPIENT, rules[runtime_rule_index]["age"])
+        self.assertNotIn(
+            DRIFT_GATE_RECIPIENT,
+            rules[broad_agent_workloads_rule_index]["age"],
+        )
+
+        runtime_recipients = _sops_age_recipients(
+            REPO_ROOT / "secrets" / "agent-workloads" / "runtime-secret.enc.yaml"
+        )
+        agent_workloads_regcred_recipients = _sops_age_recipients(
+            REPO_ROOT / "secrets" / "agent-workloads" / "regcred.enc.yaml"
+        )
+        control_plane_recipients = _sops_age_recipients(
+            REPO_ROOT / "secrets" / "agent-control-plane" / "runtime-secret.enc.yaml"
+        )
+
+        self.assertIn(DRIFT_GATE_RECIPIENT, runtime_recipients)
+        self.assertNotIn(DRIFT_GATE_RECIPIENT, agent_workloads_regcred_recipients)
+        self.assertNotIn(DRIFT_GATE_RECIPIENT, control_plane_recipients)
+
     def test_gate_skips_without_release_pins(self) -> None:
         root = _fixture_repo(include_pins=False)
 
@@ -230,6 +305,15 @@ def _yaml_text(payload: dict[str, Any]) -> str:
     yaml.default_flow_style = False
     yaml.dump(payload, stream)
     return stream.getvalue()
+
+
+def _sops_age_recipients(path: Path) -> set[str]:
+    loaded = YAML_PARSER.load(path.read_text())
+    return {
+        entry["recipient"]
+        for entry in loaded["sops"]["age"]
+        if isinstance(entry, dict) and isinstance(entry.get("recipient"), str)
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_workloads_networkpolicy.py
+++ b/tests/test_agent_workloads_networkpolicy.py
@@ -156,7 +156,7 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
         self.assertEqual(
             apply_executor["image"],
             "registry.digitalocean.com/sendouq/opencode-apply-executor"
-            "@sha256:92ca9f53912c56bd680f214eeba73feacc56b339b66c58f0ff42ed4876600312",
+            "@sha256:7db3062f3a97fb584606e05484136f4d62b16b1f6072f18a1341e5c64da83353",
         )
 
         apply_mounts = {


### PR DESCRIPTION
## Summary
- Adds a CI drift gate for agent-workloads workload identity token `code_digest` claims.
- The gate activates when `apps/agent-workloads/values.yaml` contains `mandateReleasePins`, verifies those pins match the embedded registry overlay manifests, decrypts `runtime-secret.enc.yaml`, and compares each workload token claim.
- Adds Python contract tests to CI and extends the mutable-tag check to include `apps/`.
- Fixes stale CES-94 test expectations for the current immutable OpenCode pins already merged to `main`.

## Authority invariants preserved
- This PR does not mint workload identity tokens and does not require the HMAC signing seed.
- The CI check reads decrypted token claims only to compare `code_digest`; it never prints token values.
- Runtime dispatch authority remains in Mandate admission/leases; this only blocks GitOps drift before merge.
- No ambient worker credentials or provider keys are introduced.

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run --directory /root/dev/SplatTopConfig python -m unittest discover -s tests` passed: 14 tests.
- `UV_CACHE_DIR=/tmp/uv-cache uv run --directory /root/dev/SplatTopConfig python scripts/check_agent_workloads_identity_digests.py` passed with gate inactive because current main has no `mandateReleasePins` yet.
- `git grep` mutable latest scan over `apps`, `helm`, and `argocd` passed.
- `git diff --check` passed.

## Security review notes
- A future auto re-pin PR that adds `mandateReleasePins` will be unmergeable until the SOPS-managed token claims match the overlay/code digests.
- Signature verification remains the control-plane verifier's job; this CI gate specifically prevents the observed stale-claim deploy failure.

## Deferred
- CES-95 remains the operator-owned token re-mint and live verification task.
- This PR does not add CI token minting or broaden SplatTopConfig secret authority.