### PR TITLE
CES-123: add Mandate workload enablement planner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,10 @@ These documents capture the canonical workflows for the SplatTop config reposito
 3. `argo-operations.md` – AppProject guardrails, policy enforcement, and day-to-day Argo duties.
 4. `domains-and-hostnames.md` – public hostname rollout checklist, including multi-zone external-dns changes.
 5. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
-6. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-7. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+6. `mandate-apply.md` – local declarative enablement planner for Mandate
+   workload capability wiring.
+7. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+8. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/mandate-apply.md
+++ b/docs/mandate-apply.md
@@ -1,0 +1,70 @@
+# Mandate Apply
+
+`scripts/mandate_apply.py` is the first local CES-123 enablement planner for
+Mandate workload capabilities. It consumes one declarative
+`MandateWorkloadEnablement` YAML document and reconciles only the
+deployment-owned edges that SplatTopConfig is allowed to own.
+
+Dry-run is the default. Use `--write` only on a branch intended for a normal PR.
+The tool never mutates the live cluster, never edits SOPS secret values, never
+mints workload identity tokens, and never changes workload-release-owned facts.
+
+## Example
+
+```yaml
+schema_version: mandate-workload-enablement.v1
+kind: MandateWorkloadEnablement
+workload: data.workspace_probe
+capability: agent_workloads.readonly_query
+grant:
+  binding: private-admin-controlled-capabilities
+model_lease:
+  allowed_profile: openai.gpt-5.3-codex-spark
+worker:
+  claims: true
+secrets:
+  - key: XSCRAPER_READONLY_DATABASE_URL
+network:
+  - to: private-db-postgresql-nyc3-xscraper-do-user-15543770-0.c.db.ondigitalocean.com:25060
+```
+
+Plan without writing:
+
+```bash
+uv run python scripts/mandate_apply.py enablement.yaml --repo-root .
+```
+
+Write automatic deployment-owned edits and emit a PR body:
+
+```bash
+uv run python scripts/mandate_apply.py enablement.yaml \
+  --repo-root . \
+  --write \
+  --output-pr-body .git/mandate-apply-pr-body.md
+```
+
+## What It Can Edit
+
+- `policy.prod.yaml` embedded in the agent-control-plane registry overlay:
+  append the requested capability to an existing binding.
+- `workload_imports.yaml` embedded in the registry overlay: set exactly one
+  allowed model profile on a deployment-owned `model_lease`.
+- `apps/agent-workloads/values.yaml`: add the capability to a known worker's
+  `AGENT_WORKLOADS_WORKER_CAPABILITIES` claim list.
+
+All of these changes still require the normal PR, CI, merge, Argo sync, and
+control-plane restart path. The enablement document is not dispatch authority.
+
+## What It Refuses Or Names
+
+- `grant` may only name an existing binding. It cannot add users, actors,
+  channels, new bindings, wildcard grants, consequence classes, or policy
+  authority.
+- `model_lease` may only name one `allowed_profile`. Multiple profiles and other
+  model lease fields are refused in this v0.
+- `secrets` may only name keys. Missing key references or missing encrypted SOPS
+  keys are reported as operator gaps; values are never read or written.
+- `network` requests are reported as operator-review gaps because the deployed
+  NetworkPolicy uses CIDR and selector rules, not hostname authority.
+- Workload-release-owned fields stay in `agent-workloads` and require the normal
+  publish, re-pin, and re-mint flow described by `docs/grant-ownership.md`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,6 +82,22 @@ Utilities that were previously bundled with the app repo move here when they are
   in `argocd/applications/agent-control-plane.yaml`. Use
   `--print-target-revision` to retrieve that SHA for automation.
 
