### PR TITLE
Bump agent control plane to 16decdad

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-55c0d8586ea9
+  tag: sha-16decdad8a82
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 55c0d8586ea959216629e6098056211f19c88d60
+      targetRevision: 16decdad8a828af3cf8b4799bd92f0423076930f
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## Summary
- bump the Mandate/agent-control-plane chart source from `55c0d8586ea959216629e6098056211f19c88d60` to `16decdad8a828af3cf8b4799bd92f0423076930f`
- bump the deployed control-plane image tag from `sha-55c0d8586ea9` to `sha-16decdad8a82`
- leave agent-workloads images, workload identity token secrets, metadata, and registry overlay pins untouched

Published image verified from agent-platform Actions run `27450966749`:
- `registry.digitalocean.com/sendouq/agent-platform:sha-16decdad8a82`
- digest: `sha256:d254829190626fc1f1225db032c11ef6aaf8892a7fe0d6d895ec56acb99533ad`

## Why
This decouples the control-plane release from stale PR #161. PR #161 predates the CES-100 workload identity token split and still writes the old `runtime-secret.enc.yaml` token layout, so the worker release needs to be redone separately against the new `workload-identity-tokens.enc.yaml` + metadata layout.

## Validation
- `UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/SplatTopConfig-cp-bump-16decdad run python scripts/check_control_plane_release_pin.py`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/SplatTopConfig-cp-bump-16decdad run python -m unittest discover -s tests`
- `git -C /root/dev/SplatTopConfig-cp-bump-16decdad diff --check`

## Deferred
- worker advance to `sha-b0087f0ff536` remains separate and requires re-minting the three workload identity tokens in the new CES-100 secret layout
