### PR TITLE
CES-119 + CES-122: control-plane bump to d262325 (batched)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-479f254ce4b9
+  tag: sha-d26232575733
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 479f254ce4b92811e453a15b7aba2ee33b378bbc
+      targetRevision: d262325757333caacb363db6a8f334850e6c6118
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
One CP image, two merged platform changes, per the batching decision:

- **CES-119** (#102): `model.call.rejected` audit events at every broker rejection site (gateway surface included) + worker-service jobs terminally fail with the propagated broker reason.
- **CES-122** (#103): self-describing capability cards (task/result/disclosure contracts, negative affordances, budget posture) + safe job status with released result/artifact metadata, terminal error, and `withheld` reasons.

**Provenance:** publish run [27312997316](https://github.com/cesaregarza/agent-platform/actions/runs/27312997316) on merge commit `d262325757333caacb363db6a8f334850e6c6118`; buildx pushed `sha-d26232575733` → index `sha256:d68124…` (same digest as `latest`, verified present in DOCR). Note: DOCR's tag *listing* is lagging for this tag; the CP pulls by tag at pod creation, and the CES-108 PostSync hook now fails the sync loudly if the image can't pull — no silent wedge possible.

No workload digests move — independent of the parked re-mint batch.

## After merge
Deploy = sync `agent-control-plane` (image) + sync the overlay app (CES-108 hook rolls the 4 deploys automatically — first content-relevant exercise of the hook). Then the live verifies: CES-119 synthetic over-cap (named error + audit event) and CES-122's released/withheld projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)