### PR TITLE
CES-96: re-pin agent-workloads sha-f2c21aeda7e6

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -10,114 +10,115 @@ data:
   workload_imports.yaml: |
     schema_version: workload-imports.v1
     imports:
-      - id: data.workspace_probe
-        manifest_path: registries/imports/agent-data.workspace_probe.json
-        manifest_digest: sha256:bbcd495331dc1fb9749c299cd81fbfecb24606b9c89bc4cb002956b073880467
-        image_digest: sha256:b8bde05369d837f30f64f51d3a70d6129a9e4b8c2cf701035fd0e7193040ba1d
-        expected_source:
-          repo: agent-workloads
-          repo_url: https://github.com/cesaregarza/agent-workloads
-          path: agents/db-workspace-probe/agent.yaml
-        agent:
-          execution_posture: capability_worker
-          network_access: database_only
-          service_account_ref: agent-workloads-worker
-          identity_audience: mandate-api
-          capacity_tier: 4
-          concurrency: 1
-          max_runtime_seconds: 120
-          model_call: true
-        capabilities:
-          agent_workloads.db_probe:
-            description: Imported reversible staging database workspace probe.
-            output_schema: agent_workloads_db_probe_result_v1
-          agent_workloads.readonly_query:
-            description: Imported governed readonly SQL query worker.
-            output_schema: agent_workloads_readonly_query_result_v1
-            model_lease:
-              required: true
-              allowed_tier: fast
-              allowed_profiles:
-                - openai.gpt-5.4-mini
-              max_prompt_tokens: 12000
-              max_completion_tokens: 1200
-              max_total_tokens: 13200
-              max_cost_usd: 0.05
-            session_authority_budget:
-              max_operations: 4
-              session_taint: prod_authority
-      - id: opencode.proposer
-        manifest_path: registries/imports/agent-opencode.proposer.json
-        manifest_digest: sha256:13d0cd4ff2ea938aeb6af1d60b4e45856f0ab40e8c31e37147ba081116b0b36b
-        image_digest: sha256:4d7537a0153894afea89c48444bb833f53ec20417730f47de4681cf01322c79b
-        expected_source:
-          repo: agent-workloads
-          repo_url: https://github.com/cesaregarza/agent-workloads
-          path: agents/opencode-proposer/agent.yaml
-        agent:
-          execution_posture: hosted_harness
-          network_access: broker_only
-          service_account_ref: opencode-proposer
-          identity_audience: mandate-api
-          capacity_tier: 4
-          concurrency: 1
-          max_runtime_seconds: 900
-          model_gateway_token: true
-        capabilities:
-          agent_workloads.opencode_propose:
-            description: Imported OpenCode proposer that returns metadata-only proposal artifacts.
-            output_schema: agent_workloads_opencode_proposal_result_v1
-            model_lease:
-              required: true
-              allowed_tier: fast
-              allowed_profiles:
-                - openai.gpt-5.3-codex-spark
-              max_prompt_tokens: 30000
-              max_completion_tokens: 4000
-              max_total_tokens: 34000
-              max_cost_usd: 0.25
-            session_authority_budget:
-              max_operations: 8
-              session_taint: prod_authority
-            disclosure:
-              raw_inputs_returnable: false
-              internal_sources_returnable: false
-              excerpts_allowed: false
-              aggregate_facts_allowed: true
-              citations_allowed: provider_public_only
-              artifact_classes_allowed:
-                - opencode_proposal
-              max_confidentiality_level_out: customer_visible
-              require_output_redaction_pass: true
-              require_result_schema: true
-            artifacts:
-              allowed: true
-              broker_required: false
-      - id: opencode.apply_executor
-        manifest_path: registries/imports/agent-opencode.apply_executor.json
-        manifest_digest: sha256:66afbb6a937b40feea2dff6fca54d3784b8c7793dedd26501f49b3b1b0c026da
-        image_digest: sha256:25cf900981fda783b337bdd604b6aee1fa4b61899d8e2d2e8be3a2de2ceb2b5e
-        expected_source:
-          repo: agent-workloads
-          repo_url: https://github.com/cesaregarza/agent-workloads
-          path: agents/opencode-apply-executor/agent.yaml
-        agent:
-          execution_posture: capability_worker
-          network_access: broker_only
-          service_account_ref: opencode-apply-executor
-          identity_audience: mandate-api
-          executor: true
-          capacity_tier: 4
-          concurrency: 1
-          max_runtime_seconds: 300
-        capabilities:
-          agent_workloads.opencode_apply:
-            description: Imported OpenCode apply executor for approved proposal diffs.
-            output_schema: agent_workloads_opencode_apply_result_v1
-            approval_mode: admin_confirm
-            session_authority_budget:
-              max_operations: 1
-              session_taint: prod_authority
+    - id: data.workspace_probe
+      manifest_path: registries/imports/agent-data.workspace_probe.json
+      manifest_digest: sha256:6bf3c246730dd2c81626b11b4a9176098f3034f7ea677c1f2a444455599f3323
+      image_digest: sha256:6bef75286dd8fe43658de378f3fc7f8173b24ae898f4086efc21bad8ed88fc1e
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/db-workspace-probe/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: database_only
+        service_account_ref: agent-workloads-worker
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 120
+        model_call: true
+      capabilities:
+        agent_workloads.db_probe:
+          description: Imported reversible staging database workspace probe.
+          output_schema: agent_workloads_db_probe_result_v1
+        agent_workloads.readonly_query:
+          description: Imported governed readonly SQL query worker.
+          output_schema: agent_workloads_readonly_query_result_v1
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.4-mini
+            max_prompt_tokens: 12000
+            max_completion_tokens: 1200
+            max_total_tokens: 13200
+            max_cost_usd: 0.05
+          session_authority_budget:
+            max_operations: 4
+            session_taint: prod_authority
+    - id: opencode.proposer
+      manifest_path: registries/imports/agent-opencode.proposer.json
+      manifest_digest: sha256:ce6f4d0fb6667dbc6b720b86f569d19e6ac13afd3e51bc53c07d08804ffc3d8e
+      image_digest: sha256:a4935c1546b44659b0f178f5758c391261b797392897d60a25d64af2a6146411
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-proposer/agent.yaml
+      agent:
+        execution_posture: hosted_harness
+        network_access: broker_only
+        service_account_ref: opencode-proposer
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 900
+        model_gateway_token: true
+      capabilities:
+        agent_workloads.opencode_propose:
+          description: Imported OpenCode proposer that returns metadata-only proposal
+            artifacts.
+          output_schema: agent_workloads_opencode_proposal_result_v1
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_prompt_tokens: 30000
+            max_completion_tokens: 4000
+            max_total_tokens: 34000
+            max_cost_usd: 0.25
+          session_authority_budget:
+            max_operations: 8
+            session_taint: prod_authority
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed:
+            - opencode_proposal
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+    - id: opencode.apply_executor
+      manifest_path: registries/imports/agent-opencode.apply_executor.json
+      manifest_digest: sha256:42500c2329fc6f2d773bed7ffb4b7c20cdf8f3accf3fa2e0812a0b38b283cf1a
+      image_digest: sha256:bdb57a8680ebdc7d1452a5dbad695e86f1c674362919619e1015f8418d9bae3d
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-apply-executor/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: broker_only
+        service_account_ref: opencode-apply-executor
+        identity_audience: mandate-api
+        executor: true
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 300
+      capabilities:
+        agent_workloads.opencode_apply:
+          description: Imported OpenCode apply executor for approved proposal diffs.
+          output_schema: agent_workloads_opencode_apply_result_v1
+          approval_mode: admin_confirm
+          session_authority_budget:
+            max_operations: 1
+            session_taint: prod_authority
   policy.prod.yaml: |
     defaults:
       max_cost_usd_per_job: 0.25
