### PR TITLE
CES-131: allow opencode apply result artifact

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -197,6 +197,54 @@ data:
           description: Imported OpenCode apply executor for approved proposal diffs.
           output_schema: agent_workloads_opencode_apply_result_v1
           approval_mode: admin_confirm
+          result_contract:
+            output_schema: agent_workloads_opencode_apply_result_v1
+            released_result_fields:
+            - output_text
+            - operation_status
+            - action_id
+            - branch
+            - commit_sha
+            - applied_diff_sha256
+            - proposal_diff_sha256
+            - changed_files
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: false
+            citations_allowed: none
+            artifact_classes_allowed:
+            - opencode_apply_result
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+          disclosure_summary:
+            summary: OpenCode apply releases local apply metadata for the governed
+              delivery arc.
+            released_result: Local apply status, designation id, commit, patch digests,
+              changed files, and immutable base repo/ref/commit/tree metadata only.
+            released_artifacts: Apply result artifact metadata only; diff bytes and
+              remote delivery claims are withheld.
+            artifact_classes_allowed:
+            - opencode_apply_result
+            withheld:
+            - proposal and applied diff bytes
+            - remote ref and draft PR URL until deliverer confirmation
+            - raw task inputs
+            - internal sources and broker internals
+          negative_affordances:
+          - Does not push, open, merge, or claim a remote PR.
+          - Remote ref and PR URL arrive only through the deliverer callback after
+            confirmed write.
+          - Must not be used as a fallback when no capability matches.
           session_authority_budget:
             max_operations: 1
             session_taint: prod_authority

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -115,6 +115,67 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             capability["session_authority_budget"]["session_taint"],
             "prod_authority",
         )
+        self.assertEqual(
+            capability["artifacts"],
+            {"allowed": True, "broker_required": False},
+        )
+        self.assertEqual(
+            capability["disclosure"]["artifact_classes_allowed"],
+            ["opencode_apply_result"],
+        )
+        self.assertEqual(
+            capability["disclosure"]["max_confidentiality_level_out"],
+            "customer_visible",
+        )
+        self.assertIs(
+            capability["disclosure"]["require_output_redaction_pass"],
+            True,
+        )
+        self.assertIs(capability["disclosure"]["require_result_schema"], True)
+        self.assertEqual(
+            capability["result_contract"]["output_schema"],
+            "agent_workloads_opencode_apply_result_v1",
+        )
+        released_fields = set(capability["result_contract"]["released_result_fields"])
+        self.assertGreaterEqual(
+            released_fields,
+            {
+                "output_text",
+                "operation_status",
+                "action_id",
+                "branch",
+                "commit_sha",
+                "applied_diff_sha256",
+                "proposal_diff_sha256",
+                "changed_files",
+                "base_repo",
+                "base_ref_name",
+                "base_commit_sha",
+                "base_tree_sha",
+            },
+        )
+        self.assertTrue(
+            released_fields.isdisjoint(
+                {
+                    "diff",
+                    "patch",
+                    "unified_diff",
+                    "remote_ref",
+                    "pull_request_url",
+                    "pr_url",
+                    "delivery_status",
+                }
+            )
+        )
+        self.assertEqual(
+            capability["disclosure_summary"]["artifact_classes_allowed"],
+            ["opencode_apply_result"],
+        )
+        self.assertIn(
+            "Remote ref and PR URL arrive only through the deliverer callback after "
+            "confirmed write.",
+            capability["negative_affordances"],
+        )
 
         manifest = json.loads(self.data["agent-opencode.apply_executor.json"])
         self.assertEqual(manifest["id"], "opencode.apply_executor")


### PR DESCRIPTION
## Summary
- Adds the missing output-gate artifact policy for agent_workloads.opencode_apply.
- Allows the metadata-only opencode_apply_result artifact class.
- Declares the apply result contract/disclosure as local apply metadata only.
- Keeps remote ref / PR URL delivery claims out of the released apply contract per ADR 0012 rule 7.

## Authority invariants preserved
- Import remains data, not dispatch authority.
- The apply executor still requires admin_confirm and the existing policy grant.
- No credentials, Git write path, broker path, or remote delivery authority are added.
- Diff bytes remain withheld; released artifacts are metadata-only.
- Remote delivery claims stay reserved for deliverer confirmation/callback.

## Tests
- uv --directory /root/dev/SplatTopConfig-ces-131 run python tests/test_agent_control_plane_registry_overlay.py -v
- uv --directory /root/dev/SplatTopConfig-ces-131 run --python 3.11 python -m unittest discover -s tests -v
- git diff --check