### PR TITLE
CES-124 Slice 1: keep Mandate deployment gates local

### DIFF
--- a/.github/actions/agent-control-plane-registry-compat-gate/README.md
+++ b/.github/actions/agent-control-plane-registry-compat-gate/README.md
@@ -1,0 +1,24 @@
+# Agent Control Plane Registry Compatibility Gate
+
+Local CI gate for this deployment repository. It reads the deployment-pinned
+`agent-platform` revision, fetches a broker-scoped read token, checks out that
+exact revision, and runs the repo-local compatibility validator against the
+pull request config.
+
+## Threat Model
+
+This protects against merging deployment registry overlays that are incompatible
+with the actually deployed Mandate control-plane revision. This repo still owns
+the pin and the overlay; the action only materializes the deployed source and
+runs the repo-local validator.
+
+It does not grant dispatch, import manifests, approve capabilities, deploy the
+control plane, or decide whether an overlay is operationally desirable. A
+passing compatibility check is only one required input to normal review, policy,
+admission, lease, broker, and output-gate paths.
+
+The action must never receive repository secrets, provider credentials,
+database credentials, deployment tokens, or raw vault access as inputs. It uses
+GitHub OIDC to request only the `mandate-contracts-read` capability from the
+credential broker. The consuming job grants `id-token: write` and otherwise
+keeps `contents: read`.

--- a/.github/actions/agent-control-plane-registry-compat-gate/action.yml
+++ b/.github/actions/agent-control-plane-registry-compat-gate/action.yml
@@ -1,0 +1,144 @@
+name: Agent control-plane deployed registry compatibility gate
+description: Validate config repo registry overlays against the pinned deployed agent-platform revision.
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install config repo dependencies
+      shell: bash
+      run: uv sync
+
+    - name: Read pinned agent-platform revision
+      id: mandate-revision
+      shell: bash
+      run: |
+        set -euo pipefail
+        revision="$(uv run python scripts/check_agent_control_plane_registry_compat.py --print-target-revision)"
+        [[ -n "$revision" ]] || { echo "::error::target revision command returned empty output" >&2; exit 1; }
+        echo "revision=${revision}" >> "$GITHUB_OUTPUT"
+
+    - name: Fetch Mandate read token
+      id: broker
+      shell: bash
+      env:
+        BROKER_URL: https://credentials.garz.ai
+        BROKER_AUDIENCE: https://credentials.garz.ai/v1
+        BROKER_CAPABILITY: mandate-contracts-read
+      run: |
+        set -euo pipefail
+
+        die() {
+          echo "::error::$*" >&2
+          exit 1
+        }
+
+        need() {
+          command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+        }
+
+        mask_value() {
+          local value="$1"
+          [[ -n "$value" ]] || return 0
+
+          value="${value//'%'/'%25'}"
+          value="${value//$'\r'/'%0D'}"
+          value="${value//$'\n'/'%0A'}"
+          printf '::add-mask::%s\n' "$value"
+        }
+
+        random_delim() {
+          if command -v uuidgen >/dev/null 2>&1; then
+            printf 'BROKER_%s' "$(uuidgen | tr '[:lower:]' '[:upper:]')"
+          else
+            printf 'BROKER_%s' "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+          fi
+        }
+
+        write_multiline_file() {
+          local file="$1"
+          local name="$2"
+          local value="$3"
+          local delim
+
+          while :; do
+            delim="$(random_delim)"
+            if ! grep -qxF "$delim" <<< "$value"; then
+              break
+            fi
+          done
+
+          {
+            printf '%s<<%s\n' "$name" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$file"
+        }
+
+        need curl
+        need jq
+
+        [[ "$BROKER_URL" == https://* ]] || die "broker-url must use https://"
+        [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] ||
+          die "ACTIONS_ID_TOKEN_REQUEST_URL is not set. Did the job grant permissions: id-token: write?"
+        [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] ||
+          die "ACTIONS_ID_TOKEN_REQUEST_TOKEN is not set. Did the job grant permissions: id-token: write?"
+
+        audience_q="$(jq -rn --arg value "$BROKER_AUDIENCE" '$value | @uri')"
+        token_json="$(
+          curl --silent --show-error --fail-with-body \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience_q}"
+        )"
+        oidc_token="$(jq -er '.value | select(type == "string" and length > 0)' <<< "$token_json")" ||
+          die "GitHub OIDC token response did not include a token"
+        mask_value "$oidc_token"
+
+        request_body="$(jq -nc --arg capability "$BROKER_CAPABILITY" '{capabilities: [$capability]}')"
+        response="$(
+          curl --silent --show-error --fail-with-body \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            -X POST \
+            -H "Authorization: Bearer $oidc_token" \
+            -H "Content-Type: application/json" \
+            --data-binary "$request_body" \
+            "${BROKER_URL%/}/v1/capabilities"
+        )"
+
+        jq -e --arg capability "$BROKER_CAPABILITY" '
+          .capabilities == [$capability]
+          and (.secrets | type == "object")
+          and ((.secrets | keys) == ["MANDATE_CONTRACTS_READ_TOKEN"])
+          and (.secrets.MANDATE_CONTRACTS_READ_TOKEN | type == "string" and length > 0)
+        ' <<< "$response" >/dev/null ||
+          die "Broker response must contain exactly MANDATE_CONTRACTS_READ_TOKEN for the requested capability"
+
+        token="$(jq -r '.secrets.MANDATE_CONTRACTS_READ_TOKEN' <<< "$response")"
+        mask_value "$token"
+        write_multiline_file "$GITHUB_OUTPUT" "token" "$token"
+
+    - name: Check out pinned agent-platform source
+      uses: actions/checkout@v4
+      with:
+        repository: cesaregarza/agent-platform
+        ref: ${{ steps.mandate-revision.outputs.revision }}
+        path: agent-platform
+        token: ${{ steps.broker.outputs.token }}
+
+    - name: Install pinned agent-platform
+      shell: bash
+      run: uv pip install -e agent-platform
+
+    - name: Check deployed registry compatibility
+      shell: bash
+      run: uv run python scripts/check_agent_control_plane_registry_compat.py --agent-platform-repo agent-platform