@@ -292,8 +293,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:32e2fd891161ab286f4515e2a232e06ada4f9172f140c986871a822b60cd8141",
-      "digest": "sha256:bbcd495331dc1fb9749c299cd81fbfecb24606b9c89bc4cb002956b073880467",
+      "code_digest": "sha256:c3169393efa20ad342d82a6bec9af40d7fdc9a2b3964327c6467ae238b04b42f",
+      "digest": "sha256:6bf3c246730dd2c81626b11b4a9176098f3034f7ea677c1f2a444455599f3323",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -303,7 +304,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:b8bde05369d837f30f64f51d3a70d6129a9e4b8c2cf701035fd0e7193040ba1d",
+        "digest": "sha256:6bef75286dd8fe43658de378f3fc7f8173b24ae898f4086efc21bad8ed88fc1e",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -329,8 +330,8 @@ data:
           "consequence_class": "reversible_staging"
         }
       },
-      "code_digest": "sha256:ba73587f099115e1e884debdbbcec2627f0ae5f462f00dd01667ff8cba21353c",
-      "digest": "sha256:13d0cd4ff2ea938aeb6af1d60b4e45856f0ab40e8c31e37147ba081116b0b36b",
+      "code_digest": "sha256:488d4d9554c2ca0f90226c239e4848ddec834b27089da1adee09e6ef967f11b2",
+      "digest": "sha256:ce6f4d0fb6667dbc6b720b86f569d19e6ac13afd3e51bc53c07d08804ffc3d8e",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -340,7 +341,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:4d7537a0153894afea89c48444bb833f53ec20417730f47de4681cf01322c79b",
+        "digest": "sha256:a4935c1546b44659b0f178f5758c391261b797392897d60a25d64af2a6146411",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -366,8 +367,8 @@ data:
           "consequence_class": "consequential"
         }
       },
