### PR TITLE
CES-92: bump control plane to 479f254 (unwedges #133 overlay sync)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-2daf6a75d739
+  tag: sha-479f254ce4b9
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 2daf6a75d739aefb462221178bea77b0e85570e9
+      targetRevision: 479f254ce4b92811e453a15b7aba2ee33b378bbc
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps the control-plane image to `sha-479f254ce4b9` (agent-platform #101: dollar-only aggregate budget policy validation).

## Why this unwedges the deploy

The #133 overlay (drops `per_user_daily_tokens`) is sitting **OutOfSync** because the deployed image `sha-2daf6a75d739` requires that field at boot (`registry.py` prod snapshot validation, fail-closed) — syncing it would crash-loop the CP. This image makes the field optional-but-validated; dollar caps remain boot-required.

**Provenance:** publish run [27282645197](https://github.com/cesaregarza/agent-platform/actions/runs/27282645197) on merge commit `479f254ce4b9`, DOCR tag `sha-479f254ce4b9` → manifest `sha256:9e5a8ef4c2627a3066d42d01315238de0c6efdea07406bf7c1de611f6a3936ff`. No code_digest change for workloads — no token re-mint needed.

## After merge (deploy agent)

1. Sync `agent-control-plane` (new image) — safe against the old overlay (token cap present+valid still passes).
2. Sync `agent-control-plane-registry-overlay` (the wedged #133 policy change).
3. Rollout-restart the 4 CP deploys (registry snapshot is boot-cached).

Then Claude runs the CES-92 live verify — both prior refusal layers (broker completion cap, admission token reservation) are cleared by this chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)