--- a/.github/actions/agent-workloads-identity-digest-drift-gate/README.md
+++ b/.github/actions/agent-workloads-identity-digest-drift-gate/README.md
@@ -1,0 +1,24 @@
+# Agent Workloads Identity Digest Drift Gate
+
+Local CI gate for this deployment repository. It fetches the scoped SOPS
+drift-gate key from the credential broker, decrypts only the workload identity
+token secret, and runs the repo-local check that compares token `code_digest`
+claims to deployed release pins.
+
+## Threat Model
+
+This protects against deployment config that updates workload image or manifest
+pins without re-minting the matching workload identity tokens. The brokered Age
+key is scoped to the workload identity token secret and is exposed only to this
+job.
+
+It does not mint tokens, decide which workload digest is correct, approve a
+deployment, grant dispatch, or validate runtime behavior. This repo still owns
+its release pins, SOPS policy, branch protection, and required-check
+configuration.
+
+The action must never receive repository secrets, workload identity HMAC seeds,
+provider credentials, database credentials, or raw SOPS keys as inputs. It uses
+GitHub OIDC to request only the `sops-drift-gate-decrypt` capability from the
+credential broker. The consuming job grants `id-token: write` and otherwise
+keeps `contents: read`.

--- a/.github/actions/agent-workloads-identity-digest-drift-gate/action.yml
+++ b/.github/actions/agent-workloads-identity-digest-drift-gate/action.yml
@@ -1,0 +1,140 @@
+name: Agent workloads identity digest drift gate
+description: Verify agent-workloads release pins match broker-scoped workload identity token claims.
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      shell: bash
+      run: uv sync
+
+    - name: Install sops
+      shell: bash
+      env:
+        SOPS_VERSION: "3.9.4"
+      run: |
+        set -euo pipefail
+
+        curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+          --output /tmp/sops \
+          "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+        sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+        sops --version
+
+    - name: Fetch scoped SOPS age key
+      shell: bash
+      env:
+        BROKER_URL: https://credentials.garz.ai
+        BROKER_AUDIENCE: https://credentials.garz.ai/v1
+        BROKER_CAPABILITY: sops-drift-gate-decrypt
+      run: |
+        set -euo pipefail
+
+        die() {
+          echo "::error::$*" >&2
+          exit 1
+        }
+
+        need() {
+          command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+        }
+
+        mask_value() {
+          local value="$1"
+          [[ -n "$value" ]] || return 0
+
+          value="${value//'%'/'%25'}"
+          value="${value//$'\r'/'%0D'}"
+          value="${value//$'\n'/'%0A'}"
+          printf '::add-mask::%s\n' "$value"
+        }
+
+        random_delim() {
+          if command -v uuidgen >/dev/null 2>&1; then
+            printf 'BROKER_%s' "$(uuidgen | tr '[:lower:]' '[:upper:]')"
+          else
+            printf 'BROKER_%s' "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+          fi
+        }
+
+        write_multiline_file() {
+          local file="$1"
+          local name="$2"
+          local value="$3"
+          local delim
+
+          while :; do
+            delim="$(random_delim)"
+            if ! grep -qxF "$delim" <<< "$value"; then
+              break
+            fi
+          done
+
+          {
+            printf '%s<<%s\n' "$name" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$file"
+        }
+
+        need curl
+        need jq
+
+        [[ "$BROKER_URL" == https://* ]] || die "broker-url must use https://"
+        [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] ||
+          die "ACTIONS_ID_TOKEN_REQUEST_URL is not set. Did the job grant permissions: id-token: write?"
+        [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] ||
+          die "ACTIONS_ID_TOKEN_REQUEST_TOKEN is not set. Did the job grant permissions: id-token: write?"
+
+        audience_q="$(jq -rn --arg value "$BROKER_AUDIENCE" '$value | @uri')"
+        token_json="$(
+          curl --silent --show-error --fail-with-body \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience_q}"
+        )"
+        oidc_token="$(jq -er '.value | select(type == "string" and length > 0)' <<< "$token_json")" ||
+          die "GitHub OIDC token response did not include a token"
+        mask_value "$oidc_token"
+
+        request_body="$(jq -nc --arg capability "$BROKER_CAPABILITY" '{capabilities: [$capability]}')"
+        response="$(
+          curl --silent --show-error --fail-with-body \
+            --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-all-errors \
+            -X POST \
+            -H "Authorization: Bearer $oidc_token" \
+            -H "Content-Type: application/json" \
+            --data-binary "$request_body" \
+            "${BROKER_URL%/}/v1/capabilities"
+        )"
+
+        jq -e --arg capability "$BROKER_CAPABILITY" '
+          .capabilities == [$capability]
+          and (.secrets | type == "object")
+          and ((.secrets | keys) == ["SOPS_DRIFT_GATE_AGE_KEY"])
+          and (.secrets.SOPS_DRIFT_GATE_AGE_KEY | type == "string" and length > 0)
+        ' <<< "$response" >/dev/null ||
+          die "Broker response must contain exactly SOPS_DRIFT_GATE_AGE_KEY for the requested capability"
+
+        sops_age_key="$(jq -r '.secrets.SOPS_DRIFT_GATE_AGE_KEY' <<< "$response")"
+        mask_value "$sops_age_key"
+        write_multiline_file "$GITHUB_ENV" "SOPS_DRIFT_GATE_AGE_KEY" "$sops_age_key"
+
+    - name: Check identity digest drift
+      shell: bash
+      run: |
+        set -euo pipefail
+        [[ -n "${SOPS_DRIFT_GATE_AGE_KEY:-}" ]] ||
+          { echo "::error::SOPS drift gate age key was not fetched" >&2; exit 1; }
+        export SOPS_AGE_KEY="$SOPS_DRIFT_GATE_AGE_KEY"
+        uv run python scripts/check_agent_workloads_identity_digests.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check agent-workloads identity digest drift
-        uses: cesaregarza/.github/actions/agent-workloads-identity-digest-drift-gate@a1d2fb4a6b288066574b1ac53074ac62e920a07f
+        uses: ./.github/actions/agent-workloads-identity-digest-drift-gate
 
   agent-control-plane-deployed-registry-compat:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check deployed registry compatibility
