### PR TITLE
CES-163: raise opencode proposer operation cap

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -75,7 +75,7 @@ data:
             - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
           session_authority_budget:
-            max_operations: 16
+            max_operations: 30
             session_taint: prod_authority
           disclosure:
             raw_inputs_returnable: false

--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -75,7 +75,7 @@ data:
             - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
           session_authority_budget:
-            max_operations: 8
+            max_operations: 16
             session_taint: prod_authority
           disclosure:
             raw_inputs_returnable: false

--- a/docs/grant-ownership-source.yaml
+++ b/docs/grant-ownership-source.yaml
@@ -9,3 +9,6 @@ deployment_owned_capability_keys:
 preserve_existing_capability_keys:
 - approval_mode
 session_taint_key: session_taint
+session_authority_budget_preserved_keys:
+- max_operations
+- session_taint

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -17,7 +17,7 @@ normal publish, re-pin, and re-mint flow.
 - Source: `cesaregarza/agent-workloads/scripts/apply_splattop_release_artifacts.py`
 - Deployment-owned capability roots: `artifacts`, `disclosure`, `model_lease`
 - Preserved existing capability roots: `approval_mode`
-- Session authority preserved subkeys: `session_authority_budget.session_taint`
+- Session authority preserved subkeys: `session_authority_budget.max_operations`, `session_authority_budget.session_taint`
 
 ## Consumers
 

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -9,6 +9,7 @@ generated_from:
   preserve_existing_capability_keys:
   - approval_mode
   session_authority_budget_preserved_keys:
+  - max_operations
   - session_taint
 consumers:
 - scripts/set_grant.py
@@ -77,9 +78,10 @@ capabilities:
         remint_required: false
         digest_moves: false
         deployment_owned_subkeys:
+        - max_operations
         - session_taint
         release_owned_subkeys: '*'
-        source: SESSION_TAINT_KEY
+        source: SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS
   agent_workloads.opencode_propose:
     agent_id: opencode.proposer
     source:
@@ -142,9 +144,10 @@ capabilities:
         remint_required: false
         digest_moves: false
         deployment_owned_subkeys:
+        - max_operations
         - session_taint
         release_owned_subkeys: '*'
-        source: SESSION_TAINT_KEY
+        source: SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS
   agent_workloads.opencode_task:
     agent_id: opencode.proposer
     source:
@@ -207,9 +210,10 @@ capabilities:
         remint_required: false
         digest_moves: false
         deployment_owned_subkeys:
+        - max_operations
         - session_taint
         release_owned_subkeys: '*'
-        source: SESSION_TAINT_KEY
+        source: SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS
       task_contract:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
@@ -278,6 +282,7 @@ capabilities:
         remint_required: false
         digest_moves: false
         deployment_owned_subkeys:
+        - max_operations
         - session_taint
         release_owned_subkeys: '*'
-        source: SESSION_TAINT_KEY
+        source: SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS

--- a/scripts/grant_ownership.py
+++ b/scripts/grant_ownership.py
@@ -44,6 +44,7 @@ class ApplierContract:
     deployment_owned_capability_keys: tuple[str, ...]
     preserve_existing_capability_keys: tuple[str, ...]
     session_taint_key: str
