### PR TITLE
CES-96: re-pin agent-workloads sha-2e410dc4264a

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:7fb2fc05d9d609987b26e8d1082d534989ec58e2d373f30c770e0223ba22f65d
-      image_digest: sha256:ac24cb307f3b12e1acfba1f6e63002966c7970e7930e59e7f374c1e1cf5b6ffb
+      manifest_digest: sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2
+      image_digest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
             session_taint: prod_authority
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:3a1c4c1c7bd12fcd08840602c987e9272ab15276ab295e323734ba00f346f56f
-      image_digest: sha256:dd33c8c9c43d61605866f1acebe8b5e0eb3c11749a0347f82bff52fe2045f905
+      manifest_digest: sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf
+      image_digest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -177,8 +177,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:9633ba4b5c12147d558f77de32f8be6111aaab82f2a710fe7be4c607085cf298
-      image_digest: sha256:e6d6e13993ffd55a472e369cc971e4de663c4f749c1332a4ecebcc6df7d5de6e
+      manifest_digest: sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9
+      image_digest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -424,7 +424,7 @@ data:
         }
       },
       "code_digest": "sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42",
-      "digest": "sha256:7fb2fc05d9d609987b26e8d1082d534989ec58e2d373f30c770e0223ba22f65d",
+      "digest": "sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -434,7 +434,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:ac24cb307f3b12e1acfba1f6e63002966c7970e7930e59e7f374c1e1cf5b6ffb",
+        "digest": "sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -465,7 +465,7 @@ data:
         }
       },
       "code_digest": "sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9",
-      "digest": "sha256:3a1c4c1c7bd12fcd08840602c987e9272ab15276ab295e323734ba00f346f56f",
+      "digest": "sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -475,7 +475,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:dd33c8c9c43d61605866f1acebe8b5e0eb3c11749a0347f82bff52fe2045f905",
+        "digest": "sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -502,7 +502,7 @@ data:
         }
       },
       "code_digest": "sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868",
-      "digest": "sha256:9633ba4b5c12147d558f77de32f8be6111aaab82f2a710fe7be4c607085cf298",
+      "digest": "sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -512,7 +512,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:e6d6e13993ffd55a472e369cc971e4de663c4f749c1332a4ecebcc6df7d5de6e",
+        "digest": "sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-eb62322fffbe
-  digest: sha256:ac24cb307f3b12e1acfba1f6e63002966c7970e7930e59e7f374c1e1cf5b6ffb
+  tag: sha-2e410dc4264a
+  digest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-eb62322fffbe
-    digest: sha256:dd33c8c9c43d61605866f1acebe8b5e0eb3c11749a0347f82bff52fe2045f905
+    tag: sha-2e410dc4264a
+    digest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-eb62322fffbe
-    digest: sha256:e6d6e13993ffd55a472e369cc971e4de663c4f749c1332a4ecebcc6df7d5de6e
+    tag: sha-2e410dc4264a
+    digest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -222,13 +222,13 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42
-    manifestDigest: sha256:7fb2fc05d9d609987b26e8d1082d534989ec58e2d373f30c770e0223ba22f65d
-    imageDigest: sha256:ac24cb307f3b12e1acfba1f6e63002966c7970e7930e59e7f374c1e1cf5b6ffb
+    manifestDigest: sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2
+    imageDigest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
   opencode.apply_executor:
     codeDigest: sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868
-    manifestDigest: sha256:9633ba4b5c12147d558f77de32f8be6111aaab82f2a710fe7be4c607085cf298
-    imageDigest: sha256:e6d6e13993ffd55a472e369cc971e4de663c4f749c1332a4ecebcc6df7d5de6e
+    manifestDigest: sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9
+    imageDigest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
   opencode.proposer:
     codeDigest: sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9
-    manifestDigest: sha256:3a1c4c1c7bd12fcd08840602c987e9272ab15276ab295e323734ba00f346f56f
-    imageDigest: sha256:dd33c8c9c43d61605866f1acebe8b5e0eb3c11749a0347f82bff52fe2045f905
+    manifestDigest: sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf
+    imageDigest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad

