### PR TITLE
CES-107: wire model-gateway kill switch and revocations

### DIFF
--- a/apps/agent-control-plane-runtime-controls/configmap.yaml
+++ b/apps/agent-control-plane-runtime-controls/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-control-plane-model-gateway-controls
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: model-gateway-controls
+    app.kubernetes.io/managed-by: argocd
+  annotations:
+    mandate.cesaregarza.io/operator-editable: "true"
+    mandate.cesaregarza.io/purpose: model-gateway-kill-switch-and-revocations
+data:
+  # Leave the kill-switch key absent during normal operation. Creating
+  # data.kill-switch makes the configured file appear in the mounted directory
+  # and causes the model gateway to fail closed with model_gateway_kill_switch_active.
+  revocations.txt: |
+    # Add one revoked id per line. Accepted prefixes: job:, job_id:, lease:, lease_id:.

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -46,3 +46,7 @@ Required before activation:
 - The approval interaction path is service-only:
   `POST /v1/openclaw/discord/approval-interactions` maps trusted Discord
   component payloads to the internal resolver and is not exposed through MCP.
+- Model-gateway kill switch and per-job/lease revocation files are mounted from
+  `agent-control-plane-model-gateway-controls` as a directory so operator edits
+  project without pod restarts. See
+  [model-gateway controls](../../docs/model-gateway-controls.md).

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -35,6 +35,8 @@ env:
   AGENT_PLATFORM_READONLY_SQL_POOL_MAX_SIZE: "1"
   AGENT_PLATFORM_MODEL_GATEWAY_BACKEND: codex_chatgpt_responses
   AGENT_PLATFORM_MODEL_GATEWAY_TIMEOUT_SECONDS: "90"
+  AGENT_PLATFORM_MODEL_GATEWAY_KILL_SWITCH_FILE: /app/model-gateway-controls/kill-switch
+  AGENT_PLATFORM_MODEL_GATEWAY_REVOCATION_FILE: /app/model-gateway-controls/revocations.txt
   AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE: hmac
   AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER: kubernetes
   AGENT_PLATFORM_WORKLOAD_IDENTITY_AUDIENCE: mandate-api
@@ -166,6 +168,9 @@ extraVolumes:
   - name: registry-overlay
     configMap:
       name: agent-control-plane-registry-overlay
+  - name: model-gateway-controls
+    configMap:
+      name: agent-control-plane-model-gateway-controls
 
 extraVolumeMounts:
   - name: registry-overlay
@@ -182,6 +187,9 @@ extraVolumeMounts:
     readOnly: true
   - name: registry-overlay
     mountPath: /app/registries/imports
+    readOnly: true
+  - name: model-gateway-controls
+    mountPath: /app/model-gateway-controls
     readOnly: true
 
 postgresSweep:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -20,6 +20,9 @@ spec:
     - repoURL: https://github.com/cesaregarza/SplatTopConfig
       targetRevision: main
       ref: values
+    - repoURL: https://github.com/cesaregarza/SplatTopConfig
+      targetRevision: main
+      path: apps/agent-control-plane-runtime-controls
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-control-plane

