### PR TITLE
CES-108: PostSync hook auto-rolls the control plane on registry-overlay sync

### DIFF
--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -3,6 +3,22 @@
 This app installs the prod deployment overlay for live `agent-workloads`
 worker-service paths.
 
+## Sync rolls the control plane automatically (CES-108)
+
+The control plane builds its `RegistrySnapshot` once at boot and never
+re-reads the mounted overlay, so every overlay change requires a restart of
+all four control-plane Deployments to take effect. A `PostSync` hook Job
+(`restart-hook.yaml`, ServiceAccount/Role scoped to exactly those four
+Deployments in `restart-rbac.yaml`) performs the `rollout restart` and then
+waits on `rollout status` for each — **a config the deployed image cannot
+boot fails the sync loudly** instead of crash-looping in silence. No manual
+`kubectl rollout restart` step is needed for overlay-only changes.
+
+Note: the hook fires on every sync of this app, including no-op re-syncs;
+restarts are rolling and the app is manual-sync, so syncs are deliberate.
+Workload-identity token re-mints (the `agent-workloads-secrets` app) still
+require a manual worker rollout — see CES-108 for the recorded follow-up.
+
 The ConfigMap mounts registry overlay files into the Mandate pod:
 
 - `workload_imports.yaml` imports deployment-pinned workload manifests and image

--- a/apps/agent-control-plane-registry-overlay/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-hook.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: registry-overlay-restart
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay-restart
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-control-plane
+        app.kubernetes.io/component: registry-overlay-restart
+    spec:
+      serviceAccountName: registry-overlay-restart
+      restartPolicy: Never
+      containers:
+        - name: rollout-restart
+          # CES-108: the control plane boot-caches the registry snapshot; an
+          # overlay sync without a rollout leaves stale authority serving.
+          image: rancher/kubectl:v1.33.4@sha256:5c0d769f262a320aef3a37e74188ebd5376e8acf2db85421a9cc138df1fcb6fb
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              deploys="agent-control-plane agent-control-plane-callback-adapter agent-control-plane-local-worker agent-control-plane-model-gateway"
+              for d in $deploys; do
+                kubectl -n agent-control-plane rollout restart "deploy/$d"
+              done
+              for d in $deploys; do
+                kubectl -n agent-control-plane rollout status "deploy/$d" --timeout=240s
+              done
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: registry-overlay-restart
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay-restart
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: registry-overlay-restart
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay-restart
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - agent-control-plane
+      - agent-control-plane-callback-adapter
+      - agent-control-plane-local-worker
+      - agent-control-plane-model-gateway
+    verbs: ["get", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: registry-overlay-restart
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay-restart
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: registry-overlay-restart
+subjects:
+  - kind: ServiceAccount
+    name: registry-overlay-restart
+    namespace: agent-control-plane


### PR DESCRIPTION
Option (a) from the ticket: an Argo `PostSync` hook Job in the overlay app restarts all four control-plane Deployments and then waits on `rollout status --timeout=240s` for each.

## Why this shape

- **Binds the restart to the overlay app's own sync** — the only variant that can't be forgotten, since it IS the sync.
- **Fail-loud runtime backstop**: if a synced overlay can't boot the deployed image (today's #136 wedge class), the hook's rollout-status wait fails → the Argo operation fails visibly, instead of silent crash-looping discovered later. Complements the CES-126 merge-time gate.
- **RBAC**: ServiceAccount + Role scoped to `get/watch/patch` on exactly the four named Deployments in `agent-control-plane` — no list, no create, no other namespaces.
- **Image**: `rancher/kubectl:v1.33.4` **digest-pinned** (`sha256:5c0d769f…`), matching the v1.33 server. (bitnami/kubectl no longer publishes versioned tags — only mutable `latest` — so it was rejected.)

## Ticket caveats addressed

- *Hook fires on every sync, not only content change*: accepted and documented in the README — the app is manual-sync, so syncs are deliberate; restarts are rolling.
- *restartedAt OutOfSync risk*: empirically clear — today's manual restarts (16:25, 17:05 UTC) left the `agent-control-plane` app reporting Synced afterwards. Will re-verify on the hook's first live run; `ignoreDifferences` follows if it ever wedges.
- *Workload-identity secret path*: deferred, recorded on CES-108 — the secrets app is SOPS-managed and CES-100 is about to restructure the watched object; a symmetric hook there lands after CES-100.
- README documents the mechanism; the manual restart step comes out of the deploy procedure after the first live-verified hook run (CES-113's registry-digest metric is the eventual clean proof).

## After merge

Deploy = just sync the overlay app; the hook does the rest. First live run doubles as the acceptance verify (overlay change → pods roll → new snapshot serving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)