-        uses: cesaregarza/.github/actions/agent-control-plane-registry-compat-gate@a1d2fb4a6b288066574b1ac53074ac62e920a07f
+        uses: ./.github/actions/agent-control-plane-registry-compat-gate
 
   helm-and-kubeconform:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,39 +45,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: uv sync
-
-      - name: Install sops
-        run: |
-          set -euo pipefail
-          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
-            --output /tmp/sops \
-            https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
-          sudo install -m 0755 /tmp/sops /usr/local/bin/sops
-          sops --version
-
-      - name: Fetch drift-gate SOPS age key
-        id: drift-gate-broker
-        uses: cesaregarza/.github/actions/fetch-broker-credentials@main
-        with:
-          broker-url: https://credentials.garz.ai
-          audience: https://credentials.garz.ai/v1
-          capability: sops-drift-gate-decrypt
-          export-env: true
-
       - name: Check agent-workloads identity digest drift
-        env:
-          SOPS_AGE_KEY: ${{ env.SOPS_DRIFT_GATE_AGE_KEY }}
-        run: uv run python scripts/check_agent_workloads_identity_digests.py
+        uses: cesaregarza/.github/actions/agent-workloads-identity-digest-drift-gate@a1d2fb4a6b288066574b1ac53074ac62e920a07f
 
   agent-control-plane-deployed-registry-compat:
     runs-on: ubuntu-latest