--- a/docs/model-gateway-controls.md
+++ b/docs/model-gateway-controls.md
@@ -1,0 +1,114 @@
+# Model Gateway Kill Switch And Revocations
+
+This runbook covers the deployment-owned controls mounted into the Mandate
+model-gateway and API pods from the
+`agent-control-plane-model-gateway-controls` ConfigMap.
+
+Mandate owns the enforcement code. SplatTopConfig owns the live files that make
+the controls operable in this cluster.
+
+## Files
+
+The agent-control-plane values set:
+
+- `AGENT_PLATFORM_MODEL_GATEWAY_KILL_SWITCH_FILE=/app/model-gateway-controls/kill-switch`
+- `AGENT_PLATFORM_MODEL_GATEWAY_REVOCATION_FILE=/app/model-gateway-controls/revocations.txt`
+
+The ConfigMap is mounted as a directory, not by `subPath`, so kubelet projects
+key changes into running pods without a pod restart.
+
+Normal state:
+
+- `kill-switch` key absent
+- `revocations.txt` present and readable, with comments or one revoked id per line
+
+## Halt All Model-Gateway Traffic
+
+Use this when model calls must stop immediately but the control plane should
+remain up for status, audit, cancellation, and operator actions.
+
+Recommended emergency path:
+
+```bash
+kubectl -n agent-control-plane patch configmap agent-control-plane-model-gateway-controls \
+  --type merge \
+  -p '{"data":{"kill-switch":"active\n"}}'
+```
+
+Expected result: after the kubelet ConfigMap projection window, model-gateway
+requests fail before token validation with `model_gateway_kill_switch_active`
+and HTTP 503.
+
+Deactivation:
+
+```bash
+kubectl -n agent-control-plane patch configmap agent-control-plane-model-gateway-controls \
+  --type json \
+  -p '[{"op":"remove","path":"/data/kill-switch"}]'
+```
+
+Argo decision: this control is intentionally operator-editable out of band.
+The `agent-control-plane` Argo Application is manual-sync; Argo will show drift
+after an emergency edit but will not auto-revert it. A later manual sync can
+remove an active kill switch because Git keeps the safe default with no
+`kill-switch` key. Before syncing while the switch is active, either confirm the
+incident is over or commit the active state to Git intentionally.
+
+## Revoke One Job Or Lease
+
+Edit `revocations.txt` with one id per line. Blank lines and `#` comments are
+allowed. Accepted formats:
+
+```text
+job_abc123
+job:job_abc123
+job_id:job_abc123
+lease_abc123
+lease:lease_abc123
+lease_id:lease_abc123
+```
+
+Patch example:
+
+```bash
+kubectl -n agent-control-plane patch configmap agent-control-plane-model-gateway-controls \
+  --type merge \
+  -p '{"data":{"revocations.txt":"# emergency revocations\njob:job_abc123\n"}}'
+```
+
+Expected result: matching model-gateway requests fail before the provider
+boundary with `model_gateway_lease_revoked` and HTTP 403.
+
+To clear revocations, replace the file with only comments:
+
+```bash
+kubectl -n agent-control-plane patch configmap agent-control-plane-model-gateway-controls \
+  --type merge \
+  -p '{"data":{"revocations.txt":"# no active revocations\n"}}'
+```
+
+## Propagation Window
+
+Kubernetes updates mounted ConfigMap directories asynchronously. Treat the
+worst-case propagation target as 60 seconds unless the live test records a
+smaller cluster-specific bound. Current model-gateway tokens are still bounded
+by their lease TTL and session-authority budget; the kill switch and revocation
+file are containment controls, not replacements for lease expiry.
+
+During live verification, record:
+
+- timestamp of ConfigMap edit
+- first observed `model_gateway_kill_switch_active` or `model_gateway_lease_revoked`
+- whether any pod restarted
+- timestamp of restoration
+
+## Fail-Closed Checks
+
+If the configured kill-switch or revocation source becomes unreadable, the
+model-gateway route must fail closed:
+
+- kill-switch source unreadable: `model_gateway_kill_switch_unavailable`, HTTP 503
+- revocation source unreadable: `model_gateway_revocation_source_unavailable`, HTTP 503
+
+Do not make these files writable by application containers. Operators mutate the
+ConfigMap through Kubernetes or Git; pods only read the projected files.

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -34,6 +34,12 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         cls.control_plane_application = _load_yaml(
             REPO_ROOT / "argocd" / "applications" / "agent-control-plane.yaml"
         )
+        cls.model_gateway_controls = _load_yaml(
+            REPO_ROOT
+            / "apps"
+            / "agent-control-plane-runtime-controls"
+            / "configmap.yaml"
+        )
 
     def test_opencode_proposer_import_is_overlay_pinned_and_proposal_only(self) -> None:
         imports = YAML_PARSER.load(self.data["workload_imports.yaml"])
@@ -272,6 +278,57 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "AGENT_PLATFORM_HOSTED_HARNESS_SAFE_FLOOR_AUDIT",
         ):
             self.assertEqual(env[key], "true")
