### PR TITLE
CES-108 fix: whitelist namespaced Role/RoleBinding in the splattop AppProject

### DIFF
--- a/argocd/projects/splattop-project.yaml
+++ b/argocd/projects/splattop-project.yaml
@@ -68,6 +68,10 @@ spec:
       kind: Job
     - group: batch
       kind: CronJob
+    - group: rbac.authorization.k8s.io
+      kind: Role
+    - group: rbac.authorization.k8s.io
+      kind: RoleBinding
     - group: networking.k8s.io
       kind: Ingress
     - group: networking.k8s.io


### PR DESCRIPTION
#139's first live sync failed **loudly and before creating anything**: `one or more synchronization tasks are not valid` — the `splattop` AppProject's `namespaceResourceWhitelist` allows ServiceAccount and Job but no namespaced `rbac.authorization.k8s.io` kinds, so the hook's scoped Role/RoleBinding were rejected and the whole task list was refused.

Adds exactly `Role` + `RoleBinding` (namespaced) to the whitelist. `ClusterRole`/`ClusterRoleBinding` remain blacklisted — the hook's authority stays bound to the four named Deployments in one namespace.

Note: `argocd/projects/` is not covered by the root app (it syncs `argocd/applications` only), so after merge the project change needs a one-time `kubectl apply -f argocd/projects/splattop-project.yaml`, then re-sync the overlay app for the hook's (real) first run.

Fifth fail-closed-but-fail-obscure specimen for CES-125/CES-126 today — `mandate doctor`'s repo-state checks should include AppProject whitelist coverage for the kinds an app dir contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)