### PR TITLE
CES-163: bump opencode_propose operation cap 30->100 (diagnostic headroom)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -75,7 +75,7 @@ data:
             - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
           session_authority_budget:
-            max_operations: 30
+            max_operations: 100
             session_taint: prod_authority
           disclosure:
             raw_inputs_returnable: false

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -66,7 +66,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ["openai.gpt-5.3-codex-spark"],
         )
         self.assertEqual(capability["model_lease"]["max_cost_usd"], 0.25)
-        self.assertEqual(capability["session_authority_budget"]["max_operations"], 30)
+        self.assertEqual(capability["session_authority_budget"]["max_operations"], 100)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_proposal"],


### PR DESCRIPTION
Follow-up to #169. cap=30 still exhausted (`job_9777f82b`: 30x `200` -> 31st `400 session_authority_budget_exhausted`, 181.6s, single-file edit). Calls are cheap (~$0.0037 each, $0.11/run) so cost isn't the constraint.

Bumps `opencode_propose` `session_authority_budget.max_operations` **30 -> 100** for operations headroom. The **$0.25 per-job cost cap** (`max_cost_usd_per_job` + capability `model_lease.max_cost_usd`) remains the real backstop at ~68 calls, so this is a clean diagnostic: *can opencode finish a one-file edit in <=~68 cheap calls?* If yes -> first real proposal artifact + closes CES-128/CES-163; if it cost-caps at ~68 -> opencode is definitively excessive -> CES-165 (efficiency) + CES-164 (observability).

Cap is deployment-owned and preserved across release re-syncs (aw#36). Test updated. Operator-gated: advise + stage for your merge.