@@ -88,47 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install config repo dependencies
-        run: uv sync
-
-      - name: Read pinned agent-platform revision
-        id: mandate-revision
-        run: |
-          set -euo pipefail
-          revision="$(uv run python scripts/check_agent_control_plane_registry_compat.py --print-target-revision)"
-          echo "revision=${revision}" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch Mandate read token
-        id: broker
-        uses: cesaregarza/.github/actions/fetch-broker-credentials@main
-        with:
-          broker-url: https://credentials.garz.ai
-          audience: https://credentials.garz.ai/v1
-          capability: mandate-contracts-read
-
-      - name: Check out pinned agent-platform source
-        uses: actions/checkout@v4
-        with:
-          repository: cesaregarza/agent-platform
-          ref: ${{ steps.mandate-revision.outputs.revision }}
-          path: agent-platform
-          token: ${{ fromJson(steps.broker.outputs.secrets-json).MANDATE_CONTRACTS_READ_TOKEN }}
-
-      - name: Install pinned agent-platform
-        run: uv pip install -e agent-platform
-
       - name: Check deployed registry compatibility
-        run: >-
-          uv run python scripts/check_agent_control_plane_registry_compat.py
-          --agent-platform-repo agent-platform
+        uses: cesaregarza/.github/actions/agent-control-plane-registry-compat-gate@a1d2fb4a6b288066574b1ac53074ac62e920a07f
 
   helm-and-kubeconform:
     runs-on: ubuntu-latest

--- a/tests/test_agent_control_plane_registry_compat.py
+++ b/tests/test_agent_control_plane_registry_compat.py
@@ -15,9 +15,43 @@ from ruamel.yaml import YAML
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "check_agent_control_plane_registry_compat.py"
 YAML_PARSER = YAML()
+SHARED_ACTION_PIN = "a1d2fb4a6b288066574b1ac53074ac62e920a07f"
+OLD_MUTABLE_BROKER_ACTION = (
+    "cesaregarza/.github/actions/" "fetch-broker-credentials" "@main"
+)
 
 
 class AgentControlPlaneRegistryCompatTests(unittest.TestCase):
