### PR TITLE
Fix XScraper readonly DSN credentials

### DIFF
--- a/secrets/agent-workloads/runtime-secret.enc.yaml
+++ b/secrets/agent-workloads/runtime-secret.enc.yaml
@@ -35,8 +35,8 @@ sops:
             ZmpBOWlRcDRhZVI2b0c4VE9yNTRVcEkKOJxWIhvQp9VzZaYWPbohFuaIBmFdvAIP
             2B/lmotTllfJ89wGuI5jozerAhDk79wWFxeuQyOny8ChskNlYr323g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-12T07:27:42Z"
-    mac: ENC[AES256_GCM,data:RLqdOew1jnePqKV+7WbQJk/pN2DlbPynG0Wmc0lx8DG1p6Rf7cY1qrebf2kVsVEMLo7/wCNNLtGq2sVHGLP4UVS57rkVg3vu8CNhzO1Cmp5ctio7a1aya0tryLR/nO2DoFlnzJMRrvZZwGiBynmg8Ten5hKN6fDB/s+vKCPDTIQ=,iv:3ytQy76s/uLSKoyUFjveg7AbmdhIk1XC7aG1N2bOtbM=,tag:iRCMlkTFbvFip0DRXZVKtw==,type:str]
+    lastmodified: "2026-06-12T11:12:07Z"
+    mac: ENC[AES256_GCM,data:WbTgPE2PQAQEetO/CHXN+KnAE4uGRAUzWV9c6b6xAxbSPB+9t4FTb3Mad1n2yaiCn3ZpiXopR+fIhCz3aXtnzd6a1FJFHqi9QJXKpO+wg6+FsGrm4UdPpLWMmF9E0SZj91GiZblg1gObaZJpT8GkvT/sazuAgSuEFJCShHwpH2Y=,iv:7CggexWZVrJyVPx0+MzjLvYH9hmofdAsZC0yRplOWJU=,tag:oJ4RQxhZwUbCPO1SVXF4WQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
## Summary
- Rebuild `XSCRAPER_READONLY_DATABASE_URL` in `secrets/agent-workloads/runtime-secret.enc.yaml` with the historical username/password/database/query values from before `2a8b562`.
- Change only the DSN host to the private DigitalOcean Postgres endpoint.
- Leave workload identity tokens and all other secret keys untouched.

## Validation
- Decrypted historical and updated DSNs locally with the Argo SOPS age key.
- Verified the updated DSN has userinfo, the private host, port `25060`, and preserved database path/query parameters.
- `git diff --check` passed.
- Signed commit verified with `git log --show-signature -1 --oneline`.