### PR TITLE
CES-96: re-pin agent-workloads sha-e7c0661cd39f

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:3b8bdbc75338bc02f7ef14317e3b7b45c1ce1e665e73bca358189b821358d506
-      image_digest: sha256:35846e2cccf5cd145420c0ede8e9e237034baca105655f9707dab1d32a6d742c
+      manifest_digest: sha256:69566eecc3c645b3f2187749c9f38e04ffd5489637b5ddfc4d8118a245296588
+      image_digest: sha256:297cc05c5627f30b9ae95ff6e55e7efee0c75cb3727255c814e30f2f1b37cc67
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
             session_taint: prod_authority
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:f18dd53da0bffb5bd32dfbe7b25f84f1e3d2cee8e7a07b98a2496f7d310f9075
-      image_digest: sha256:dde932a245fbeac119d34cbe7b3508a7b37e1507e0cbebd4137262b1dfb2c238
+      manifest_digest: sha256:f4650b7fb28730b4b48fd3fc232863bb77d010e77dafa697b74124d9a79545bc
+      image_digest: sha256:169d675f953946af884a706396457d5d7cf117ac02d139576af068b841fb8e45
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -100,11 +100,17 @@ data:
             - changed_files
             - diff_sha256
             - diff_truncated
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
           disclosure_summary:
             summary: OpenCode proposal diffs remain metadata-only for the governed apply
               arc.
-            released_result: Proposal digest and file metadata only.
-            released_artifacts: Proposal artifact metadata only; diff bytes are withheld.
+            released_result: Proposal digest, file metadata, and immutable base repo/ref/commit/tree
+              metadata only.
+            released_artifacts: Proposal artifact metadata only; diff bytes are withheld
+              from released output after platform capture.
             artifact_classes_allowed:
             - opencode_proposal
             withheld:
@@ -171,8 +177,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:ab3a8030100f7a29a00152c963a42e14337459329e95540d0fe1de3863507449
-      image_digest: sha256:d8e7f2be393a31c681c466ad3f326d135dc272902adcf50dbef8d88680e42eac
+      manifest_digest: sha256:f8e47d470e9cbf3ffbe4b029dc1a403e93bfa2d116e4d6e0a24ba71c5070962b
+      image_digest: sha256:e0c29ca916a4de945fd5fff47cd1c2947a66ff3f53bb032c545c34925aff3169
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -369,8 +375,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:78cf58463668406d359d55dda907b52aae7991866977d4842cd779e5c472fa94",
-      "digest": "sha256:3b8bdbc75338bc02f7ef14317e3b7b45c1ce1e665e73bca358189b821358d506",
+      "code_digest": "sha256:752890d91bc12890d604ae1b6eb0283fa4df395bba5e930608f64aab0a073630",
+      "digest": "sha256:69566eecc3c645b3f2187749c9f38e04ffd5489637b5ddfc4d8118a245296588",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -380,7 +386,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:35846e2cccf5cd145420c0ede8e9e237034baca105655f9707dab1d32a6d742c",
+        "digest": "sha256:297cc05c5627f30b9ae95ff6e55e7efee0c75cb3727255c814e30f2f1b37cc67",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -410,8 +416,8 @@ data:
           "consequence_class": "reversible_staging"
         }
       },
-      "code_digest": "sha256:6576bd287336252c37bd315c3a95eee6d65f2fe17492774fe3afe84b37169ac5",
-      "digest": "sha256:f18dd53da0bffb5bd32dfbe7b25f84f1e3d2cee8e7a07b98a2496f7d310f9075",
+      "code_digest": "sha256:d68d46a02eee3b631045308cfdd3f392663aea5e0ae032987fa84b5d94781716",
+      "digest": "sha256:f4650b7fb28730b4b48fd3fc232863bb77d010e77dafa697b74124d9a79545bc",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -421,7 +427,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:dde932a245fbeac119d34cbe7b3508a7b37e1507e0cbebd4137262b1dfb2c238",
+        "digest": "sha256:169d675f953946af884a706396457d5d7cf117ac02d139576af068b841fb8e45",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -447,8 +453,8 @@ data:
           "consequence_class": "consequential"
         }
       },