+    def test_ci_compat_gate_uses_pinned_shared_action_not_mutable_broker_action(
+        self,
+    ) -> None:
+        workflow_path = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+        workflow = YAML_PARSER.load(workflow_path.read_text())
+        workflow_text = workflow_path.read_text()
+        job = workflow["jobs"]["agent-control-plane-deployed-registry-compat"]
+
+        self.assertNotIn(
+            OLD_MUTABLE_BROKER_ACTION,
+            workflow_text,
+        )
+        self.assertEqual(job["permissions"]["contents"], "read")
+        self.assertEqual(job["permissions"]["id-token"], "write")
+
+        check_step = next(
+            step
+            for step in job["steps"]
+            if step.get("uses", "").startswith(
+                "cesaregarza/.github/actions/"
+                "agent-control-plane-registry-compat-gate@"
+            )
+        )
+        self.assertEqual(
+            check_step["uses"],
+            "cesaregarza/.github/actions/"
+            f"agent-control-plane-registry-compat-gate@{SHARED_ACTION_PIN}",
+        )
+        self.assertNotIn("@main", check_step["uses"])
+
     def test_missing_per_user_daily_tokens_fails_against_old_pin_and_passes_after_bump(
         self,
     ) -> None:

--- a/tests/test_agent_control_plane_registry_compat.py
+++ b/tests/test_agent_control_plane_registry_compat.py
@@ -15,14 +15,24 @@ from ruamel.yaml import YAML
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "check_agent_control_plane_registry_compat.py"
 YAML_PARSER = YAML()
-SHARED_ACTION_PIN = "a1d2fb4a6b288066574b1ac53074ac62e920a07f"
 OLD_MUTABLE_BROKER_ACTION = (
-    "cesaregarza/.github/actions/" "fetch-broker-credentials" "@main"
+    "cesaregarza/"
+    ".github/actions/"
+    "fetch-broker-credentials"
+    "@main"
+)
+SHARED_ACTION_REPO = "cesaregarza/" ".github/actions/"
+LOCAL_COMPAT_GATE_ACTION = (
+    REPO_ROOT
+    / ".github"
+    / "actions"
+    / "agent-control-plane-registry-compat-gate"
+    / "action.yml"
 )
 
 
 class AgentControlPlaneRegistryCompatTests(unittest.TestCase):
-    def test_ci_compat_gate_uses_pinned_shared_action_not_mutable_broker_action(
+    def test_ci_compat_gate_uses_local_action_not_mutable_broker_action(
         self,
     ) -> None:
         workflow_path = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
@@ -34,6 +44,7 @@ class AgentControlPlaneRegistryCompatTests(unittest.TestCase):
             OLD_MUTABLE_BROKER_ACTION,
             workflow_text,
         )
+        self.assertNotIn(SHARED_ACTION_REPO, workflow_text)
         self.assertEqual(job["permissions"]["contents"], "read")
         self.assertEqual(job["permissions"]["id-token"], "write")
 
@@ -41,16 +52,27 @@ class AgentControlPlaneRegistryCompatTests(unittest.TestCase):
             step
             for step in job["steps"]
             if step.get("uses", "").startswith(
-                "cesaregarza/.github/actions/"
-                "agent-control-plane-registry-compat-gate@"
+                "./.github/actions/agent-control-plane-registry-compat-gate"
             )
         )
         self.assertEqual(
             check_step["uses"],
-            "cesaregarza/.github/actions/"
-            f"agent-control-plane-registry-compat-gate@{SHARED_ACTION_PIN}",
+            "./.github/actions/agent-control-plane-registry-compat-gate",
         )
         self.assertNotIn("@main", check_step["uses"])
