### PR TITLE
CES-96: re-pin agent-workloads sha-de9135d8ed21

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:db209179f19dd5d313fa75b90c5a9d7e3e24b1649b5ddd62e384ce4a707fb215
-      image_digest: sha256:2ca9df7f43137618ca5cd465a510db12135dd440e18f635af70fe7d104ba6fe9
+      manifest_digest: sha256:7aa7d616ab8b60263fb29bb29529f834dd0d4a02e8818392eecd033e2c1dbcb3
+      image_digest: sha256:2e77769ba180d98fcc630a1cd090ef8ac7e2a237c1b2ead2ffc6f8a9ca923f09
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
             session_taint: prod_authority
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:1b6230bfcaf21d3d8c3e03fbee2c377eb9df981f4c06b3cad2c947a4971db062
-      image_digest: sha256:7bb7cea76405b6d7f51d76177bbca9114aae3b6e86768196392a2d26af927f3f
+      manifest_digest: sha256:c8aa26bc3e3969d4161ee18116e39fe95276fd38adb14ab30cd856c9a9c67ebf
+      image_digest: sha256:21efb63d0af10f2fcc6b3b5aa9f4ad1f1b48501fa05b2b55eaf81bc2d96b4e25
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -177,8 +177,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:5e003a2e3e8b1fd94d9be09ba341d5612c225f5e1fe4fd9e7241b8ff7ff79481
-      image_digest: sha256:da2baad71b0d1f04f0141bab6b07aa8da09cdd83f2db449de55816e26275c551
+      manifest_digest: sha256:9c471da6268f25b8d441f500f2f0b43116875b9e7a867cb5c72db4046957fe77
+      image_digest: sha256:dcba8148765d8bb97f2cad7919567333dc3b42215a3506a95c081cf356f66c3f
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -424,7 +424,7 @@ data:
         }
       },
       "code_digest": "sha256:15f65e465c8a4a1263ce2a992c340419186e6ed25390b07d42de5afde91b7bb4",
-      "digest": "sha256:db209179f19dd5d313fa75b90c5a9d7e3e24b1649b5ddd62e384ce4a707fb215",
+      "digest": "sha256:7aa7d616ab8b60263fb29bb29529f834dd0d4a02e8818392eecd033e2c1dbcb3",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -434,7 +434,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:2ca9df7f43137618ca5cd465a510db12135dd440e18f635af70fe7d104ba6fe9",
+        "digest": "sha256:2e77769ba180d98fcc630a1cd090ef8ac7e2a237c1b2ead2ffc6f8a9ca923f09",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -465,7 +465,7 @@ data:
         }
       },
       "code_digest": "sha256:1cc9b4bb5af9c2d12779a0c6a4ef9849f23b3cf547eff4eb5720a267968efc69",
-      "digest": "sha256:1b6230bfcaf21d3d8c3e03fbee2c377eb9df981f4c06b3cad2c947a4971db062",
+      "digest": "sha256:c8aa26bc3e3969d4161ee18116e39fe95276fd38adb14ab30cd856c9a9c67ebf",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -475,7 +475,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:7bb7cea76405b6d7f51d76177bbca9114aae3b6e86768196392a2d26af927f3f",
+        "digest": "sha256:21efb63d0af10f2fcc6b3b5aa9f4ad1f1b48501fa05b2b55eaf81bc2d96b4e25",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -502,7 +502,7 @@ data:
         }
       },
       "code_digest": "sha256:3783f59b2dfc7c2bf54688ffc9469d846f63b55ecad015df6b12aaeaadf6a3fe",