+    session_authority_budget_preserved_keys: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -104,6 +105,20 @@ def load_applier_contract(
     source_path = repo_root / OWNERSHIP_SOURCE_PATH
     if source_path.exists():
         source = _load_yaml(source_path)
+        preserved_keys = tuple(
+            sorted(
+                str(key)
+                for key in source.get("session_authority_budget_preserved_keys")
+                or [_required_str(source.get("session_taint_key"), "session_taint_key")]
+            )
+        )
+        session_taint_key = _required_str(
+            source.get("session_taint_key") or "session_taint",
+            "session_taint_key",
+        )
+        if session_taint_key not in preserved_keys:
+            preserved_keys = tuple(sorted((*preserved_keys, session_taint_key)))
+
         return ApplierContract(
             deployment_owned_capability_keys=tuple(
                 sorted(
@@ -121,10 +136,8 @@ def load_applier_contract(
                     )
                 )
             ),
-            session_taint_key=_required_str(
-                source.get("session_taint_key"),
-                "session_taint_key",
-            ),
+            session_taint_key=session_taint_key,
+            session_authority_budget_preserved_keys=preserved_keys,
         )
 
     return extract_applier_contract(find_agent_workloads_repo(repo_root=repo_root))
@@ -136,6 +149,7 @@ def extract_applier_contract(agent_workloads_repo: Path) -> ApplierContract:
     wanted = {
         "DEPLOYMENT_OWNED_CAPABILITY_KEYS",
         "PRESERVE_EXISTING_CAPABILITY_KEYS",
+        "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
         "SESSION_TAINT_KEY",
     }
     values: dict[str, Any] = {}
@@ -150,6 +164,15 @@ def extract_applier_contract(agent_workloads_repo: Path) -> ApplierContract:
         deployment_owned = tuple(sorted(values["DEPLOYMENT_OWNED_CAPABILITY_KEYS"]))
         preserve_existing = tuple(sorted(values["PRESERVE_EXISTING_CAPABILITY_KEYS"]))
         session_taint_key = str(values["SESSION_TAINT_KEY"])
+        preserved_keys = tuple(
+            sorted(
+                str(key)
+                for key in values.get(
+                    "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
+                    {session_taint_key},
+                )
+            )
+        )
     except KeyError as exc:
         raise GrantOwnershipError(
             f"{source_path} is missing expected applier contract constant {exc.args[0]}"
@@ -159,6 +182,7 @@ def extract_applier_contract(agent_workloads_repo: Path) -> ApplierContract:
         deployment_owned_capability_keys=deployment_owned,
         preserve_existing_capability_keys=preserve_existing,
         session_taint_key=session_taint_key,
+        session_authority_budget_preserved_keys=preserved_keys,
     )
 
 
@@ -225,7 +249,9 @@ def build_ownership_map(
             "preserve_existing_capability_keys": list(
                 contract.preserve_existing_capability_keys
             ),
-            "session_authority_budget_preserved_keys": [contract.session_taint_key],
+            "session_authority_budget_preserved_keys": list(
+                contract.session_authority_budget_preserved_keys
+            ),
         },
         "consumers": [
             "scripts/set_grant.py",
@@ -337,6 +363,9 @@ def write_ownership_outputs(
                 contract.preserve_existing_capability_keys
             ),
             "session_taint_key": contract.session_taint_key,
+            "session_authority_budget_preserved_keys": list(
+                contract.session_authority_budget_preserved_keys
+            ),
         },
     )
     ownership = build_ownership_map(
@@ -544,9 +573,11 @@ def _ownership_for_key(key: str, contract: ApplierContract) -> dict[str, Any]:
             "deploy_consequence": CONTROL_PLANE_RESTART,
             "remint_required": False,
             "digest_moves": False,
-            "deployment_owned_subkeys": [contract.session_taint_key],
+            "deployment_owned_subkeys": list(
+                contract.session_authority_budget_preserved_keys
+            ),
             "release_owned_subkeys": "*",
-            "source": "SESSION_TAINT_KEY",
+            "source": "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
         }
     return {
         "owner": RELEASE_OWNER,

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -66,7 +66,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ["openai.gpt-5.3-codex-spark"],
         )
         self.assertEqual(capability["model_lease"]["max_cost_usd"], 0.25)
-        self.assertEqual(capability["session_authority_budget"]["max_operations"], 16)
+        self.assertEqual(capability["session_authority_budget"]["max_operations"], 30)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_proposal"],

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -66,7 +66,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ["openai.gpt-5.3-codex-spark"],
         )
         self.assertEqual(capability["model_lease"]["max_cost_usd"], 0.25)
-        self.assertEqual(capability["session_authority_budget"]["max_operations"], 8)
+        self.assertEqual(capability["session_authority_budget"]["max_operations"], 16)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_proposal"],

--- a/tests/test_grant_ownership.py
+++ b/tests/test_grant_ownership.py
@@ -92,6 +92,28 @@ class GrantOwnershipTests(unittest.TestCase):
         self.assertIn("overlay-only: CP restart required, no re-mint", body)
         self.assertIn("No workload manifest, image, or code digest moves.", body)
 
+    def test_set_grant_allows_session_authority_max_operations_overlay_edit(
+        self,
+    ) -> None:
+        root = _fixture_repo()
+        pr_body = root / "grant-edit-pr.md"
+
+        result = apply_grant_edit(
+            repo_root=root,
+            capability_id="agent_workloads.opencode_propose",
+            key_path="session_authority_budget.max_operations",
+            raw_value="16",
+            pr_body_path=pr_body,
+        )
+
+        capability = _capability(root, "agent_workloads.opencode_propose")
+        self.assertEqual(capability["session_authority_budget"]["max_operations"], 16)
+        self.assertEqual(result.action, "set")
+        self.assertEqual(result.new_value, 16)
+        body = pr_body.read_text()
+        self.assertIn("overlay-only: CP restart required, no re-mint", body)
+        self.assertIn("No workload manifest, image, or code digest moves.", body)
+
     def test_set_grant_refuses_release_owned_output_schema(self) -> None:
         root = _fixture_repo()
 


### PR DESCRIPTION
## Summary
- Raise the deployed `agent_workloads.opencode_propose` session-authority operations cap from 8 to 16.
- Regenerate grant ownership docs so `session_authority_budget.max_operations` is explicitly deployment-owned and overlay-only.
- Add regression coverage for editing the cap through the grant ownership path.

## Authority invariants preserved
- No workload image, manifest digest, code digest, token, or secret changed.
- The budget remains bounded and fail-closed; this only right-sizes the explicit ceiling.
- Import remains data, not dispatch; admission, lease projection, model gateway budget checks, output gate, and audit remain authoritative.

## Tests
- `PYTHONPATH=. UV_CACHE_DIR=/root/dev/.uv-cache uv run --with pytest pytest tests/test_agent_control_plane_registry_overlay.py tests/test_grant_ownership.py`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `git diff --check`

## Could not run
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_agent_workloads_identity_digests.py` failed locally because this environment cannot decrypt the SOPS workload identity token secret. This PR intentionally does not change workload identity tokens or code digests.

## Companion
- Requires/aligns with agent-workloads PR #36: https://github.com/cesaregarza/agent-workloads/pull/36

Refs CES-163.