+- `mandate_apply.py` – plans or writes a local CES-123
+  `MandateWorkloadEnablement` document into deployment-owned files only. Dry-run
+  is the default; `--write` edits files for a normal PR. It never reads or
+  writes secret values, never mutates live Kubernetes objects, and reports SOPS
+  or NetworkPolicy work as operator gaps:
+
+  ```bash
+  uv run python scripts/mandate_apply.py enablement.yaml --repo-root .
+  uv run python scripts/mandate_apply.py enablement.yaml \
+    --repo-root . \
+    --write \
+    --output-pr-body .git/mandate-apply-pr-body.md
+  ```
+
+  See `docs/mandate-apply.md` for the document schema and boundaries.
+
 - `bootstrap_bot.py` – scaffolds a bot entry (apps/bots YAML), secrets folder (README/kustomization/ksops), and copies the DB CA into the shared chart. Examples:
 
   ```bash

--- a/scripts/mandate_apply.py
+++ b/scripts/mandate_apply.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.workload_enablement import (
+    WorkloadEnablementError,
+    apply_workload_enablement,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or apply a Mandate workload enablement document into the "
+            "deployment repo. Dry-run is the default; --write edits files for a PR."
+        )
+    )
+    parser.add_argument("document", type=Path, help="MandateWorkloadEnablement YAML")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the SplatTopConfig checkout.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write automatic deployment-owned edits. Never writes secret values.",
+    )
+    parser.add_argument(
+        "--output-pr-body",
+        type=Path,
+        help="Write a PR body describing edits, gaps, and authority invariants.",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = apply_workload_enablement(
+            repo_root=args.repo_root,
+            document_path=args.document,
+            write=args.write,
+            pr_body_path=args.output_pr_body,
+        )
+    except WorkloadEnablementError as exc:
+        parser.exit(1, f"error: {exc}\n")
+
+    mode = "wrote" if args.write else "planned"
+    print(f"{mode} enablement for {result.capability} on {result.workload}")
+    if result.changed_files:
+        print("changed files:")
+        for path in result.changed_files:
+            print(f"- {path}")
+    print("actions:")
+    for action in result.actions:
+        print(f"- {action.code}: {action.message}")
+    if result.gaps:
+        print("operator gaps:")
+        for gap in result.gaps:
+            print(f"- {gap.code}: {gap.message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workload_enablement.py
+++ b/scripts/workload_enablement.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from scripts.grant_ownership import (
+    CONFIGMAP_PATH,
+    OWNERSHIP_MAP_PATH,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_WORKLOADS_VALUES_PATH = Path("apps/agent-workloads/values.yaml")
+AGENT_WORKLOADS_RUNTIME_SECRET_PATH = Path(
+    "secrets/agent-workloads/runtime-secret.enc.yaml"
+)
+
+SCHEMA_VERSION = "mandate-workload-enablement.v1"
+KIND = "MandateWorkloadEnablement"
+
+YAML_SAFE = YAML(typ="safe")
+YAML_RT = YAML()
+YAML_RT.preserve_quotes = True
+YAML_RT.width = 4096
+
+ALLOWED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "kind",
+    "workload",
+    "capability",
+    "grant",
+    "model_lease",
+    "worker",
+    "secrets",
+    "network",
+}
+ALLOWED_GRANT_KEYS = {"binding"}
+ALLOWED_MODEL_LEASE_KEYS = {"allowed_profile"}
+ALLOWED_WORKER_KEYS = {"claims"}
+ALLOWED_SECRET_KEYS = {"key"}
+ALLOWED_NETWORK_KEYS = {"to"}
+
+WORKER_CAPABILITY_ENV_PATHS = {
+    "data.workspace_probe": ("env", "AGENT_WORKLOADS_WORKER_CAPABILITIES"),
+    "opencode.proposer": (
+        "opencodeProposer",
+        "env",
+        "AGENT_WORKLOADS_WORKER_CAPABILITIES",
+    ),
+    "opencode.apply_executor": (
+        "opencodeApplyExecutor",
+        "env",
+        "AGENT_WORKLOADS_WORKER_CAPABILITIES",
+    ),
+}
+
+
+class WorkloadEnablementError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class EnablementAction:
+    code: str
+    message: str
+    path: str
+
+
+@dataclass(frozen=True)
+class WorkloadEnablementResult:
+    workload: str
+    capability: str
+    actions: tuple[EnablementAction, ...]
+    gaps: tuple[EnablementAction, ...]
+    changed_files: tuple[str, ...]
+
+    @property
+    def has_gaps(self) -> bool:
+        return bool(self.gaps)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.changed_files)
+
+
+def plan_workload_enablement(
+    *,
+    repo_root: Path = REPO_ROOT,
+    document_path: Path,
+) -> WorkloadEnablementResult:
+    return apply_workload_enablement(
+        repo_root=repo_root,
+        document_path=document_path,
+        write=False,
+    )
+
+
+def apply_workload_enablement(
+    *,
+    repo_root: Path = REPO_ROOT,
+    document_path: Path,
+    write: bool,
+    pr_body_path: Path | None = None,
+) -> WorkloadEnablementResult:
+    document = _load_document(document_path)
+    capability_id = _required_str(document.get("capability"), "capability")
+    workload_id = _required_str(document.get("workload"), "workload")
+
+    configmap_path = repo_root / CONFIGMAP_PATH
+    configmap = _load_yaml_rt(configmap_path)
+    data = _required_mapping(configmap.get("data"), "registry overlay ConfigMap data")
+    workload_imports = _load_yaml_text_rt(
+        _required_str(data.get("workload_imports.yaml"), "data.workload_imports.yaml")
+    )
+    policy = _load_yaml_text_rt(
+        _required_str(data.get("policy.prod.yaml"), "data.policy.prod.yaml")
+    )
+    values_path = repo_root / AGENT_WORKLOADS_VALUES_PATH
+    values = _load_yaml_rt(values_path)
+    ownership = _load_yaml(repo_root / OWNERSHIP_MAP_PATH)
+
+    import_entry, capability = _find_imported_capability(
+        workload_imports=workload_imports,
+        workload_id=workload_id,
+        capability_id=capability_id,
+    )
+    _require_deployment_owned(ownership, capability_id, "model_lease")
+    _require_deployment_owned(ownership, capability_id, "session_authority_budget")
+
+    actions: list[EnablementAction] = []
+    gaps: list[EnablementAction] = []
+    changed_files: set[str] = set()
+
+    if _plan_policy_grant(
+        document=document,
+        capability_id=capability_id,
+        policy=policy,
+        actions=actions,
+    ):
+        changed_files.add(str(CONFIGMAP_PATH))
+
+    if _plan_model_lease(
+        document=document,
+        capability_id=capability_id,
+        capability=capability,
+        actions=actions,
+    ):
+        changed_files.add(str(CONFIGMAP_PATH))
+
+    if _plan_worker_claims(
+        document=document,
+        workload_id=workload_id,
+        capability_id=capability_id,
+        values=values,
+        actions=actions,
+    ):
+        changed_files.add(str(AGENT_WORKLOADS_VALUES_PATH))
+
+    _plan_secret_references(
+        repo_root=repo_root,
+        document=document,
+        values=values,
+        actions=actions,
+        gaps=gaps,
+    )
+    _plan_network_requests(document=document, gaps=gaps)
+
+    if write and changed_files:
+        data["workload_imports.yaml"] = _dump_yaml(workload_imports)
+        data["policy.prod.yaml"] = _dump_yaml(policy)
+        _write_yaml(configmap_path, configmap)
+        _write_yaml(values_path, values)
+
+    result = WorkloadEnablementResult(
+        workload=_required_str(import_entry.get("id"), "workload import id"),
+        capability=capability_id,
+        actions=tuple(actions),
+        gaps=tuple(gaps),
+        changed_files=tuple(sorted(changed_files)),
+    )
+    if pr_body_path is not None:
+        pr_body_path.parent.mkdir(parents=True, exist_ok=True)
+        pr_body_path.write_text(render_workload_enablement_pr_body(result), encoding="utf-8")
+    return result
+
+
+def render_workload_enablement_pr_body(result: WorkloadEnablementResult) -> str:
+    lines = [
+        "## Summary",
+        f"- reconcile `{result.capability}` for workload `{result.workload}`.",
+        "- Apply deployment-owned enablement edits only.",
+        "",
+        "## Automatic edits",
+    ]
+    if result.actions:
+        lines.extend(f"- `{action.code}`: {action.message}" for action in result.actions)
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Operator gaps"])
+    if result.gaps:
+        lines.extend(f"- `{gap.code}`: {gap.message}" for gap in result.gaps)
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Authority Invariants",
+            "- No live ConfigMap, Secret, or Kubernetes object is mutated.",
+            "- Secret values are never read or written; only key names are inspected.",
+            "- Deployment-owned overlay edits require the normal PR and control-plane restart.",
+            "- Workload-release-owned fields remain refused by the ownership map.",
+            "- Import and enablement documents are not dispatch authority by themselves.",
+            "",
+            "Refs CES-123.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _load_document(path: Path) -> dict[str, Any]:
+    document = _load_yaml(path)
+    _reject_unknown_keys(document, ALLOWED_TOP_LEVEL_KEYS, "enablement document")
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise WorkloadEnablementError(
+            f"schema_version must be {SCHEMA_VERSION!r}"
+        )
+    if document.get("kind") != KIND:
+        raise WorkloadEnablementError(f"kind must be {KIND!r}")
+    _validate_grant(document.get("grant"))
+    _validate_model_lease(document.get("model_lease"))
+    _validate_worker(document.get("worker"))
+    _validate_secrets(document.get("secrets"))
+    _validate_network(document.get("network"))
+    return document
+
+
+def _validate_grant(value: Any) -> None:
+    if value is None:
+        return
+    grant = _required_mapping(value, "grant")
+    _reject_unknown_keys(grant, ALLOWED_GRANT_KEYS, "grant")
+    _required_str(grant.get("binding"), "grant.binding")
+
+
+def _validate_model_lease(value: Any) -> None:
+    if value is None:
+        return
+    lease = _required_mapping(value, "model_lease")
+    _reject_unknown_keys(lease, ALLOWED_MODEL_LEASE_KEYS, "model_lease")
+    profile = lease.get("allowed_profile")
+    if not isinstance(profile, str) or not profile:
+        raise WorkloadEnablementError(
+            "model_lease must declare exactly one non-empty allowed_profile"
+        )
+
+
+def _validate_worker(value: Any) -> None:
+    if value is None:
+        return
+    worker = _required_mapping(value, "worker")
+    _reject_unknown_keys(worker, ALLOWED_WORKER_KEYS, "worker")
+    if worker.get("claims") is not True:
+        raise WorkloadEnablementError("worker.claims must be true when declared")
+
+
+def _validate_secrets(value: Any) -> None:
+    if value is None:
+        return
+    secrets = _required_list(value, "secrets")
+    for index, secret in enumerate(secrets):
+        item = _required_mapping(secret, f"secrets[{index}]")
+        _reject_unknown_keys(item, ALLOWED_SECRET_KEYS, f"secrets[{index}]")
+        _required_str(item.get("key"), f"secrets[{index}].key")
+
+
+def _validate_network(value: Any) -> None:
+    if value is None:
+        return
+    requests = _required_list(value, "network")
+    for index, request in enumerate(requests):
+        item = _required_mapping(request, f"network[{index}]")
+        _reject_unknown_keys(item, ALLOWED_NETWORK_KEYS, f"network[{index}]")
+        _required_str(item.get("to"), f"network[{index}].to")
+
+
+def _plan_policy_grant(
+    *,
+    document: dict[str, Any],
+    capability_id: str,
+    policy: dict[str, Any],
+    actions: list[EnablementAction],
+) -> bool:
+    grant = document.get("grant")
+    if grant is None:
+        return False
+    binding_id = _required_str(grant.get("binding"), "grant.binding")
+    binding = _find_policy_binding(policy, binding_id)
+    capabilities = _required_mapping(binding.get("capabilities"), "binding.capabilities")
+    allowed = _required_list(capabilities.get("allow"), "binding.capabilities.allow")
+    if capability_id in allowed:
+        actions.append(
+            EnablementAction(
+                code="policy_grant_present",
+                message=f"`{binding_id}` already grants `{capability_id}`.",
+                path="data.policy.prod.yaml",
+            )
+        )
+        return False
+    allowed.append(capability_id)
+    actions.append(
+        EnablementAction(
+            code="policy_grant_added",
+            message=f"Add `{capability_id}` to policy binding `{binding_id}`.",
+            path="data.policy.prod.yaml",
+        )
+    )
+    return True
+
+
+def _plan_model_lease(
+    *,
+    document: dict[str, Any],
+    capability_id: str,
+    capability: dict[str, Any],
+    actions: list[EnablementAction],
+) -> bool:
+    requested = document.get("model_lease")
+    if requested is None:
+        return False
+    profile = _required_str(requested.get("allowed_profile"), "model_lease.allowed_profile")
+    lease = _required_mapping(
+        capability.get("model_lease"),
+        f"{capability_id}.model_lease",
+    )
+    current_profiles = lease.get("allowed_profiles") or []
+    if current_profiles == [profile]:
+        actions.append(
+            EnablementAction(
+                code="model_profile_present",
+                message=f"`{capability_id}` already allows exactly `{profile}`.",
+                path="data.workload_imports.yaml",
+            )
+        )
+        return False
+    lease["allowed_profiles"] = [profile]
+    actions.append(
+        EnablementAction(
+            code="model_profile_set",
+            message=f"Set `{capability_id}` allowed model profile to `{profile}`.",
+            path="data.workload_imports.yaml",
+        )
+    )
+    return True
+
+
+def _plan_worker_claims(
+    *,
+    document: dict[str, Any],
+    workload_id: str,
+    capability_id: str,
+    values: dict[str, Any],
+    actions: list[EnablementAction],
+) -> bool:
+    worker = document.get("worker")
+    if worker is None or worker.get("claims") is not True:
+        return False
+    env_path = WORKER_CAPABILITY_ENV_PATHS.get(workload_id)
+    if env_path is None:
+        raise WorkloadEnablementError(
+            f"worker claim-list path is unknown for workload {workload_id!r}"
+        )
+    current = _get_nested(values, list(env_path))
+    if not isinstance(current, str):
+        raise WorkloadEnablementError(
+            f"worker capability env is missing or not scalar for workload {workload_id!r}"
+        )
+    capabilities = [item.strip() for item in current.split(",") if item.strip()]
+    if capability_id in capabilities:
+        actions.append(
+            EnablementAction(
+                code="worker_claim_present",
+                message=f"`{workload_id}` already claims `{capability_id}`.",
+                path=str(AGENT_WORKLOADS_VALUES_PATH),
+            )
+        )
+        return False
+    capabilities.append(capability_id)
+    _set_nested(values, list(env_path), ",".join(sorted(capabilities)))
+    actions.append(
+        EnablementAction(
+            code="worker_claim_added",
+            message=f"Add `{capability_id}` to `{workload_id}` worker claim list.",
+            path=str(AGENT_WORKLOADS_VALUES_PATH),
+        )
+    )
+    return True
+
+
+def _plan_secret_references(
+    *,
+    repo_root: Path,
+    document: dict[str, Any],
+    values: dict[str, Any],
+    actions: list[EnablementAction],
+    gaps: list[EnablementAction],
+) -> None:
+    secret_items = document.get("secrets") or []
+    if not secret_items:
+        return
+    known_key_refs = set(str(key) for key in values.get("secretKeys") or [])
+    runtime_secret_path = repo_root / AGENT_WORKLOADS_RUNTIME_SECRET_PATH
+    runtime_secret_text = runtime_secret_path.read_text(encoding="utf-8")
+    for item in secret_items:
+        key = _required_str(item.get("key"), "secret.key")
+        if key in known_key_refs:
+            actions.append(
+                EnablementAction(
+                    code="secret_key_ref_present",
+                    message=f"`{key}` is referenced by agent-workloads values.",
+                    path=str(AGENT_WORKLOADS_VALUES_PATH),
+                )
+            )
+        else:
+            gaps.append(
+                EnablementAction(
+                    code="secret_key_ref_missing",
+                    message=(
+                        f"`{key}` is not in agent-workloads secretKeys; add the key "
+                        "reference without adding any secret value."
+                    ),
+                    path=str(AGENT_WORKLOADS_VALUES_PATH),
+                )
+            )
+        if f"{key}:" in runtime_secret_text:
+            actions.append(
+                EnablementAction(
+                    code="sops_secret_key_present",
+                    message=f"`{key}` exists in the encrypted runtime Secret.",
+                    path=str(AGENT_WORKLOADS_RUNTIME_SECRET_PATH),
+                )
+            )
+        else:
+            gaps.append(
+                EnablementAction(
+                    code="sops_secret_key_missing",
+                    message=(
+                        f"`{key}` is absent from the encrypted runtime Secret; "
+                        "operator must add it through SOPS. The apply tool does not "
+                        "read or write secret values."
+                    ),
+                    path=str(AGENT_WORKLOADS_RUNTIME_SECRET_PATH),
+                )
+            )
+
+
+def _plan_network_requests(
+    *,
+    document: dict[str, Any],
+    gaps: list[EnablementAction],
+) -> None:
+    for request in document.get("network") or []:
+        target = _required_str(request.get("to"), "network.to")
+        gaps.append(
+            EnablementAction(
+                code="network_mapping_review_required",
+                message=(
+                    f"`{target}` requires operator review against the Helm "
+                    "NetworkPolicy CIDR/selector model before it can be edited."
+                ),
+                path=str(AGENT_WORKLOADS_VALUES_PATH),
+            )
+        )
+
+
+def _find_imported_capability(
+    *,
+    workload_imports: dict[str, Any],
+    workload_id: str,
+    capability_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    imports = _required_list(workload_imports.get("imports"), "workload imports")
+    for raw_entry in imports:
+        entry = _required_mapping(raw_entry, "workload import")
+        if entry.get("id") != workload_id:
+            continue
+        capabilities = _required_mapping(entry.get("capabilities"), "capabilities")
+        capability = capabilities.get(capability_id)
+        if isinstance(capability, dict):
+            return entry, capability
+        raise WorkloadEnablementError(
+            f"workload {workload_id!r} does not declare capability {capability_id!r}"
+        )
+    raise WorkloadEnablementError(f"workload import not found: {workload_id}")
+
+
+def _find_policy_binding(policy: dict[str, Any], binding_id: str) -> dict[str, Any]:
+    for binding in _required_list(policy.get("bindings"), "policy.bindings"):
+        item = _required_mapping(binding, "policy binding")
+        if item.get("id") == binding_id:
+            return item
+    raise WorkloadEnablementError(f"policy binding not found: {binding_id}")
+
+
+def _require_deployment_owned(
+    ownership: dict[str, Any],
+    capability_id: str,
+    root_key: str,
+) -> None:
+    capabilities = _required_mapping(
+        ownership.get("capabilities"),
+        "ownership.capabilities",
+    )
+    capability = _required_mapping(
+        capabilities.get(capability_id),
+        f"ownership.capabilities.{capability_id}",
+    )
+    keys = _required_mapping(capability.get("keys"), f"{capability_id}.keys")
+    info = keys.get(root_key)
+    if info is None:
+        return
+    info_map = _required_mapping(info, f"{capability_id}.keys.{root_key}")
+    owner = info_map.get("owner")
+    if owner not in {"deployment_overlay", "mixed"}:
+        raise WorkloadEnablementError(
+            f"{capability_id}.{root_key} is {owner}-owned; edit the workload release "
+            "instead because that moves digests and requires re-minting"
+        )
+
+
+def _reject_unknown_keys(
+    payload: dict[str, Any],
+    allowed: set[str],
+    label: str,
+) -> None:
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        rendered = ", ".join(unknown)
+        raise WorkloadEnablementError(f"{label} contains unsupported keys: {rendered}")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_SAFE.load(path.read_text(encoding="utf-8"))
+    return _required_mapping(loaded, str(path))
+
+
+def _load_yaml_rt(path: Path) -> dict[str, Any]:
+    loaded = YAML_RT.load(path.read_text(encoding="utf-8"))
+    return _required_mapping(loaded, str(path))
+
+
+def _load_yaml_text_rt(raw: str) -> dict[str, Any]:
+    loaded = YAML_RT.load(raw)
+    return _required_mapping(loaded, "YAML text")
+
+
+def _dump_yaml(payload: Any) -> str:
+    stream = StringIO()
+    YAML_RT.dump(payload, stream)
+    return stream.getvalue()
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(_dump_yaml(payload), encoding="utf-8")
+
+
+def _get_nested(root: dict[str, Any], parts: list[str]) -> Any:
+    current: Any = root
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _set_nested(root: dict[str, Any], parts: list[str], value: Any) -> None:
+    current = root
+    for part in parts[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            raise WorkloadEnablementError(f"cannot descend into scalar key {part!r}")
+        current = child
+    current[parts[-1]] = value
+
+
+def _required_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise WorkloadEnablementError(f"YAML mapping expected: {label}")
+    return value
+
+
+def _required_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise WorkloadEnablementError(f"YAML list expected: {label}")
+    return value
+
+
+def _required_str(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise WorkloadEnablementError(f"non-empty string expected: {label}")
+    return value

--- a/tests/test_workload_enablement.py
+++ b/tests/test_workload_enablement.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from scripts.grant_ownership import (
+    CONFIGMAP_PATH,
+    OWNERSHIP_DOC_PATH,
+    OWNERSHIP_MAP_PATH,
+    OWNERSHIP_SOURCE_PATH,
+)
+from scripts.workload_enablement import (
+    AGENT_WORKLOADS_RUNTIME_SECRET_PATH,
+    AGENT_WORKLOADS_VALUES_PATH,
+    WorkloadEnablementError,
+    apply_workload_enablement,
+    plan_workload_enablement,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+YAML_WRITER = YAML()
+
+
+class WorkloadEnablementTests(unittest.TestCase):
+    def test_existing_readonly_query_enablement_plans_no_changes(self) -> None:
+        root = _fixture_repo()
+        document = _write_enablement(
+            root,
+            {
+                "schema_version": "mandate-workload-enablement.v1",
+                "kind": "MandateWorkloadEnablement",
+                "workload": "data.workspace_probe",
+                "capability": "agent_workloads.readonly_query",
+                "grant": {"binding": "private-admin-controlled-capabilities"},
+                "model_lease": {
+                    "allowed_profile": "openai.gpt-5.3-codex-spark",
+                },
+                "worker": {"claims": True},
+                "secrets": [{"key": "XSCRAPER_READONLY_DATABASE_URL"}],
+            },
+        )
+
+        result = plan_workload_enablement(repo_root=root, document_path=document)
+
+        self.assertEqual(result.changed_files, ())
+        self.assertFalse(result.gaps)
+        self.assertIn("policy_grant_present", _codes(result.actions))
+        self.assertIn("model_profile_present", _codes(result.actions))
+        self.assertIn("worker_claim_present", _codes(result.actions))
+        self.assertIn("secret_key_ref_present", _codes(result.actions))
+        self.assertIn("sops_secret_key_present", _codes(result.actions))
+
+    def test_write_adds_policy_grant_and_worker_claim_only(self) -> None:
+        root = _fixture_repo()
+        _remove_policy_grant(root, "agent_workloads.readonly_query")
+        _set_worker_capabilities(root, "data.workspace_probe", ["agent_workloads.db_probe"])
+        document = _write_enablement(
+            root,
+            {
+                "schema_version": "mandate-workload-enablement.v1",
+                "kind": "MandateWorkloadEnablement",
+                "workload": "data.workspace_probe",
+                "capability": "agent_workloads.readonly_query",
+                "grant": {"binding": "private-admin-controlled-capabilities"},
+                "worker": {"claims": True},
+            },
+        )
+
+        result = apply_workload_enablement(
+            repo_root=root,
+            document_path=document,
+            write=True,
+            pr_body_path=root / "mandate-apply-pr.md",
+        )
+
+        self.assertEqual(
+            result.changed_files,
+            (
+                "apps/agent-control-plane-registry-overlay/configmap.yaml",
+                "apps/agent-workloads/values.yaml",
+            ),
+        )
+        self.assertIn("policy_grant_added", _codes(result.actions))
+        self.assertIn("worker_claim_added", _codes(result.actions))
+        self.assertIn(
+            "agent_workloads.readonly_query",
+            _policy_allow(root, "private-admin-controlled-capabilities"),
+        )
+        self.assertEqual(
+            _worker_capabilities(root, "data.workspace_probe"),
+            ["agent_workloads.db_probe", "agent_workloads.readonly_query"],
+        )
+        secret_text = (root / AGENT_WORKLOADS_RUNTIME_SECRET_PATH).read_text()
+        self.assertIn("ENC[AES256_GCM", secret_text)
+        body = (root / "mandate-apply-pr.md").read_text()
+        self.assertIn("No live ConfigMap, Secret, or Kubernetes object is mutated.", body)
+        self.assertIn("Secret values are never read or written", body)
+
+    def test_missing_secret_is_named_as_operator_sops_gap(self) -> None:
+        root = _fixture_repo()
+        document = _write_enablement(
+            root,
+            {
+                "schema_version": "mandate-workload-enablement.v1",
+                "kind": "MandateWorkloadEnablement",
+                "workload": "data.workspace_probe",
+                "capability": "agent_workloads.readonly_query",
+                "secrets": [{"key": "MISSING_READONLY_DATABASE_URL"}],
+            },
+        )
+
+        result = plan_workload_enablement(repo_root=root, document_path=document)
+
+        self.assertIn("secret_key_ref_missing", _codes(result.gaps))
+        self.assertIn("sops_secret_key_missing", _codes(result.gaps))
+        self.assertFalse(result.changed_files)
+
+    def test_forbidden_grant_user_edit_fails_closed(self) -> None:
+        root = _fixture_repo()
+        document = _write_enablement(
+            root,
+            {
+                "schema_version": "mandate-workload-enablement.v1",
+                "kind": "MandateWorkloadEnablement",
+                "workload": "data.workspace_probe",
+                "capability": "agent_workloads.readonly_query",
+                "grant": {
+                    "binding": "private-admin-controlled-capabilities",
+                    "users": ["94265880216612864"],
+                },
+            },
+        )
+
+        with self.assertRaisesRegex(
+            WorkloadEnablementError,
+            "grant contains unsupported keys: users",
+        ):
+            plan_workload_enablement(repo_root=root, document_path=document)
+
+    def test_multiple_model_profiles_fail_closed(self) -> None:
+        root = _fixture_repo()
+        document = _write_enablement(
+            root,
+            {
+                "schema_version": "mandate-workload-enablement.v1",
+                "kind": "MandateWorkloadEnablement",
+                "workload": "data.workspace_probe",
+                "capability": "agent_workloads.readonly_query",
+                "model_lease": {
+                    "allowed_profiles": [
+                        "openai.gpt-5.3-codex-spark",
+                        "openai.gpt-5.3-codex-large",
+                    ],
+                },
+            },
+        )
+
+        with self.assertRaisesRegex(
+            WorkloadEnablementError,
+            "model_lease contains unsupported keys: allowed_profiles",
+        ):
+            plan_workload_enablement(repo_root=root, document_path=document)
+
+
+def _fixture_repo() -> Path:
+    root = Path(tempfile.mkdtemp())
+    for path in [
+        CONFIGMAP_PATH,
+        OWNERSHIP_SOURCE_PATH,
+        OWNERSHIP_MAP_PATH,
+        OWNERSHIP_DOC_PATH,
+        AGENT_WORKLOADS_VALUES_PATH,
+        AGENT_WORKLOADS_RUNTIME_SECRET_PATH,
+    ]:
+        source = REPO_ROOT / path
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+    return root
+
+
+def _write_enablement(root: Path, payload: dict[str, Any]) -> Path:
+    path = root / "enablement.yaml"
+    with path.open("w", encoding="utf-8") as handle:
+        YAML_WRITER.dump(payload, handle)
+    return path
+
+
+def _remove_policy_grant(root: Path, capability_id: str) -> None:
+    configmap = _load_configmap(root)
+    policy = YAML_PARSER.load(configmap["data"]["policy.prod.yaml"])
+    allow = _policy_allow_from_payload(policy, "private-admin-controlled-capabilities")
+    allow.remove(capability_id)
+    configmap["data"]["policy.prod.yaml"] = _yaml_text(policy)
+    _write_yaml(root / CONFIGMAP_PATH, configmap)
+
+
+def _policy_allow(root: Path, binding_id: str) -> list[str]:
+    configmap = _load_configmap(root)
+    policy = YAML_PARSER.load(configmap["data"]["policy.prod.yaml"])
+    return _policy_allow_from_payload(policy, binding_id)
+
+
+def _policy_allow_from_payload(policy: dict[str, Any], binding_id: str) -> list[str]:
+    for binding in policy["bindings"]:
+        if binding["id"] == binding_id:
+            return binding["capabilities"]["allow"]
+    raise AssertionError(f"binding not found: {binding_id}")
+
+
+def _set_worker_capabilities(
+    root: Path,
+    workload_id: str,
+    capabilities: list[str],
+) -> None:
+    values = _load_values(root)
+    env = _worker_env(values, workload_id)
+    env["AGENT_WORKLOADS_WORKER_CAPABILITIES"] = ",".join(capabilities)
+    _write_yaml(root / AGENT_WORKLOADS_VALUES_PATH, values)
+
+
+def _worker_capabilities(root: Path, workload_id: str) -> list[str]:
+    values = _load_values(root)
+    raw = _worker_env(values, workload_id)["AGENT_WORKLOADS_WORKER_CAPABILITIES"]
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _worker_env(values: dict[str, Any], workload_id: str) -> dict[str, Any]:
+    if workload_id == "data.workspace_probe":
+        return values["env"]
+    if workload_id == "opencode.proposer":
+        return values["opencodeProposer"]["env"]
+    if workload_id == "opencode.apply_executor":
+        return values["opencodeApplyExecutor"]["env"]
+    raise AssertionError(f"unknown worker fixture: {workload_id}")
+
+
+def _load_configmap(root: Path) -> dict[str, Any]:
+    return YAML_PARSER.load((root / CONFIGMAP_PATH).read_text())
+
+
+def _load_values(root: Path) -> dict[str, Any]:
+    return YAML_PARSER.load((root / AGENT_WORKLOADS_VALUES_PATH).read_text())
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        YAML_WRITER.dump(payload, handle)
+
+
+def _yaml_text(payload: dict[str, Any]) -> str:
+    stream = StringIO()
+    YAML_WRITER.dump(payload, stream)
+    return stream.getvalue()
+
+
+def _codes(actions: tuple[Any, ...]) -> set[str]:
+    return {action.code for action in actions}


### PR DESCRIPTION
## Summary
- adds `scripts/mandate_apply.py` and `scripts/workload_enablement.py` for local `MandateWorkloadEnablement` planning
- supports dry-run by default and explicit `--write` for deployment-owned PR edits
- can reconcile existing policy binding grants, one allowed model profile, and known worker claim-list entries
- reports SOPS secret-key and NetworkPolicy work as operator gaps instead of touching secret values or hostname-to-CIDR authority
- documents the v0 surface in `docs/mandate-apply.md`

## Authority invariants preserved
- import is not dispatch: the enablement document is planning input only
- packs/manifests are not authority: this only edits deployment-owned overlay/values when explicitly requested
- admission still validates dispatch after merge through the normal registry overlay and control-plane restart path
- leases/brokers/output gates remain authoritative; no runtime path changes
- no ambient credentials introduced; secret values are never read or written
- no model/task params become authority; unsupported grant users, multiple model profiles, and unknown fields fail closed

## Tests
- Happy path:
  - current `agent_workloads.readonly_query` enablement plans as already present with no file changes
  - `--write` path adds a missing policy grant and worker claim-list entry only
- Fail closed / gaps:
  - missing secret key reference and missing SOPS key are named as operator gaps
  - `grant.users` is rejected
  - multiple `model_lease.allowed_profiles` are rejected
- Validation:
  - `uv run python -m unittest discover -s tests` passed: 40 tests
  - `uv run python scripts/generate_grant_ownership.py --check` passed
  - `uv run python scripts/check_control_plane_release_pin.py` passed
  - `uv run python -m compileall -q scripts tests` passed
  - `git diff --check` passed

## Docs
- adds `docs/mandate-apply.md`
- updates `docs/README.md` and `scripts/README.md`

## Deferred
- PR creation/push automation for `mandate_apply.py`
- automatic NetworkPolicy CIDR/selector edits from hostname requests
- SOPS secret-value writes
- release-owned workload edits, repins, or re-mints
- end-to-end merge-to-live automation

## Security review notes
This is a local planning/editing tool for GitOps state, not a runtime mutation path. It refuses actor/user authority edits, refuses multi-profile model authority in v0, and treats secrets/network requests as reviewable gaps unless they can be validated without reading secret values or inventing network authority.