### PR TITLE
CES-109: grant agent_workloads.readonly_query in prod

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -147,6 +147,7 @@ data:
             - mandate.ops.inspect
             - mandate.deploy.smoke
             - agent_workloads.db_probe
+            - agent_workloads.readonly_query
             - agent_workloads.opencode_apply
             - agent_workloads.opencode_propose
           approval_overrides:


### PR DESCRIPTION
One-line grant: adds `agent_workloads.readonly_query` to the `private-admin-controlled-capabilities` allow list.

The capability has been **imported-but-not-granted since CES-83**: the `data.workspace_probe` import carries it (overlay `workload_imports.yaml` — model_lease `openai.gpt-5.4-mini`, prompt/completion/total caps 12000/1200/13200, $0.05/call), the standing `agent-workloads` worker claims its jobs, and the readonly SQL broker is already configured (builtin `readonly_sql` is granted and live). Policy was the only missing piece.

No approval override (read-only, mirrors `readonly_sql`). No digest movement, no re-mint.

## After merge (deploy agent)
Sync `agent-control-plane-registry-overlay` → rollout-restart the 4 control-plane deploys (policy is boot-cached). Then Claude live-verifies a governed readonly query end-to-end (second real worker capability in prod).

Note: this capability's still-capped model_lease makes it the natural live test subject for CES-119's loud-refusal acceptance (synthetic over-cap request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)