-      "code_digest": "sha256:9648a4a0d3ef973de7e24c51775df3ae2930d00595467e537df97fb397d63b18",
-      "digest": "sha256:66afbb6a937b40feea2dff6fca54d3784b8c7793dedd26501f49b3b1b0c026da",
+      "code_digest": "sha256:0d01fc44a543cb54f513d459a02be105cd2f929c687f44536eb11996b65c97b7",
+      "digest": "sha256:42500c2329fc6f2d773bed7ffb4b7c20cdf8f3accf3fa2e0812a0b38b283cf1a",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -377,7 +378,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:25cf900981fda783b337bdd604b6aee1fa4b61899d8e2d2e8be3a2de2ceb2b5e",
+        "digest": "sha256:bdb57a8680ebdc7d1452a5dbad695e86f1c674362919619e1015f8418d9bae3d",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -1,19 +1,15 @@
 global:
   imagePullSecrets:
-    - regcred
+  - regcred
   runtimeSecretName: agent-workloads-secrets
-
 nameOverride: agent-workloads
 fullnameOverride: agent-workloads
-
 replicaCount: 1
-
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-505f7689c65a
-  digest: sha256:b8bde05369d837f30f64f51d3a70d6129a9e4b8c2cf701035fd0e7193040ba1d
+  tag: sha-f2c21aeda7e6
+  digest: sha256:6bef75286dd8fe43658de378f3fc7f8173b24ae898f4086efc21bad8ed88fc1e
   pullPolicy: IfNotPresent
-
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
   AGENT_WORKLOADS_WORKER_ID: data.workspace_probe
@@ -21,32 +17,27 @@ env:
   MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE: /var/run/mandate/workload-identity/token
   AGENT_WORKLOADS_ENVIRONMENT: production
   AGENT_WORKLOADS_SCHEMA: agent_workloads
-  AGENT_WORKLOADS_POLL_SECONDS: "2"
-  AGENT_WORKLOADS_READONLY_QUERY_MAX_PASSES: "3"
-  AGENT_WORKLOADS_READONLY_QUERY_MAX_ROWS: "50"
-  AGENT_WORKLOADS_READONLY_QUERY_CONNECT_TIMEOUT_SECONDS: "5"
+  AGENT_WORKLOADS_POLL_SECONDS: '2'
+  AGENT_WORKLOADS_READONLY_QUERY_MAX_PASSES: '3'
+  AGENT_WORKLOADS_READONLY_QUERY_MAX_ROWS: '50'
+  AGENT_WORKLOADS_READONLY_QUERY_CONNECT_TIMEOUT_SECONDS: '5'
   OPENAI_SQL_BROKER_MODEL: gpt-5.3-codex-spark
   OPENAI_SQL_BROKER_REASONING_EFFORT: low
-  OPENAI_SQL_BROKER_TIMEOUT_SECONDS: "45"
-
+  OPENAI_SQL_BROKER_TIMEOUT_SECONDS: '45'
 secretKeys:
-  - AGENT_WORKLOADS_DATABASE_URL
-
+- AGENT_WORKLOADS_DATABASE_URL
 secretEnv: {}
-
 extraVolumes:
-  - name: workload-identity-token
-    secret:
-      secretName: agent-workloads-secrets
-      items:
-        - key: DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN
-          path: token
-
+- name: workload-identity-token
+  secret:
+    secretName: agent-workloads-secrets
+    items:
+    - key: DATA_WORKSPACE_PROBE_WORKLOAD_IDENTITY_TOKEN
+      path: token
 extraVolumeMounts:
-  - name: workload-identity-token
-    mountPath: /var/run/mandate/workload-identity
-    readOnly: true
-
+- name: workload-identity-token
+  mountPath: /var/run/mandate/workload-identity
+  readOnly: true
 resources:
   requests:
     cpu: 25m
