### PR TITLE
CES-96: re-pin agent-workloads sha-44a12af092fb

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2
-      image_digest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
+      manifest_digest: sha256:70550b1572c4a1c2aa4e79e0b7e1b1bdec20696c2639c129aea7ff391770d0be
+      image_digest: sha256:0175691ef198c50c858ccbb0eeff7f50cc30b2e1553315aba445fe588b3efe21
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
             session_taint: prod_authority
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf
-      image_digest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad
+      manifest_digest: sha256:835876ce4d4c0415422a57330aaa732c560ca60871387a0b59cfb99ac151b107
+      image_digest: sha256:23618ccf10c5cfa15ffdf25f609664d306a12c2d2f448fa816f0df4d46a6eddd
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -177,8 +177,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9
-      image_digest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
+      manifest_digest: sha256:6bbbea91bf5447d839322a0f088e5a67b6ac7349c17644f9a7451cf09bebf0d6
+      image_digest: sha256:d41cf6649a6d0a1c3205e2934dc783049a74d1f0346424348a8ea37955e0d8f0
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -424,7 +424,7 @@ data:
         }
       },
       "code_digest": "sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42",
-      "digest": "sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2",
+      "digest": "sha256:70550b1572c4a1c2aa4e79e0b7e1b1bdec20696c2639c129aea7ff391770d0be",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -434,7 +434,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb",
+        "digest": "sha256:0175691ef198c50c858ccbb0eeff7f50cc30b2e1553315aba445fe588b3efe21",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -465,7 +465,7 @@ data:
         }
       },
       "code_digest": "sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9",
-      "digest": "sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf",
+      "digest": "sha256:835876ce4d4c0415422a57330aaa732c560ca60871387a0b59cfb99ac151b107",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -475,7 +475,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad",
+        "digest": "sha256:23618ccf10c5cfa15ffdf25f609664d306a12c2d2f448fa816f0df4d46a6eddd",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -502,7 +502,7 @@ data:
         }
       },
       "code_digest": "sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868",
-      "digest": "sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9",
+      "digest": "sha256:6bbbea91bf5447d839322a0f088e5a67b6ac7349c17644f9a7451cf09bebf0d6",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -512,7 +512,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7",
+        "digest": "sha256:d41cf6649a6d0a1c3205e2934dc783049a74d1f0346424348a8ea37955e0d8f0",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-2e410dc4264a
-  digest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
+  tag: sha-44a12af092fb
+  digest: sha256:0175691ef198c50c858ccbb0eeff7f50cc30b2e1553315aba445fe588b3efe21
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-2e410dc4264a
-    digest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad
+    tag: sha-44a12af092fb
+    digest: sha256:23618ccf10c5cfa15ffdf25f609664d306a12c2d2f448fa816f0df4d46a6eddd
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-2e410dc4264a
-    digest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
+    tag: sha-44a12af092fb
+    digest: sha256:d41cf6649a6d0a1c3205e2934dc783049a74d1f0346424348a8ea37955e0d8f0
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -222,13 +222,13 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42
-    manifestDigest: sha256:9212130b326f64eea445653bf139c9d18c5199b501f00f0ba0930085cdc926a2
-    imageDigest: sha256:4506b6b5f84f26c5c7a548b0fb6767f127524f3dabeaa0bba3e2965a99f7f5cb
+    manifestDigest: sha256:70550b1572c4a1c2aa4e79e0b7e1b1bdec20696c2639c129aea7ff391770d0be
+    imageDigest: sha256:0175691ef198c50c858ccbb0eeff7f50cc30b2e1553315aba445fe588b3efe21
   opencode.apply_executor:
     codeDigest: sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868
-    manifestDigest: sha256:74f53456f96067ada8666a75cd00b7662acb3c06f48f24ecab5a6bf1ef015de9
-    imageDigest: sha256:bd3147695724fff4f6a868084e65573e061a560935ff3aef504dc916aa5523f7
+    manifestDigest: sha256:6bbbea91bf5447d839322a0f088e5a67b6ac7349c17644f9a7451cf09bebf0d6
+    imageDigest: sha256:d41cf6649a6d0a1c3205e2934dc783049a74d1f0346424348a8ea37955e0d8f0
   opencode.proposer:
     codeDigest: sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9
-    manifestDigest: sha256:1c6d0e701ba429d4bbbaca7db40f279fa5895a04a7895065a51c6354a49da1bf
-    imageDigest: sha256:5a8f65b9006b1c66bd5d885aef95fc3fbc23a41bbea1784e0e78397580b5acad
+    manifestDigest: sha256:835876ce4d4c0415422a57330aaa732c560ca60871387a0b59cfb99ac151b107
+    imageDigest: sha256:23618ccf10c5cfa15ffdf25f609664d306a12c2d2f448fa816f0df4d46a6eddd


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `44a12af092fb1205f4676ead598bddbbbd7b0a33`
- Publish run id: `27663264495`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:0175691ef198c50c858ccbb0eeff7f50cc30b2e1553315aba445fe588b3efe21` | `sha256:70550b1572c4a1c2aa4e79e0b7e1b1bdec20696c2639c129aea7ff391770d0be` | `sha256:c58a45c779220a8b6671fb84b65bd19405af8f7d06e90e10b6252a4f7005ce42` |
| `opencode.apply_executor` | `sha256:d41cf6649a6d0a1c3205e2934dc783049a74d1f0346424348a8ea37955e0d8f0` | `sha256:6bbbea91bf5447d839322a0f088e5a67b6ac7349c17644f9a7451cf09bebf0d6` | `sha256:7f00ce7a63646eee642ec04f0bf7fc81adadbbf8991a7682e59c17920c55f868` |
| `opencode.proposer` | `sha256:23618ccf10c5cfa15ffdf25f609664d306a12c2d2f448fa816f0df4d46a6eddd` | `sha256:835876ce4d4c0415422a57330aaa732c560ca60871387a0b59cfb99ac151b107` | `sha256:9f5ab7f2e7726a0c6e4423284e381ce0172f5e1840c6f76d4c8c02b6b35826f9` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.