-      "digest": "sha256:5e003a2e3e8b1fd94d9be09ba341d5612c225f5e1fe4fd9e7241b8ff7ff79481",
+      "digest": "sha256:9c471da6268f25b8d441f500f2f0b43116875b9e7a867cb5c72db4046957fe77",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -512,7 +512,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:da2baad71b0d1f04f0141bab6b07aa8da09cdd83f2db449de55816e26275c551",
+        "digest": "sha256:dcba8148765d8bb97f2cad7919567333dc3b42215a3506a95c081cf356f66c3f",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-37790c3ab89d
-  digest: sha256:2ca9df7f43137618ca5cd465a510db12135dd440e18f635af70fe7d104ba6fe9
+  tag: sha-de9135d8ed21
+  digest: sha256:2e77769ba180d98fcc630a1cd090ef8ac7e2a237c1b2ead2ffc6f8a9ca923f09
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-37790c3ab89d
-    digest: sha256:7bb7cea76405b6d7f51d76177bbca9114aae3b6e86768196392a2d26af927f3f
+    tag: sha-de9135d8ed21
+    digest: sha256:21efb63d0af10f2fcc6b3b5aa9f4ad1f1b48501fa05b2b55eaf81bc2d96b4e25
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-37790c3ab89d
-    digest: sha256:da2baad71b0d1f04f0141bab6b07aa8da09cdd83f2db449de55816e26275c551
+    tag: sha-de9135d8ed21
+    digest: sha256:dcba8148765d8bb97f2cad7919567333dc3b42215a3506a95c081cf356f66c3f
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -222,13 +222,13 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:15f65e465c8a4a1263ce2a992c340419186e6ed25390b07d42de5afde91b7bb4
-    manifestDigest: sha256:db209179f19dd5d313fa75b90c5a9d7e3e24b1649b5ddd62e384ce4a707fb215
-    imageDigest: sha256:2ca9df7f43137618ca5cd465a510db12135dd440e18f635af70fe7d104ba6fe9
+    manifestDigest: sha256:7aa7d616ab8b60263fb29bb29529f834dd0d4a02e8818392eecd033e2c1dbcb3
+    imageDigest: sha256:2e77769ba180d98fcc630a1cd090ef8ac7e2a237c1b2ead2ffc6f8a9ca923f09
   opencode.apply_executor:
     codeDigest: sha256:3783f59b2dfc7c2bf54688ffc9469d846f63b55ecad015df6b12aaeaadf6a3fe
-    manifestDigest: sha256:5e003a2e3e8b1fd94d9be09ba341d5612c225f5e1fe4fd9e7241b8ff7ff79481
-    imageDigest: sha256:da2baad71b0d1f04f0141bab6b07aa8da09cdd83f2db449de55816e26275c551
+    manifestDigest: sha256:9c471da6268f25b8d441f500f2f0b43116875b9e7a867cb5c72db4046957fe77
+    imageDigest: sha256:dcba8148765d8bb97f2cad7919567333dc3b42215a3506a95c081cf356f66c3f
   opencode.proposer:
     codeDigest: sha256:1cc9b4bb5af9c2d12779a0c6a4ef9849f23b3cf547eff4eb5720a267968efc69
-    manifestDigest: sha256:1b6230bfcaf21d3d8c3e03fbee2c377eb9df981f4c06b3cad2c947a4971db062
-    imageDigest: sha256:7bb7cea76405b6d7f51d76177bbca9114aae3b6e86768196392a2d26af927f3f
+    manifestDigest: sha256:c8aa26bc3e3969d4161ee18116e39fe95276fd38adb14ab30cd856c9a9c67ebf
+    imageDigest: sha256:21efb63d0af10f2fcc6b3b5aa9f4ad1f1b48501fa05b2b55eaf81bc2d96b4e25


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `de9135d8ed217bd182162e565536a7bcf031521a`
- Publish run id: `27491058367`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:2e77769ba180d98fcc630a1cd090ef8ac7e2a237c1b2ead2ffc6f8a9ca923f09` | `sha256:7aa7d616ab8b60263fb29bb29529f834dd0d4a02e8818392eecd033e2c1dbcb3` | `sha256:15f65e465c8a4a1263ce2a992c340419186e6ed25390b07d42de5afde91b7bb4` |
| `opencode.apply_executor` | `sha256:dcba8148765d8bb97f2cad7919567333dc3b42215a3506a95c081cf356f66c3f` | `sha256:9c471da6268f25b8d441f500f2f0b43116875b9e7a867cb5c72db4046957fe77` | `sha256:3783f59b2dfc7c2bf54688ffc9469d846f63b55ecad015df6b12aaeaadf6a3fe` |
| `opencode.proposer` | `sha256:21efb63d0af10f2fcc6b3b5aa9f4ad1f1b48501fa05b2b55eaf81bc2d96b4e25` | `sha256:c8aa26bc3e3969d4161ee18116e39fe95276fd38adb14ab30cd856c9a9c67ebf` | `sha256:1cc9b4bb5af9c2d12779a0c6a4ef9849f23b3cf547eff4eb5720a267968efc69` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.