@@ -54,56 +45,54 @@ resources:
   limits:
     cpu: 250m
     memory: 256Mi
-
 networkPolicy:
   enabled: true
   egress:
     dns:
       enabled: true
       destinations:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
-      ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-    destinations:
       - namespaceSelector:
           matchLabels:
-            kubernetes.io/metadata.name: agent-control-plane
+            kubernetes.io/metadata.name: kube-system
         podSelector:
           matchLabels:
-            app.kubernetes.io/name: agent-control-plane
-            app.kubernetes.io/instance: agent-control-plane
-            app.kubernetes.io/component: api
-        ports:
-          - port: 80
-            protocol: TCP
-          - port: 8000
-            protocol: TCP
-      - ipBlock:
-          cidr: 10.108.0.0/20
-        ports:
-          - port: 25060
-            protocol: TCP
-      - ipBlock:
-          cidr: 159.203.109.0/32
-        ports:
-          - port: 25060
-            protocol: TCP
-
+            k8s-app: kube-dns
+      ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    destinations:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: agent-control-plane
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: agent-control-plane
+          app.kubernetes.io/instance: agent-control-plane
+          app.kubernetes.io/component: api
+      ports:
+      - port: 80
+        protocol: TCP
+      - port: 8000
+        protocol: TCP
+    - ipBlock:
+        cidr: 10.108.0.0/20
+      ports:
+      - port: 25060
+        protocol: TCP
+    - ipBlock:
+        cidr: 159.203.109.0/32
+      ports:
+      - port: 25060
+        protocol: TCP
 opencodeProposer:
   enabled: true
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-505f7689c65a
-    digest: sha256:4d7537a0153894afea89c48444bb833f53ec20417730f47de4681cf01322c79b
+    tag: sha-f2c21aeda7e6
+    digest: sha256:a4935c1546b44659b0f178f5758c391261b797392897d60a25d64af2a6146411
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -112,17 +101,17 @@ opencodeProposer:
     MANDATE_MODEL_GATEWAY_BASE_URL: http://agent-control-plane-model-gateway.agent-control-plane.svc.cluster.local/v1
     AGENT_WORKLOADS_WORKER_ID: opencode.proposer
     AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.opencode_propose
-    AGENT_WORKLOADS_POLL_SECONDS: "2"
+    AGENT_WORKLOADS_POLL_SECONDS: '2'
     AGENT_WORKLOADS_ENVIRONMENT: production
     AGENT_WORKLOADS_OPENCODE_WORKSPACE_DIR: /workspace/job
     AGENT_WORKLOADS_OPENCODE_PROPOSALS_DIR: /workspace/proposals
-    AGENT_WORKLOADS_OPENCODE_TIMEOUT_SECONDS: "600"
+    AGENT_WORKLOADS_OPENCODE_TIMEOUT_SECONDS: '600'
   resources:
     requests:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: "1"
+      cpu: '1'
       memory: 1Gi
   networkPolicy:
     enabled: true
@@ -130,37 +119,36 @@ opencodeProposer:
       dns:
         enabled: true
         destinations:
-          - namespaceSelector:
-              matchLabels:
-                kubernetes.io/metadata.name: kube-system
-            podSelector:
-              matchLabels:
-                k8s-app: kube-dns
-        ports:
-          - port: 53
-            protocol: UDP
-          - port: 53
-            protocol: TCP
-      destinations:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: agent-control-plane
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
-              app.kubernetes.io/name: agent-control-plane
-              app.kubernetes.io/instance: agent-control-plane
-          ports:
-            - port: 80
-              protocol: TCP
-            - port: 8000
-              protocol: TCP
-
+              k8s-app: kube-dns
+        ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      destinations:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: agent-control-plane
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: agent-control-plane
+            app.kubernetes.io/instance: agent-control-plane
+        ports:
+        - port: 80
+          protocol: TCP
+        - port: 8000
+          protocol: TCP
 opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-505f7689c65a
-    digest: sha256:25cf900981fda783b337bdd604b6aee1fa4b61899d8e2d2e8be3a2de2ceb2b5e
+    tag: sha-f2c21aeda7e6
+    digest: sha256:bdb57a8680ebdc7d1452a5dbad695e86f1c674362919619e1015f8418d9bae3d
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -168,7 +156,7 @@ opencodeApplyExecutor:
     MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
     AGENT_WORKLOADS_WORKER_ID: opencode.apply_executor
     AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.opencode_apply
