### PR TITLE
CES-108 fix: hook generateName + BeforeHookCreation-only (resume skipped the named hook)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-hook.yaml
@@ -1,14 +1,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: registry-overlay-restart
+  generateName: registry-overlay-restart-
   namespace: agent-control-plane
   labels:
     app.kubernetes.io/name: agent-control-plane
     app.kubernetes.io/component: registry-overlay-restart
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   backoffLimit: 1
   activeDeadlineSeconds: 600


### PR DESCRIPTION
Controller logs from the first two live runs showed the trap precisely: the dry-run task list **includes** the PostSync Job, the operation reports *waiting for completion of hook*, then 2s later the controller **resumes the operation with `skipHooks: true`** — and because `HookSucceeded` deletes the named Job, a completed hook leaves no trace, so Argo can't distinguish "ran and was cleaned" from "never ran," assumes ran, and succeeds without ever creating the Job (no restart, sync green — exactly the silent class this hook exists to kill).

Fix is the conventional hook pattern:
- `metadata.generateName` instead of a fixed name
- `hook-delete-policy: BeforeHookCreation` only — the completed Job stays visible (debuggable) until the next sync's hook creation replaces it

After merge: re-sync the overlay app; expect a `registry-overlay-restart-*` Job to actually run, roll the 4 CP deploys, and gate the sync on their rollout status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)