### PR TITLE
CP re-pin: agent-control-plane 16decdad -> 51a0257868d9 (transcripts + CES-129 + edge)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-16decdad8a82
+  tag: sha-51a0257868d9
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 16decdad8a828af3cf8b4799bd92f0423076930f
+      targetRevision: 51a0257868d9f6212e9e60ecca04c20c52ffa0d8
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps the deployed control-plane image `16decdad -> 51a0257868d9` (targetRevision + values image.tag). Deploys ~20 commits of accumulated agent-platform main:
- **CES-164 transcripts** — ap#142 (per-call audit completeness) + ap#145 (`model_call_transcripts` table, fail-safe + redacted). The reason for this deploy: light up the transcript capture so we can read what opencode does across its ~50 calls (CES-165).
- **CES-129 gateway resilience** — auth refresh / 5xx-refund / CAS-retry / refusal logging; likely fixes the long-run opencode model-gateway 403.
- **Edge work** — CES-139/144/147 (signed mctx_v1 trusted context + static-context disable + no-edge warning), CES-141 edge doctor. In-cluster CP helm sets `AGENT_PLATFORM_ENVIRONMENT=prod`, so the static-disable is satisfied (the runbook nit only affects the separate droplet shim).
- CES-154 synthetic live-verify runner (CronJob disabled-by-default).

Image `sha-51a0257868d9` (`sha256:cb62a009...`) is published in DOCR. The `agent-control-plane-deployed-registry-compat` gate validates the current cap=100 overlay boots on this binary. Operator-gated: advise + stage for your merge; on merge I sync the agent-control-plane app + roll the 4 CP pods, then re-run opencode and read the transcript.