+
+    def test_local_compat_gate_fetches_exact_brokered_read_token_shape(self) -> None:
+        action_text = LOCAL_COMPAT_GATE_ACTION.read_text(encoding="utf-8")
+
+        self.assertIn("mandate-contracts-read", action_text)
+        self.assertIn("ACTIONS_ID_TOKEN_REQUEST_URL", action_text)
+        self.assertIn(
+            '(.secrets | keys) == ["MANDATE_CONTRACTS_READ_TOKEN"]',
+            action_text,
+        )
+        self.assertIn("MANDATE_CONTRACTS_READ_TOKEN", action_text)
+        self.assertIn("repository: cesaregarza/agent-platform", action_text)
+        self.assertNotIn("secrets-" "json", action_text)
 
     def test_missing_per_user_daily_tokens_fails_against_old_pin_and_passes_after_bump(
         self,

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -50,15 +50,25 @@ TOKEN_METADATA_PATH = Path(
     "secrets/agent-workloads/workload-identity-tokens.metadata.yaml"
 )
 DIGEST_SPEC_VERSION = "agent-workloads-code-digest-v1"
-SHARED_ACTION_PIN = "a1d2fb4a6b288066574b1ac53074ac62e920a07f"
 OLD_MUTABLE_BROKER_ACTION = (
-    "cesaregarza/.github/actions/" "fetch-broker-credentials" "@main"
+    "cesaregarza/"
+    ".github/actions/"
+    "fetch-broker-credentials"
+    "@main"
+)
+SHARED_ACTION_REPO = "cesaregarza/" ".github/actions/"
+LOCAL_DRIFT_GATE_ACTION = (
+    REPO_ROOT
+    / ".github"
+    / "actions"
+    / "agent-workloads-identity-digest-drift-gate"
+    / "action.yml"
 )
 REPO_SOPS_SECRET_CONTEXT = "secrets." "SOPS_AGE_KEY"
 
 
 class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
-    def test_ci_drift_gate_uses_brokered_sops_key_not_repo_secret(self) -> None:
+    def test_ci_drift_gate_uses_local_brokered_sops_key_not_repo_secret(self) -> None:
         workflow_path = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
         workflow = YAML_PARSER.load(workflow_path.read_text())
         workflow_text = workflow_path.read_text()
@@ -66,6 +76,7 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
 
         self.assertNotIn(REPO_SOPS_SECRET_CONTEXT, workflow_text)
         self.assertNotIn(OLD_MUTABLE_BROKER_ACTION, workflow_text)
+        self.assertNotIn(SHARED_ACTION_REPO, workflow_text)
         self.assertEqual(job["permissions"]["contents"], "read")
         self.assertEqual(job["permissions"]["id-token"], "write")
 
@@ -73,19 +84,27 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
             step
             for step in job["steps"]
             if step.get("uses", "").startswith(
-                "cesaregarza/.github/actions/"
-                "agent-workloads-identity-digest-drift-gate@"
+                "./.github/actions/agent-workloads-identity-digest-drift-gate"
             )
         )
         self.assertEqual(
             check_step["uses"],
-            "cesaregarza/.github/actions/"
-            f"agent-workloads-identity-digest-drift-gate@{SHARED_ACTION_PIN}",
+            "./.github/actions/agent-workloads-identity-digest-drift-gate",
         )
         self.assertNotIn(
             "@main",
             check_step["uses"],
         )