--- a/secrets/agent-workloads/workload-identity-tokens.enc.yaml
+++ b/secrets/agent-workloads/workload-identity-tokens.enc.yaml
@@ -4,9 +4,9 @@ metadata:
     name: agent-workloads-workload-identity-tokens
     namespace: agent-workloads
 stringData:
-    MANDATE_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:C0N+WRCkLN4EFCMc+Xq7M+WIEliNKCnNX8HX11Dw0Vi53C/S3L5dOvfv8+mXyxbVXZ80pYLPIowaZ9YbI/XSigXJZL1S0WqGJVNhVpWz5HgcZLnxw6La8s+MorWJroTEVQ2S37MQvzrZUbHq3ypd2jn7mFHSQMBTFMj0GWSZLBVvkYOSCmkuUUX011WQuhqMcUOgvG+nhtwAvSovZf/4AK6m5CkS5IVb+q0bbCNaJZBqlSFW7vf/GO2HSeglf3RCWu+adXu2BJ1c/u8WkkH9yETb1Cs3OOMnt2F6bJpV0Mukxwgjigp5h4XXxEAtDa1ozoUw8tj+AkniVBPI8LZwXDTDxqqw/Po8z2rGZv2ByO6tQASu8IXVA0IuYa455mKmzm/AHYlT1v5vkX/WGo6CeWmIsGE+o+1/h1j+um6plTtiy9YTe3AfhfcBd25vS6FNi76yUg==,iv:QF57nixKWuo+g3/CRXBytGRqBF95uXByeK4HLrQWFOI=,tag:5mXQbgHOVXnUT63RnQP03A==,type:str]
-    OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:ET1yAoXp7AJJIY1c+52fvJqxtUJocvGyHgKe5cRK+fb/7nRQHIDXJwaQECo4ICa/CQW/fQhFFO21D87yqrHXeQ+pwuASGiYIyuFH+I/w4XFrIYHd9qgs2xtKuC8mWPv8XQnHDNnDmMw0hZ8LdhjyYJvbsrTwTFHooQX3ZU/dUhjNVJXzwC66Vx84RsRdaubu+0NELWH2hW0jXRYDcNHOpGqHX57iQIIZPbRuJ4RZkMXTAePHh+Z50kh0xSgf3vKwCJNupCtwC/49+DUHMPgYDxEFzLsqHQ5OkCugPmB11vTcCxUADUL5arOi0xh4y4dKx4KOAEV1PnTOPQ2QtrXc7rXtdUXJ1Dfs/3bmcPCvUjJ8zGshn1g77U/L0fZlL/dprTByR4TjxpPnNDtwS6l72IMDhsftMB4WmlzX0cbM1dFIKw7l+ff0qTCAKbm90E0E06owxUiwMzg=,iv:4z4pBFfHDUectwC6mnD0LUjgq5pdbPRMrpH+8GJyfzY=,tag:8aWYCxB+TM5Pogl9+u7Xtg==,type:str]
-    OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:iIAKEubq6Fffn2M4xufkTy5lLnyIZegNgVF/gmhdJPkaOM15eupgrJRrr93v2Aa6N0s+Go3Jh7uBldIYRBdOLqmZtsYWVv2lXNKZZ8wnUYu818rqc0LGD2GBOGrzp3NhHhGsJi73R6w0BZ6xHoTwTcqqT+Ng5TY3GvnhioytkDXAkLeLR41GbiaF07CY86gktqOPbQ6UyrP7n8v5tnm+HP7/p9ly79sYfR6ZCydBUjetG+fuyArwzBRgn5N2hgXUtug5CJrQb4Exmpz2YDs2g18Ufh4y/H6kZPvmoH450wpSapDmhplZKve7LWkgOQ/MLJ1+g4Xg5vA+ShHjfpSZA2XIV7wKb7wN5l9xU5hzAQswQP2lTqi6B/64EGPFD2ZX+z5tWV8y/7PAjwVGQTXFy8jty7onfvmrh3FM5Wjt00U2uj/gkLmIH0l+cpD+M9F2,iv:vd9AfNt4E/6D++v5KTM+MjWYNu+Ty9Zb2NDkZxz5S9I=,tag:pcwLBdK7av2hyE5gvB7d8w==,type:str]
+    MANDATE_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:UypuGQEH6XLOxy+X4xZEDXwsJ6jI5r29Cthe+7K0Wpbs+ooFfKIGbP75jbz28z/h6U+hJ+THZSvK+5W2pZ87bnZfKeJzGHzyI5tG7OVInud9N1XFJfFcPvmeJVCjp7wf7gfXbYjw6P3w4chh/U8POJkyoP4b2uNr/oXNiVVG82CSTxzyCuaW/Qjyei+DDep237fReagvQ4BCilFgSfRha9yF5iEwiiRGWbxGDjK9qbZLpmQlBq0mtPLzvAiQuYXzbcF8cAQ5QfMX/2hMcl4AwamTFxmdNFU0Y5mNfq1EPdwtXbQ5GY66GnT9hEmBrQbJeT+R9TI8Gy1iHaCqTgIH+yEK4Uc8laaTuXnKF7ravZg5+UV8YhAblnYqUsaiMgaAkjd+t4iiOUEnL/FcCs6CYWTBM7k262niw9+A0E6cyBCEWyKEncjj84h5xClvkOHLK0eFsw==,iv:+6jpcpJdeA4yNmNn6KQYb4aB9IK1Qj58Qv1k4IyXF0g=,tag:6QreyKJvdSrg7lNPPtPdeQ==,type:str]
+    OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:hLYS6wY2/HM64yZf4i5ZGh2OCu8ut99Vre40BrXs0UL7gKHiFD/kNE4WD8E6yOHElEHWZnGF5xVe6n6N15hlfarlaDzpK/bmI/BV4hcewVKuakquBRJh7H+wZGgqjSB8BN0nZEfKb3ob0ryrFUMRnMYSDGdMk/JnsBniUza3w7X+dUwA6fFmwsu8iPI/SXz9iI5kgHLBjQIq/65usk8wjsvhJjY4rNHmoTOCzZyWVe59HcEike94jAWYaSvMqGaNsOtgWikFTgdHvI8WjklHS/Gg5NUA6BqivIoSWM/h8EuBZQvOEYKZBzukSyvYMBeeUC2FDNAwZUDf29NmCj5g2pd/c3RQ82dLx9fgjc8g5jrgd49mrq/wdAsRAdmZMcV4FBvpwQI3WznsBisDzOvuecx6loMtFCd0lNxmIkONvAA/wNRQEqMOq36WQkoz0MjIiAPvnPp6W4w=,iv:gdjjpQgq3XMAZbOhPnrEuvHTa2tpzGvz16aBs0qNNtA=,tag:6aiUuPaKHxQWkGD2cRGIzg==,type:str]
+    OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:vRAPDksh5p+BmGCauytJv27Stn1oflwmX1y7ecZbrh7tRJAx/tzicym3IvDBiww0uVBb7HbidzDWKRtCaeOsc686lTt04dIGIfE+17PoS+cm4LPu7Emc4RvCebJQlN/hvDIqILJpk4pcsQKkBErqSLSP3s/8nDCtVH6no6p2vZ2Xt1JtGVas4NqT+q/vMnyU4iylFt3QYUAQHxofs370OpyDLunzcqUATehloj0cqG/aYeTunkzGPmq2obrtz+zBLmSoFKRRQx30/7OWsMU1do41Z0g4QU6jJtqv3a1oMf0ZDY4Ideg9f/wzyolMqDDcYgjUn345LvZn1/v4FltrG6ywzLKeAuLZz8GsAf+IJK/N8joaz4Tl/6ub7ngqTgxxl6coQwXxbBNCkn5h4TwkQz6TDyLf4pcpRuwdocbth3HV9q2Ia1yQgBncV2XVy/15,iv:dG2HTRSK9QT/52Y9S25g9/EZrc2Owg7t+LIuFcybN+I=,tag:EluPDk5cV1WFBHOWMQsiUQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -16,23 +16,23 @@ sops:
         - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZFZoN2dpckVmSk50N1pO
