### PR TITLE
CES-112: close release pin drift gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Run Python contract tests
         run: uv run python -m unittest discover -s tests
 
+      - name: Check control-plane release pin
+        run: uv run python scripts/check_control_plane_release_pin.py
+
   agent-workloads-identity-digest-drift:
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/check_agent_workloads_identity_digests.py
+++ b/scripts/check_agent_workloads_identity_digests.py
@@ -34,6 +34,11 @@ TOKEN_KEYS_BY_AGENT_ID = {
     "opencode.proposer": "OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN",
     "opencode.apply_executor": "OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN",
 }
+IMAGE_PATHS_BY_AGENT_ID = {
+    "data.workspace_probe": ("image",),
+    "opencode.proposer": ("opencodeProposer", "image"),
+    "opencode.apply_executor": ("opencodeApplyExecutor", "image"),
+}
 
 YAML_PARSER = YAML(typ="safe")
 
@@ -100,6 +105,11 @@ def check_agent_workloads_identity_digests(
     overlay_pins = _load_overlay_pins(repo_root / overlay_configmap_path)
     for agent_id in sorted(expected_agents):
         _assert_pin_matches_overlay(agent_id, release_pins[agent_id], overlay_pins[agent_id])
+        _assert_values_image_digest_matches_pin(
+            agent_id,
+            values,
+            release_pins[agent_id],
+        )
 
     _assert_runtime_secret_excludes_tokens(repo_root / runtime_secret_path)
     secret_path = repo_root / token_secret_path
@@ -130,7 +140,7 @@ def check_agent_workloads_identity_digests(
         token_claims_by_agent=token_claims_by_agent,
     )
 
-    return "agent-workloads workload identity code_digests match release pins."
+    return "agent-workloads deployed images and workload identity code_digests match release pins."
 
 
 def _load_overlay_pins(configmap_path: Path) -> dict[str, dict[str, str]]:
@@ -185,6 +195,41 @@ def _assert_pin_matches_overlay(
                 f"{agent_id} mandateReleasePins.{key} differs from registry overlay: "
                 f"expected {expected}, got {actual}"
             )
+
+
+def _assert_values_image_digest_matches_pin(
+    agent_id: str,
+    values: dict[str, Any],
+    release_pin: Any,
+) -> None:
+    if not isinstance(release_pin, dict):
+        raise DriftGateError(f"{agent_id} mandateReleasePins entry must be a mapping")
+    expected = release_pin.get("imageDigest")
+    _validate_digest(expected, f"{agent_id} mandateReleasePins.imageDigest")
+
+    image_path = IMAGE_PATHS_BY_AGENT_ID[agent_id]
+    image = _nested_mapping(values, image_path, f"{agent_id} values image")
+    actual = image.get("digest")
+    _validate_digest(actual, f"{agent_id} values image.digest")
+    if actual != expected:
+        raise DriftGateError(
+            f"{agent_id} values image.digest differs from mandateReleasePins.imageDigest: "
+            f"expected {expected}, got {actual}"
+        )
+
+
+def _nested_mapping(
+    mapping: dict[str, Any],
+    path: tuple[str, ...],
+    label: str,
+) -> dict[str, Any]:
+    current: Any = mapping
+    for key in path:
+        if not isinstance(current, dict) or not isinstance(current.get(key), dict):
+            dotted = ".".join(path)
+            raise DriftGateError(f"{label} must be a mapping at {dotted}")
+        current = current[key]
+    return current
 
 
 def _assert_runtime_secret_excludes_tokens(secret_path: Path) -> None:

--- a/scripts/check_control_plane_release_pin.py
+++ b/scripts/check_control_plane_release_pin.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Fail closed when the control-plane chart pin and runtime image tag diverge."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APPLICATION_PATH = Path("argocd/applications/agent-control-plane.yaml")
+VALUES_PATH = Path("apps/agent-control-plane/values.yaml")
+AGENT_PLATFORM_REPO_URL = "git@github.com:cesaregarza/agent-platform.git"
+REVISION_RE = re.compile(r"^[0-9a-fA-F]{12,40}$")
+
+YAML_PARSER = YAML(typ="safe")
+
+
+class ControlPlanePinError(RuntimeError):
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare the agent-platform chart targetRevision with the "
+            "agent-control-plane runtime image tag."
+        )
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--application-path", type=Path, default=APPLICATION_PATH)
+    parser.add_argument("--values-path", type=Path, default=VALUES_PATH)
+    args = parser.parse_args()
+
+    try:
+        result = check_control_plane_release_pin(
+            repo_root=args.repo_root,
+            application_path=args.application_path,
+            values_path=args.values_path,
+        )
+    except ControlPlanePinError as exc:
+        print(f"control-plane release pin gate failed: {exc}", file=sys.stderr)
+        return 1
+    print(result)
+    return 0
+
+
+def check_control_plane_release_pin(
+    *,
+    repo_root: Path,
+    application_path: Path,
+    values_path: Path,
+) -> str:
+    application = _load_yaml(repo_root / application_path)
+    values = _load_yaml(repo_root / values_path)
+
+    target_revision = _agent_platform_target_revision(application)
+    image = _required_mapping(values, "image", "agent-control-plane values")
+    image_tag = _required_str(image, "tag", "agent-control-plane image")
+
+    if REVISION_RE.fullmatch(target_revision) is None:
+        raise ControlPlanePinError(
+            "agent-platform targetRevision must be a 12-40 character hex commit pin"
+        )
+    expected_tag = f"sha-{target_revision[:12]}"
+    if image_tag != expected_tag:
+        raise ControlPlanePinError(
+            "agent-control-plane image.tag must match agent-platform targetRevision: "
+            f"expected {expected_tag}, got {image_tag}"
+        )
+
+    return "agent-control-plane chart targetRevision and image tag match."
+
+
+def _agent_platform_target_revision(application: dict[str, Any]) -> str:
+    spec = _required_mapping(application, "spec", "agent-control-plane application")
+    sources = spec.get("sources")
+    if not isinstance(sources, list):
+        raise ControlPlanePinError("agent-control-plane application spec.sources must be a list")
+
+    matches = [
+        source
+        for source in sources
+        if isinstance(source, dict) and source.get("repoURL") == AGENT_PLATFORM_REPO_URL
+    ]
+    if len(matches) != 1:
+        raise ControlPlanePinError(
+            "agent-control-plane application must have exactly one "
+            f"{AGENT_PLATFORM_REPO_URL} source"
+        )
+    return _required_str(matches[0], "targetRevision", "agent-platform source")
+
+
+def _required_mapping(mapping: dict[str, Any], key: str, label: str) -> dict[str, Any]:
+    value = mapping.get(key)
+    if not isinstance(value, dict):
+        raise ControlPlanePinError(f"{label} missing mapping {key}")
+    return value
+
+
+def _required_str(mapping: dict[str, Any], key: str, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ControlPlanePinError(f"{label} missing non-empty {key}")
+    return value
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ControlPlanePinError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -170,6 +170,16 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
         with self.assertRaisesRegex(DriftGateError, "mandateReleasePins.codeDigest"):
             _check(root)
 
+    def test_gate_rejects_values_image_digest_release_pin_mismatch(self) -> None:
+        root = _fixture_repo()
+        values_path = root / "apps" / "agent-workloads" / "values.yaml"
+        values = YAML_PARSER.load(values_path.read_text())
+        values["opencodeProposer"]["image"]["digest"] = "sha256:" + "8" * 64
+        _write_yaml(values_path, values)
+
+        with self.assertRaisesRegex(DriftGateError, "values image.digest"):
+            _check(root)
+
     def test_gate_rejects_stale_workload_identity_token_code_digest(self) -> None:
         root = _fixture_repo(
             token_digests={
@@ -227,7 +237,24 @@ def _fixture_repo(
     root = Path(tempfile.mkdtemp())
     values_path = root / "apps" / "agent-workloads" / "values.yaml"
     values_path.parent.mkdir(parents=True)
-    values: dict[str, Any] = {"image": {"tag": "sha-test"}}
+    values: dict[str, Any] = {
+        "image": {
+            "tag": "sha-test",
+            "digest": DIGESTS["data.workspace_probe"]["imageDigest"],
+        },
+        "opencodeProposer": {
+            "image": {
+                "tag": "sha-test",
+                "digest": DIGESTS["opencode.proposer"]["imageDigest"],
+            }
+        },
+        "opencodeApplyExecutor": {
+            "image": {
+                "tag": "sha-test",
+                "digest": DIGESTS["opencode.apply_executor"]["imageDigest"],
+            }
+        },
+    }
     if include_pins:
         values["mandateReleasePins"] = DIGESTS
     _write_yaml(values_path, values)

--- a/tests/test_control_plane_release_pin.py
+++ b/tests/test_control_plane_release_pin.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from scripts.check_control_plane_release_pin import (
+    ControlPlanePinError,
+    check_control_plane_release_pin,
+)
+
+
+YAML_PARSER = YAML(typ="safe")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ControlPlaneReleasePinTests(unittest.TestCase):
+    def test_current_control_plane_release_pin_matches(self) -> None:
+        result = check_control_plane_release_pin(
+            repo_root=REPO_ROOT,
+            application_path=Path("argocd/applications/agent-control-plane.yaml"),
+            values_path=Path("apps/agent-control-plane/values.yaml"),
+        )
+
+        self.assertIn("targetRevision and image tag match", result)
+
+    def test_control_plane_release_pin_check_runs_in_python_contracts_ci(self) -> None:
+        workflow = YAML_PARSER.load(
+            (REPO_ROOT / ".github" / "workflows" / "ci.yaml").read_text()
+        )
+        steps = workflow["jobs"]["python-contracts"]["steps"]
+
+        self.assertTrue(
+            any(
+                step.get("run")
+                == "uv run python scripts/check_control_plane_release_pin.py"
+                for step in steps
+            )
+        )
+
+    def test_control_plane_release_pin_rejects_tag_mismatch(self) -> None:
+        root = _fixture_repo(
+            target_revision="abcdef1234567890abcdef1234567890abcdef12",
+            image_tag="sha-deadbeef0000",
+        )
+
+        with self.assertRaisesRegex(
+            ControlPlanePinError,
+            "image.tag must match agent-platform targetRevision",
+        ):
+            check_control_plane_release_pin(
+                repo_root=root,
+                application_path=Path("argocd/applications/agent-control-plane.yaml"),
+                values_path=Path("apps/agent-control-plane/values.yaml"),
+            )
+
+
+def _fixture_repo(*, target_revision: str, image_tag: str) -> Path:
+    root = Path(tempfile.mkdtemp())
+    application_path = root / "argocd" / "applications" / "agent-control-plane.yaml"
+    values_path = root / "apps" / "agent-control-plane" / "values.yaml"
+    application_path.parent.mkdir(parents=True)
+    values_path.parent.mkdir(parents=True)
+
+    _write_yaml(
+        application_path,
+        {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Application",
+            "spec": {
+                "sources": [
+                    {
+                        "repoURL": "git@github.com:cesaregarza/agent-platform.git",
+                        "targetRevision": target_revision,
+                        "path": "helm/mandate",
+                    },
+                    {
+                        "repoURL": "https://github.com/cesaregarza/SplatTopConfig",
+                        "targetRevision": "main",
+                        "ref": "values",
+                    },
+                ]
+            },
+        },
+    )
+    _write_yaml(values_path, {"image": {"tag": image_tag}})
+    return root
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    from io import StringIO
+
+    stream = StringIO()
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(payload, stream)
+    path.write_text(stream.getvalue(), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Refs CES-112.
- Extends the existing agent-workloads identity drift gate to compare the Helm-deployed image digests with the matching mandateReleasePins imageDigest values.
- Adds a fail-closed control-plane release pin check for the agent-platform chart targetRevision and the agent-control-plane image tag.
- Runs the control-plane pin check in the pull_request Python contracts CI job.
- Adds negative tests for both drift cases.

## Authority invariants preserved
- This is a repo-side drift gate only; it does not add runtime authority or credential paths.
- Workload identity remains bound by the existing token/overlay/code-digest checks.
- The new checks fail closed before deployment when GitOps values diverge from attested pins.
- No secrets or ambient credentials are introduced.

## Tests
- uv run python -m unittest discover -s tests: 20 passed.
- uv run python scripts/check_control_plane_release_pin.py: passed.
- Real agent-workloads values image digest check against mandateReleasePins: passed.
- py_compile on changed scripts/tests: passed.
- git diff --check: passed.

## Docs
- No docs changed; CI workflow now carries the additional control-plane release pin gate.

## Deferred
- Runtime/claim-time image binding remains CES-104.
- Full agent-workloads drift script still decrypts SOPS only in CI with the brokered drift-gate key.