+
+    def test_local_drift_gate_fetches_exact_brokered_sops_key_shape(self) -> None:
+        action_text = LOCAL_DRIFT_GATE_ACTION.read_text(encoding="utf-8")
+
+        self.assertIn("sops-drift-gate-decrypt", action_text)
+        self.assertIn("ACTIONS_ID_TOKEN_REQUEST_URL", action_text)
+        self.assertIn('(.secrets | keys) == ["SOPS_DRIFT_GATE_AGE_KEY"]', action_text)
+        self.assertIn("SOPS_DRIFT_GATE_AGE_KEY", action_text)
+        self.assertNotIn(REPO_SOPS_SECRET_CONTEXT, action_text)
+        self.assertNotIn("secrets-" "json", action_text)
 
     def test_plaintext_secret_guard_allows_non_secret_metadata_ledgers(self) -> None:
         workflow_text = (

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -50,6 +50,11 @@ TOKEN_METADATA_PATH = Path(
     "secrets/agent-workloads/workload-identity-tokens.metadata.yaml"
 )
 DIGEST_SPEC_VERSION = "agent-workloads-code-digest-v1"
+SHARED_ACTION_PIN = "a1d2fb4a6b288066574b1ac53074ac62e920a07f"
+OLD_MUTABLE_BROKER_ACTION = (
+    "cesaregarza/.github/actions/" "fetch-broker-credentials" "@main"
+)
+REPO_SOPS_SECRET_CONTEXT = "secrets." "SOPS_AGE_KEY"
 
 
 class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
@@ -59,32 +64,27 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
         workflow_text = workflow_path.read_text()
         job = workflow["jobs"]["agent-workloads-identity-digest-drift"]
 
-        self.assertNotIn("secrets.SOPS_AGE_KEY", workflow_text)
+        self.assertNotIn(REPO_SOPS_SECRET_CONTEXT, workflow_text)
+        self.assertNotIn(OLD_MUTABLE_BROKER_ACTION, workflow_text)
         self.assertEqual(job["permissions"]["contents"], "read")
         self.assertEqual(job["permissions"]["id-token"], "write")
-
-        fetch_step = next(
-            step for step in job["steps"] if step.get("id") == "drift-gate-broker"
-        )
-        self.assertEqual(
-            fetch_step["uses"],
-            "cesaregarza/.github/actions/fetch-broker-credentials@main",
-        )
-        self.assertEqual(
-            fetch_step["with"]["capability"],
-            "sops-drift-gate-decrypt",
-        )
-        self.assertEqual(fetch_step["with"]["export-env"], True)
 
         check_step = next(
             step
             for step in job["steps"]
-            if step.get("run")
-            == "uv run python scripts/check_agent_workloads_identity_digests.py"
+            if step.get("uses", "").startswith(
+                "cesaregarza/.github/actions/"
+                "agent-workloads-identity-digest-drift-gate@"
+            )
         )
         self.assertEqual(
-            check_step["env"]["SOPS_AGE_KEY"],
-            "${{ env.SOPS_DRIFT_GATE_AGE_KEY }}",
+            check_step["uses"],
+            "cesaregarza/.github/actions/"
+            f"agent-workloads-identity-digest-drift-gate@{SHARED_ACTION_PIN}",
+        )
+        self.assertNotIn(
+            "@main",
+            check_step["uses"],
         )
 
     def test_plaintext_secret_guard_allows_non_secret_metadata_ledgers(self) -> None:


### PR DESCRIPTION
## Summary
- Keeps the deployment-side identity digest drift and deployed registry compatibility gates inside this repo as local composite actions.
- Replaces the proposed shared `.github` action dependency with:
  - `./.github/actions/agent-workloads-identity-digest-drift-gate`
  - `./.github/actions/agent-control-plane-registry-compat-gate`
- Keeps the repo-local check scripts and deployment-owned pins/secrets as the source of truth.

## Authority invariants preserved
- The local actions are CI guardrails only; they do not deploy, mint workload identity, grant policy, or dispatch capabilities.
- Deployment-owned release pins, SOPS policy, and token metadata stay in this repo.
- Credentials are still fetched through broker capabilities and GitHub OIDC; no repository secret inputs are introduced.
- Checks remain bound to normal GitHub branch protection; a passing check is not authority by itself.

## Tests
- Updated workflow tests assert local action usage and absence of `cesaregarza/.github/actions` dependencies.
- Local action tests assert exact broker response secret shapes:
  - `SOPS_DRIFT_GATE_AGE_KEY` for `sops-drift-gate-decrypt`
  - `MANDATE_CONTRACTS_READ_TOKEN` for `mandate-contracts-read`
- Existing drift and registry compatibility property tests continue to pass.

Validation on current pushed head:
- `uv run python -m unittest tests.test_agent_workloads_identity_digests tests.test_agent_control_plane_registry_compat` passed: 18 tests
- `uv run python -m unittest discover -s tests` passed: 43 tests
- `uv run python scripts/generate_grant_ownership.py --check` passed
- `uv run python scripts/check_control_plane_release_pin.py` passed
- `uv run python -m compileall -q scripts tests` passed
- `rg --hidden -n "cesaregarza/.github/actions|fetch-broker-credentials@main|secrets\\.SOPS_AGE_KEY|secrets-json" .github tests docs scripts` returned no matches
- `git diff --check origin/main...HEAD` passed

## Docs
- Added local action READMEs with threat models for both deployment gates.

## Deferred
- The publish-with-digests and open-repin-pr extraction remain future CES-124 work.
- The previous shared `.github` PR is no longer needed for this slice.

Security review notes:
- This removes mutable shared-action dependencies while keeping brokered credential fetching and exact response validation in the deployment repo.
- The local actions never accept repo `secrets.*`, provider keys, DB credentials, raw SOPS keys, or deployment tokens as inputs.