### PR TITLE
CES-218: bump agent-control-plane to FIX image sha-fdefab075aeb (clear migration crash-loop)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-10dcea284c52
+  tag: sha-fdefab075aeb
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 10dcea284c527974ac5b3755e5db07d1ef99cb59
+      targetRevision: fdefab075aeba6d9c69001a939b8edfb6cdb39c3
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Rolls the CP from the broken `sha-10dcea284c52` (crash-looping on `postgres migration checksum mismatch: 001`) to the **fixed** image `sha-fdefab075aeb` (agent-platform #182 / `fdefab0`).

**Pins:** image tag → `sha-fdefab075aeb` (digest `sha256:17209ea508dd…`, DOCR-verified, published off green main `fdefab0`); targetRevision → `fdefab075aeb…`.

**Prod DB already migrated:** one-off `mandate-migrate` Job applied + recorded `012/013/014` (schema_migrations now 001-014, legacy `task_submissions_request_scope_nullsafe_idx` dropped, neutral index present, `001` checksum matches original). So the new CP's startup validator will pass.

**Urgent** — the legacy idempotency index is already dropped, so the still-serving old CP lacks its DB-level dedup until this rolls; merge promptly. Post-merge (by Claude): splattop-root sync → agent-control-plane sync → verify 4 pods Healthy on sha-fdefab075aeb → live-verify.