### PR TITLE
CES-92: drop per_user_daily_tokens aggregate cap (dollar-governed only)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -126,7 +126,6 @@ data:
         per_capability_daily_usd:
           agent_workloads.opencode_apply: 1.0
           agent_workloads.opencode_propose: 1.0
-        per_user_daily_tokens: 200000
 
     bindings:
       - id: private-admin-controlled-capabilities


### PR DESCRIPTION
## What happened

First live `opencode_propose` submission after the #132 deploy was refused at admission: `422 aggregate budget requires a job token budget`.

This is the aggregate governor working as designed (`task_submission.py:259-271`): prod policy sets `per_user_daily_tokens: 200000`, and the governor fail-closed reserves each job's lease `max_total_tokens` against it at admission. The #132 uncap removed that field from the propose lease — an unbounded job cannot be reserved against a bounded daily token budget. The two decisions collide structurally.

## The change

Remove `per_user_daily_tokens` from `policy.prod.yaml` (one line). Token-denominated aggregate governance goes away; spend remains governed at **three dollar layers**:

| Layer | Cap |
|---|---|
| Per job | `max_cost_usd_per_job: 0.25` |
| Per capability daily | propose/apply $1.00, default $5.00 |
| Platform daily | $25.00 |

Rationale: the operator ceiling decision is **cost**. The token layer is the same spend denominated in a proxy unit, and it structurally requires every model-authority lease to carry a per-job token cap — incompatible with any uncapped capability. Dollar reservations + cost ledger keep the fail-closed reservation model intact.

## Alternative considered

Re-adding a sized `max_total_tokens` to the propose lease (e.g. 150k): keeps the token layer but re-introduces a per-call total cap that can re-bite on large repos, allows only one concurrent propose job (150k of 200k daily), and one leaked reservation (CES-99) blocks the day. Rejected as fragile.

## After merge (deploy agent)

Sync `agent-control-plane-registry-overlay` → **rollout-restart the 4 control-plane deploys** (policy is boot-cached with the rest of the registry snapshot). No image change. Then I run the CES-92 live verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)