### PR TITLE
CES-99/125/102/113: control-plane bump to 7a0b3b0b (night's platform batch)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-d26232575733
+  tag: sha-37bca031ef2c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-37bca031ef2c
+  tag: sha-7a0b3b0b1631
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: d262325757333caacb363db6a8f334850e6c6118
+      targetRevision: 37bca031ef2c457f9e59c93155d67742f8c41bff
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 37bca031ef2c457f9e59c93155d67742f8c41bff
+      targetRevision: 7a0b3b0b16310372ad2e8735ffed6ebf927b7688
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Carries agent-platform #104 (terminal aggregate-budget **settlement** — succeeded jobs charge durable actuals, failed/cancelled/expired release; the $1/day propose cap returns to meaning ~80 real jobs instead of 4 reservations) and #105 (`mandate doctor` CLI — no runtime effect).

**Provenance**: `sha-37bca031ef2c` DOCR-verified → `sha256:9ea7943c…`, publish on merge commit `37bca031ef2c457f9e59c93155d67742f8c41bff`.

Deployable in the same window as #144 (independent changes: this is the CP image; #144 is workload pins+tokens). Sync order irrelevant between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)