### PR TITLE
CES-109 fix: readonly_query lease = spark only (exactly-one-profile rule)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -39,7 +39,6 @@ data:
             allowed_tier: fast
             allowed_profiles:
             - openai.gpt-5.3-codex-spark
-            - openai.gpt-5.4-mini
             max_prompt_tokens: 12000
             max_completion_tokens: 1200
             max_total_tokens: 13200


### PR DESCRIPTION
#136's spark addition kept `gpt-5.4-mini` alongside — but worker_service model leases must declare **exactly one** allowed profile (`RegistryError` at snapshot build; the lease decides the profile, so two is ambiguous → fail-closed at boot). The 3 snapshot-building CP deploys crash-looped on rollout; **prod unaffected** (old pods serving throughout).

This makes the lease `openai.gpt-5.3-codex-spark` only — the operator decision, satisfying the one-profile rule. The planner env already requests spark.

Today's second live specimen for the CES-117 **deployed-version compat gate**: both wedges (this and the #133/#101 ordering) were boot-time RegistryErrors that a snapshot-build-against-deployed-code CI check would have made unmergeable.

After merge: sync overlay → the crash-looping pods pick up the fixed configmap on their next restart and the rollouts complete on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)