-      "code_digest": "sha256:533d343476d4640b4019b3f6ed1b4c32711dffe378a5f3ab1020dd7c24dbafbc",
-      "digest": "sha256:ab3a8030100f7a29a00152c963a42e14337459329e95540d0fe1de3863507449",
+      "code_digest": "sha256:2dccbf16c23f003bc234abe1ae97e146df38f02a7778aebd2d5d80aa4df04da5",
+      "digest": "sha256:f8e47d470e9cbf3ffbe4b029dc1a403e93bfa2d116e4d6e0a24ba71c5070962b",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -458,7 +464,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:d8e7f2be393a31c681c466ad3f326d135dc272902adcf50dbef8d88680e42eac",
+        "digest": "sha256:e0c29ca916a4de945fd5fff47cd1c2947a66ff3f53bb032c545c34925aff3169",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-49774b486c04
-  digest: sha256:35846e2cccf5cd145420c0ede8e9e237034baca105655f9707dab1d32a6d742c
+  tag: sha-e7c0661cd39f
+  digest: sha256:297cc05c5627f30b9ae95ff6e55e7efee0c75cb3727255c814e30f2f1b37cc67
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -92,8 +92,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-49774b486c04
-    digest: sha256:dde932a245fbeac119d34cbe7b3508a7b37e1507e0cbebd4137262b1dfb2c238
+    tag: sha-e7c0661cd39f
+    digest: sha256:169d675f953946af884a706396457d5d7cf117ac02d139576af068b841fb8e45
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -148,8 +148,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-49774b486c04
-    digest: sha256:d8e7f2be393a31c681c466ad3f326d135dc272902adcf50dbef8d88680e42eac
+    tag: sha-e7c0661cd39f
+    digest: sha256:e0c29ca916a4de945fd5fff47cd1c2947a66ff3f53bb032c545c34925aff3169
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -173,14 +173,14 @@ opencodeApplyExecutor:
       memory: 512Mi
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:78cf58463668406d359d55dda907b52aae7991866977d4842cd779e5c472fa94
-    manifestDigest: sha256:3b8bdbc75338bc02f7ef14317e3b7b45c1ce1e665e73bca358189b821358d506
-    imageDigest: sha256:35846e2cccf5cd145420c0ede8e9e237034baca105655f9707dab1d32a6d742c
+    codeDigest: sha256:752890d91bc12890d604ae1b6eb0283fa4df395bba5e930608f64aab0a073630
+    manifestDigest: sha256:69566eecc3c645b3f2187749c9f38e04ffd5489637b5ddfc4d8118a245296588
+    imageDigest: sha256:297cc05c5627f30b9ae95ff6e55e7efee0c75cb3727255c814e30f2f1b37cc67
   opencode.apply_executor:
-    codeDigest: sha256:533d343476d4640b4019b3f6ed1b4c32711dffe378a5f3ab1020dd7c24dbafbc
-    manifestDigest: sha256:ab3a8030100f7a29a00152c963a42e14337459329e95540d0fe1de3863507449
-    imageDigest: sha256:d8e7f2be393a31c681c466ad3f326d135dc272902adcf50dbef8d88680e42eac
+    codeDigest: sha256:2dccbf16c23f003bc234abe1ae97e146df38f02a7778aebd2d5d80aa4df04da5
+    manifestDigest: sha256:f8e47d470e9cbf3ffbe4b029dc1a403e93bfa2d116e4d6e0a24ba71c5070962b
+    imageDigest: sha256:e0c29ca916a4de945fd5fff47cd1c2947a66ff3f53bb032c545c34925aff3169
   opencode.proposer:
-    codeDigest: sha256:6576bd287336252c37bd315c3a95eee6d65f2fe17492774fe3afe84b37169ac5
-    manifestDigest: sha256:f18dd53da0bffb5bd32dfbe7b25f84f1e3d2cee8e7a07b98a2496f7d310f9075
-    imageDigest: sha256:dde932a245fbeac119d34cbe7b3508a7b37e1507e0cbebd4137262b1dfb2c238
+    codeDigest: sha256:d68d46a02eee3b631045308cfdd3f392663aea5e0ae032987fa84b5d94781716
+    manifestDigest: sha256:f4650b7fb28730b4b48fd3fc232863bb77d010e77dafa697b74124d9a79545bc
+    imageDigest: sha256:169d675f953946af884a706396457d5d7cf117ac02d139576af068b841fb8e45


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `e7c0661cd39f7b12800751918d0cf8ee52e9c0ea`
- Publish run id: `27325184811`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:297cc05c5627f30b9ae95ff6e55e7efee0c75cb3727255c814e30f2f1b37cc67` | `sha256:69566eecc3c645b3f2187749c9f38e04ffd5489637b5ddfc4d8118a245296588` | `sha256:752890d91bc12890d604ae1b6eb0283fa4df395bba5e930608f64aab0a073630` |
| `opencode.apply_executor` | `sha256:e0c29ca916a4de945fd5fff47cd1c2947a66ff3f53bb032c545c34925aff3169` | `sha256:f8e47d470e9cbf3ffbe4b029dc1a403e93bfa2d116e4d6e0a24ba71c5070962b` | `sha256:2dccbf16c23f003bc234abe1ae97e146df38f02a7778aebd2d5d80aa4df04da5` |
| `opencode.proposer` | `sha256:169d675f953946af884a706396457d5d7cf117ac02d139576af068b841fb8e45` | `sha256:f4650b7fb28730b4b48fd3fc232863bb77d010e77dafa697b74124d9a79545bc` | `sha256:d68d46a02eee3b631045308cfdd3f392663aea5e0ae032987fa84b5d94781716` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.