+
+    def test_model_gateway_kill_switch_and_revocation_files_are_wired(self) -> None:
+        values = self.control_plane_values
+        env = values["env"]
+        self.assertEqual(
+            env["AGENT_PLATFORM_MODEL_GATEWAY_KILL_SWITCH_FILE"],
+            "/app/model-gateway-controls/kill-switch",
+        )
+        self.assertEqual(
+            env["AGENT_PLATFORM_MODEL_GATEWAY_REVOCATION_FILE"],
+            "/app/model-gateway-controls/revocations.txt",
+        )
+
+        volumes = {volume["name"]: volume for volume in values["extraVolumes"]}
+        self.assertEqual(
+            volumes["model-gateway-controls"]["configMap"]["name"],
+            "agent-control-plane-model-gateway-controls",
+        )
+
+        mounts = {mount["name"]: mount for mount in values["extraVolumeMounts"]}
+        controls_mount = mounts["model-gateway-controls"]
+        self.assertEqual(controls_mount["mountPath"], "/app/model-gateway-controls")
+        self.assertTrue(controls_mount["readOnly"])
+        self.assertNotIn("subPath", controls_mount)
+
+        configmap = self.model_gateway_controls
+        self.assertEqual(configmap["kind"], "ConfigMap")
+        self.assertEqual(
+            configmap["metadata"]["name"],
+            "agent-control-plane-model-gateway-controls",
+        )
+        self.assertEqual(configmap["metadata"]["namespace"], "agent-control-plane")
+        self.assertEqual(
+            configmap["metadata"]["annotations"][
+                "mandate.cesaregarza.io/operator-editable"
+            ],
+            "true",
+        )
+        self.assertNotIn("kill-switch", configmap["data"])
+        self.assertIn("revocations.txt", configmap["data"])
+
+        raw_sources = [
+            source
+            for source in self.control_plane_application["spec"]["sources"]
+            if source.get("path") == "apps/agent-control-plane-runtime-controls"
+        ]
+        self.assertEqual(len(raw_sources), 1)
+        self.assertEqual(
+            raw_sources[0]["repoURL"],
+            "https://github.com/cesaregarza/SplatTopConfig",
+        )
 
     def test_control_plane_pin_understands_opencode_executor_imports(self) -> None:
         sources = self.control_plane_application["spec"]["sources"]


### PR DESCRIPTION
## Summary
- Implements the SplatTopConfig wiring slice for CES-107.
- Adds an operator-editable `agent-control-plane-model-gateway-controls` ConfigMap as a raw source in the existing `agent-control-plane` Argo Application.
- Mounts that ConfigMap as a directory, not `subPath`, and sets `AGENT_PLATFORM_MODEL_GATEWAY_KILL_SWITCH_FILE` / `AGENT_PLATFORM_MODEL_GATEWAY_REVOCATION_FILE` in the Mandate values.
- Adds a runbook for kill-switch activation, lease/job revocation entries, deactivation, kubelet propagation expectations, and the manual-sync Argo revert decision.

## Authority invariants preserved
- This PR wires existing platform enforcement only; it adds no new authority path.
- Workers still do not receive model provider credentials.
- The model gateway remains the enforcement boundary for leased model calls.
- The ConfigMap contains only operator control flags and revoked ids; no secrets or tokens are introduced.
- Task/model/workload inputs do not become revocation authority.

## Tests
- New coverage proves:
  - kill switch and revocation env paths are configured;
  - the controls ConfigMap is mounted as a directory without `subPath`;
  - the default ConfigMap omits the `kill-switch` key;
  - `revocations.txt` is present;
  - the existing Argo app includes the raw controls source.
- Local validation:
  - `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` ✅ (`17 tests`)
  - `helm lint /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml` ✅
  - `helm template agent-control-plane /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml` ✅
  - `kubeconform -strict apps/agent-control-plane-runtime-controls/configmap.yaml` ✅
  - `kubeconform -strict -ignore-missing-schemas /tmp/agent-control-plane-ces107-rendered.yaml` ✅
  - `git diff --check` ✅

## Docs
- Added `docs/model-gateway-controls.md`.
- Linked the runbook from `apps/agent-control-plane/README.md`.

## Deferred
- Live verification remains operator-owned after merge/sync: create the kill-switch file, verify 503 without pod restart, remove it, then verify service restoration.
- Per-job/lease live revocation verification also remains post-sync because it needs a live lease id.
- No agent-platform code change was made; the shipped platform already owns the fail-closed behavior.

## Security review notes
- The control files are directory-mounted so kubelet updates propagate without restart.
- Git default omits the kill-switch key; an active emergency switch can be out-of-band and will show Argo drift, but manual sync can revert it. The runbook calls this out explicitly.