### PR TITLE
CP re-pin: agent-control-plane 51a02578 → e71f8bf6d037 (CES-180 family + CES-104/47)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-51a0257868d9
+  tag: sha-e71f8bf6d037
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 51a0257868d9f6212e9e60ecca04c20c52ffa0d8
+      targetRevision: e71f8bf6d0376c995dd26f4ebd6995c63bdcfb2f
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## What
Bump the control-plane image + Argo `targetRevision` to agent-platform main HEAD **e71f8bf**:
- `apps/agent-control-plane/values.yaml`: `tag: sha-51a0257868d9` → `sha-e71f8bf6d037`
- `argocd/applications/agent-control-plane.yaml`: `targetRevision` → `e71f8bf6d0376c995dd26f4ebd6995c63bdcfb2f`

Image `sha-e71f8bf6d037` (manifest `sha256:a440c71a…`) published 2026-06-15 03:50, publish CI green.

## What deploys (23 commits since 51a02578)
- **CES-181** sandbox-boundary ADR + **CES-182–188** SandboxProfile/RuntimePosture validators (admission/registry)
- **CES-104** workload-identity bundle-claim tightening (manifest/image digest claim validation at all 4 worker endpoints)
- **CES-47** audit-history observability metrics + alert specs
- docs (CES-124/142/145/155/158 slices)

## Pre-flight — SAFE for running workloads
Read-only analysis of e71f8bf confirmed:
- The CES-180 validators **are** invoked at registry construction (`mandate/core/registry.py:230` → `validate_sandbox_profile_bindings`) **but are opt-in**: `registry_capability_validation.py:112` `if required_profile is None: continue`.
- The current profile-less prod workloads — `agent_workloads.db_probe`, `agent_workloads.opencode_propose` — declare no sandbox profile, so they **pass silently**. The CP does **not** boot fail-closed.
- **CES-104** is backward-compatible: code-only tokens still claim while the registry is unpinned (staged rollout).
- No other admission/registry boot-behavior changes in the range.

## Re-mint
**None required.** This is a control-plane image bump; no agent-workloads `code_digest` changes, so the workload-identity drift gate / token re-mint cycle does not apply.

## Deploy after merge (Claude drives, per-action authorized)
1. Argo hard-refresh + sync `agent-control-plane` → `e71f8bf6d0376c995dd26f4ebd6995c63bdcfb2f`; CP rolls on the image change (RollingUpdate, surge-first).
2. Verify the CES-113 registry-digest `/metrics` value reflects the new snapshot (also satisfies CES-108 live-verify).
3. Live-verify the ridealong tickets: CES-182–188 load without rejecting current workloads; CES-104 bundle path; CES-47 metrics present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)