-            akpTUm5xd0RLM0RkbjFwRFo4YURINzlBcVNvCmlCUEc5WHF3cjZrZk5Xak40YmZI
-            OGhNYnhucTB0blAzUDI0Z2NZRXMzcnMKLS0tIFd2dnNYNFpldXlnbEREbnZKZmRM
-            bUwxNVI4R2tuMWd1YUVuUnVreFJKUFkKIY5Znwp/030CpBbfYQa7QHhHNq04eLEA
-            Mfqk6jkPhcOx3kpsGHYJwmWdjIn8XXHy63QkSalgOLJSZy9qU7x3bg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQeGJRaWZiQVc1bVhEbUFQ
+            bzFCTytPY1crcVgzQlgrTHdid3FuNVdzUGlJCkNMMnFvQ09oOWR4YmhJZHc0TkdP
+            ZTBoQi9obXdDeGJGVFNzelhEYk50OVUKLS0tIFdndnhYQm1DRWNEeHJVTjJrU0Rm
+            bi8zNWt4a29xem0vTFlsbEpIdlJBWVkK2sA8Xb8Cjb5uphGo2C9tZthbZRiYBh6d
+            7XdwkU7olnnE5IARG7FdLN4xC4TOeJc97KRuVkakU4vXn554rMWhQg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiZElNMDFXUXdLU2RRMjRo
-            KzB0ZDF2bnNRN1VwSGNVRVlkck5pUjhlNDFZCm5ad01TUjBlSHdETnVXTGtsbEFS
-            c3F3Q2czdUdpWWd5RkxPRTRkeTBCQ0kKLS0tIEQ4eVpzaEIzQTZCS3hKV2pGckU3
-            Q1F4dkE5VUJ5K2lLaTIrR1VyRmhkSXMKZpLWhMcIy9wTzgx5SYBxMplCnW9Ep+cQ
-            bmddw9jco099OIZl/34yx/dDj09ZFB0Vj/3Qe6+ar2XvVhZE8LZgwA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqenBkU2h0R1FmWi80MCtY
+            NytVb2ZFbmtkMnBGUTJlR2RrcHRmQVhaTkFJCkh1enZuTmxDbzNJak4xcUFMZkdo
+            YTZSM1lVS3FsZFlNUnRDRDVLcHExTGcKLS0tIG1uZDNpbDlMakh2aG5HbG5EN3A2
+            cUg4MVRJaXhVVFJQRWsrVDB4ZjFuazgKNhyneD0X2SKIJ5JrEyq2DrWJSkdNMYaj
+            K6n20TyGhmTV80mntl7iK3I8eGXM71mrCUVIAOCFjXABj8OMFhLcYg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-14T17:34:28Z"
-    mac: ENC[AES256_GCM,data:h2UFTAq8RmB5rOTDa5y65B2rBLIkbEOWOl15x9lH3R4o7Ut/F+glOmZ2i5CAQu2yFI+eMnABYuRoFeQzCweJflye3NJFZ4LTzB6dbIsXfsjwzpIDZTats/V4n3zBIExk54OFHPdfh2g1dA7DwBiwCNs/wQ5nj3/UlmuxnZzRBsM=,iv:RVA1yLYLAjWEyeSkX3FuNPY4VcCO9MzhFgXixs9EhWo=,tag:J6ZHGmAE7XiWtjOxm+3bHw==,type:str]
+    lastmodified: "2026-06-14T18:31:13Z"
+    mac: ENC[AES256_GCM,data:7HHyCBZVmMCs2kCiYhQeJjNWLnFEEl5SeNoUDl5lzLeasqyrUBgVkRs97aA1txywDAuuW02lTqFHxmWEGSdkVEvIX1dHal8Q8Nz6ogVCmgaXa7VZ6MsOqxHW8mdb+T+FERFyMe8QqPdmq7Tnk271IrMuUf3EQDreDuW3/54OCoE=,iv:tD4jPs1r+PbB/JwjxQ0nj/8oG/WIdj8URnYy7RCDvQs=,tag:gs+AYulGc+1AHvGGR4F5jg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/secrets/agent-workloads/workload-identity-tokens.metadata.yaml
+++ b/secrets/agent-workloads/workload-identity-tokens.metadata.yaml
@@ -5,44 +5,44 @@ tokens:
     agent_id: data.workspace_probe
     token_key: MANDATE_WORKLOAD_IDENTITY_TOKEN
     code_digest: sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42
-    manifest_digest: sha256:7fb2fc05d9d609987b26e8d1082d534989ec58e2d373f30c770e0223ba22f65d
-    iat: 1781458468
-    exp: 1789234468
+    manifest_digest: sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2
+    iat: 1781461873
+    exp: 1789237873
     iss: kubernetes
     sub: data.workspace_probe
     aud: mandate-api
     scp:
     - worker_service
     digest_spec_version: agent-workloads-code-digest-v1
-    source_commit: eb62322fffbe
-    ciphertext_sha256: sha256:743471bf2dab78ce634467ec2a889024811a63f7f62b1743430cea856f05b0ca
+    source_commit: 2e410dc4264a
+    ciphertext_sha256: sha256:e0507c21883b00ddb08d06079c012ad56ae2f087e010a77f4f18c65ef4c2fd19
   opencode.apply_executor:
     agent_id: opencode.apply_executor
     token_key: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
     code_digest: sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868
-    manifest_digest: sha256:9633ba4b5c12147d558f77de32f8be6111aaab82f2a710fe7be4c607085cf298
-    iat: 1781458468
-    exp: 1789234468
+    manifest_digest: sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9
+    iat: 1781461873
+    exp: 1789237873
     iss: kubernetes
     sub: opencode.apply_executor
     aud: mandate-api
     scp:
     - worker_service
     digest_spec_version: agent-workloads-code-digest-v1
-    source_commit: eb62322fffbe
-    ciphertext_sha256: sha256:743471bf2dab78ce634467ec2a889024811a63f7f62b1743430cea856f05b0ca
+    source_commit: 2e410dc4264a
+    ciphertext_sha256: sha256:e0507c21883b00ddb08d06079c012ad56ae2f087e010a77f4f18c65ef4c2fd19
   opencode.proposer:
     agent_id: opencode.proposer
     token_key: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
     code_digest: sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9
-    manifest_digest: sha256:3a1c4c1c7bd12fcd08840602c987e9272ab15276ab295e323734ba00f346f56f
-    iat: 1781458468
-    exp: 1789234468
+    manifest_digest: sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf
+    iat: 1781461873
+    exp: 1789237873
     iss: kubernetes
     sub: opencode.proposer
     aud: mandate-api
     scp:
     - worker_service
     digest_spec_version: agent-workloads-code-digest-v1
-    source_commit: eb62322fffbe
-    ciphertext_sha256: sha256:743471bf2dab78ce634467ec2a889024811a63f7f62b1743430cea856f05b0ca
+    source_commit: 2e410dc4264a
+    ciphertext_sha256: sha256:e0507c21883b00ddb08d06079c012ad56ae2f087e010a77f4f18c65ef4c2fd19


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `2e410dc4264a68027ececac3c6bdcb15714945dd`
- Publish run id: `27507823100`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb` | `sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2` | `sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42` |
| `opencode.apply_executor` | `sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7` | `sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9` | `sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868` |
| `opencode.proposer` | `sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad` | `sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf` | `sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.