-    AGENT_WORKLOADS_POLL_SECONDS: "2"
+    AGENT_WORKLOADS_POLL_SECONDS: '2'
     AGENT_WORKLOADS_ENVIRONMENT: production
     AGENT_WORKLOADS_OPENCODE_APPLY_WORKSPACE_DIR: /workspace/job
     AGENT_WORKLOADS_OPENCODE_APPLY_PROPOSALS_DIR: /workspace/proposals
@@ -182,17 +170,16 @@ opencodeApplyExecutor:
     limits:
       cpu: 500m
       memory: 512Mi
-
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:32e2fd891161ab286f4515e2a232e06ada4f9172f140c986871a822b60cd8141
-    manifestDigest: sha256:bbcd495331dc1fb9749c299cd81fbfecb24606b9c89bc4cb002956b073880467
-    imageDigest: sha256:b8bde05369d837f30f64f51d3a70d6129a9e4b8c2cf701035fd0e7193040ba1d
+    codeDigest: sha256:c3169393efa20ad342d82a6bec9af40d7fdc9a2b3964327c6467ae238b04b42f
+    manifestDigest: sha256:6bf3c246730dd2c81626b11b4a9176098f3034f7ea677c1f2a444455599f3323
+    imageDigest: sha256:6bef75286dd8fe43658de378f3fc7f8173b24ae898f4086efc21bad8ed88fc1e
   opencode.apply_executor:
-    codeDigest: sha256:9648a4a0d3ef973de7e24c51775df3ae2930d00595467e537df97fb397d63b18
-    manifestDigest: sha256:66afbb6a937b40feea2dff6fca54d3784b8c7793dedd26501f49b3b1b0c026da
-    imageDigest: sha256:25cf900981fda783b337bdd604b6aee1fa4b61899d8e2d2e8be3a2de2ceb2b5e
+    codeDigest: sha256:0d01fc44a543cb54f513d459a02be105cd2f929c687f44536eb11996b65c97b7
+    manifestDigest: sha256:42500c2329fc6f2d773bed7ffb4b7c20cdf8f3accf3fa2e0812a0b38b283cf1a
+    imageDigest: sha256:bdb57a8680ebdc7d1452a5dbad695e86f1c674362919619e1015f8418d9bae3d
   opencode.proposer:
-    codeDigest: sha256:ba73587f099115e1e884debdbbcec2627f0ae5f462f00dd01667ff8cba21353c
-    manifestDigest: sha256:13d0cd4ff2ea938aeb6af1d60b4e45856f0ab40e8c31e37147ba081116b0b36b
-    imageDigest: sha256:4d7537a0153894afea89c48444bb833f53ec20417730f47de4681cf01322c79b
+    codeDigest: sha256:488d4d9554c2ca0f90226c239e4848ddec834b27089da1adee09e6ef967f11b2
+    manifestDigest: sha256:ce6f4d0fb6667dbc6b720b86f569d19e6ac13afd3e51bc53c07d08804ffc3d8e
+    imageDigest: sha256:a4935c1546b44659b0f178f5758c391261b797392897d60a25d64af2a6146411


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `f2c21aeda7e677aa22d3e87bc421ae4e1c455216`
- Publish run id: `27249404985`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:6bef75286dd8fe43658de378f3fc7f8173b24ae898f4086efc21bad8ed88fc1e` | `sha256:6bf3c246730dd2c81626b11b4a9176098f3034f7ea677c1f2a444455599f3323` | `sha256:c3169393efa20ad342d82a6bec9af40d7fdc9a2b3964327c6467ae238b04b42f` |
| `opencode.apply_executor` | `sha256:bdb57a8680ebdc7d1452a5dbad695e86f1c674362919619e1015f8418d9bae3d` | `sha256:42500c2329fc6f2d773bed7ffb4b7c20cdf8f3accf3fa2e0812a0b38b283cf1a` | `sha256:0d01fc44a543cb54f513d459a02be105cd2f929c687f44536eb11996b65c97b7` |
| `opencode.proposer` | `sha256:a4935c1546b44659b0f178f5758c391261b797392897d60a25d64af2a6146411` | `sha256:ce6f4d0fb6667dbc6b720b86f569d19e6ac13afd3e51bc53c07d08804ffc3d8e` | `sha256:488d4d9554c2ca0f90226c239e4848ddec834b27089da1adee09e6ef967f11b2` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.