### PR TITLE
CES-212: bump agent-control-plane to neutral-Core sha-10dcea284c52

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-e71f8bf6d037
+  tag: sha-10dcea284c52
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: e71f8bf6d0376c995dd26f4ebd6995c63bdcfb2f
+      targetRevision: 10dcea284c527974ac5b3755e5db07d1ef99cb59
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## CP bump → full CES-212 neutral-Core

Deploys the complete neutral-Core migration (agent-platform main `10dcea2`) to the control plane, replacing pre-neutral-Core `sha-e71f8bf6d037`.

**Pins (both = commit 10dcea2, consistent):**
- `apps/agent-control-plane/values.yaml`: image tag → `sha-10dcea284c52`
- `argocd/applications/agent-control-plane.yaml`: targetRevision → `10dcea284c527974ac5b3755e5db07d1ef99cb59`

**Digest provenance (DOCR-verified):** `sha-10dcea284c52` → `sha256:b56d9962f8ea03b1956d4bb9a530b295a317f2f142966efc74ee6c869f53da8c`, published 2026-06-16 14:48 by the `Publish Mandate Control Plane Image` workflow_dispatch run on green main `10dcea2` (`latest` points to the same digest). CI on `10dcea2` is green.

**What's in it:** entire CES-212 chain — neutral Principal/SurfaceContext/DeliveryTarget contracts, neutral idempotency, principal-subject hash, neutral policy/admission, approvals, callback delivery, mctx_v2, the Core boundary guard, rollout-compat, acceptance test — plus the **`012_neutral_core_storage.sql` migration** (additive/reversible: nullable neutral columns + new partial-unique idempotency index; legacy columns retained).

⚠️ **Migration execution:** the chart runs migrations via helm hook (`migrations.useHelmHooks=true`, `disableStartupSchemaMigration=true`). Per CES-167 the hook may not fire under Argo sync — after sync I'll verify the neutral columns exist and run `mandate-migrate` in-pod if the hook didn't run (the migration is reversible, so this is safe).

**Post-merge (operator-go'd, by Claude):** hard-refresh + Argo sync agent-control-plane to the merge SHA → restart all 4 CP deploys (boot-cached registry overlay) → verify/run the 012 migration → live-verify a job end-to-end (neutral idempotency conflict/scope-split, principal hash excludes surface, audit chain, no regressions).

Operator-gated repo — requesting your merge.