### PR TITLE
CES-108: clarify registry-overlay auto-rollout docs

### DIFF
--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -3,24 +3,29 @@
 This app installs the prod deployment overlay for live `agent-workloads`
 worker-service paths.
 
-## Sync rolls the control plane automatically (CES-108)
+## Sync rollout path (CES-108)
 
 The control plane builds its `RegistrySnapshot` once at boot and never
 re-reads the mounted overlay, so every overlay change requires a restart of
 all four control-plane Deployments to take effect. A `PostSync` hook Job
 (`restart-hook.yaml`, ServiceAccount/Role scoped to exactly those four
-Deployments in `restart-rbac.yaml`) performs the `rollout restart` and then
-waits on `rollout status` for each — **a config the deployed image cannot
-boot fails the sync loudly** instead of crash-looping in silence. No manual
-`kubectl rollout restart` step is needed for overlay-only changes.
+Deployments in `restart-rbac.yaml`) is intended to perform the `rollout
+restart` and then wait on `rollout status` for each — **a config the deployed
+image cannot boot fails the sync loudly** instead of crash-looping in silence.
+Until CES-108 live verification confirms that hook fires in prod, operators
+must confirm the Deployments rolled after overlay sync and run a manual
+`kubectl rollout restart` if they did not.
 
 Note: the hook fires on every sync of this app, including no-op re-syncs;
 restarts are rolling and the app is manual-sync, so syncs are deliberate.
 The Argo Application intentionally does not set `ApplyOutOfSyncOnly=true`:
 selective syncs do not execute hooks, which skips the restart Job and leaves
 the control plane serving the previous boot-cached registry snapshot.
-Workload-identity token re-mints (the `agent-workloads-secrets` app) still
-require a manual worker rollout — see CES-108 for the recorded follow-up.
+Workload-identity token re-mints update the `agent-workloads-secrets` app and
+roll the workload Deployments, not the control-plane Deployments. That worker
+rollout path stays separate from this overlay hook. The control-plane-read HMAC
+verify seed lives under `agent-control-plane-secrets`; rotating it is a rare
+operator action and remains outside the registry-overlay restart hook.
 
 ## Deployed-version compatibility gate (CES-126)
 

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -4,9 +4,12 @@ This file is generated from the agent-workloads release applier contract and
 the deployment registry overlay. Do not hand-edit it; run
 `scripts/generate_grant_ownership.py` instead.
 
-Changing a deployment-owned key edits the GarzAICluster registry overlay and
-requires a control-plane restart. It does not move workload image, manifest,
-or code digests, and it does not require workload identity token re-minting.
+Changing a deployment-owned key edits the GarzAICluster registry overlay.
+The CES-108 PostSync hook is intended to roll the control-plane Deployments
+after registry-overlay sync. Until CES-108 live verification closes, confirm
+the rollout after sync and run a manual restart if it did not fire. It does
+not move workload image, manifest, or code digests, and it does not require
+workload identity token re-minting.
 
 Changing a workload-release-owned key belongs in `agent-workloads`
 `agents/<id>/agent.yaml`; that moves the workload code digest and requires the
@@ -27,8 +30,9 @@ normal publish, re-pin, and re-mint flow.
 ## Policy Overlay
 
 The `policy.prod.yaml` embedded in the registry overlay is deployment-owned.
-Policy grants, approval overrides, and aggregate budget caps require a
-control-plane restart and do not require re-minting.
+Policy grants, approval overrides, and aggregate budget caps follow the
+same registry-overlay rollout-verification path and do not require
+re-minting.
 
 ## Capability Keys
 

--- a/docs/mandate-apply.md
+++ b/docs/mandate-apply.md
@@ -52,8 +52,11 @@ uv run python scripts/mandate_apply.py enablement.yaml \
 - `apps/agent-workloads/values.yaml`: add the capability to a known worker's
   `AGENT_WORKLOADS_WORKER_CAPABILITIES` claim list.
 
-All of these changes still require the normal PR, CI, merge, Argo sync, and
-control-plane restart path. The enablement document is not dispatch authority.
+All of these changes still require the normal PR, CI, merge, and Argo sync
+path. The CES-108 PostSync hook is intended to roll the control-plane
+Deployments after registry-overlay sync; until live verification closes, confirm
+the rollout or restart manually for overlay-only changes. The enablement
+document is not dispatch authority.
 
 ## What It Refuses Or Names
 

--- a/scripts/grant_ownership.py
+++ b/scripts/grant_ownership.py
@@ -283,9 +283,12 @@ def render_ownership_markdown(ownership: dict[str, Any]) -> str:
         "the deployment registry overlay. Do not hand-edit it; run",
         "`scripts/generate_grant_ownership.py` instead.",
         "",
-        "Changing a deployment-owned key edits the GarzAICluster registry overlay and",
-        "requires a control-plane restart. It does not move workload image, manifest,",
-        "or code digests, and it does not require workload identity token re-minting.",
+        "Changing a deployment-owned key edits the GarzAICluster registry overlay.",
+        "The CES-108 PostSync hook is intended to roll the control-plane Deployments",
+        "after registry-overlay sync. Until CES-108 live verification closes, confirm",
+        "the rollout after sync and run a manual restart if it did not fire. It does",
+        "not move workload image, manifest, or code digests, and it does not require",
+        "workload identity token re-minting.",
         "",
         "Changing a workload-release-owned key belongs in `agent-workloads`",
         "`agents/<id>/agent.yaml`; that moves the workload code digest and requires the",
@@ -314,8 +317,9 @@ def render_ownership_markdown(ownership: dict[str, Any]) -> str:
             "## Policy Overlay",
             "",
             "The `policy.prod.yaml` embedded in the registry overlay is deployment-owned.",
-            "Policy grants, approval overrides, and aggregate budget caps require a",
-            "control-plane restart and do not require re-minting.",
+            "Policy grants, approval overrides, and aggregate budget caps follow the",
+            "same registry-overlay rollout-verification path and do not require",
+            "re-minting.",
             "",
             "## Capability Keys",
             "",
@@ -473,7 +477,7 @@ def apply_grant_edit(
 
 def render_grant_edit_pr_body(result: GrantEditResult) -> str:
     if result.deploy_consequence == CONTROL_PLANE_RESTART:
-        consequence = "overlay-only: CP restart required, no re-mint"
+        consequence = "overlay-only: verify CP rollout after sync, no re-mint"
     else:
         consequence = result.deploy_consequence
     lines = [
@@ -492,8 +496,10 @@ def render_grant_edit_pr_body(result: GrantEditResult) -> str:
         "- No workload manifest, image, or code digest moves.",
         "- No workload identity token re-mint is required.",
         "- No live ConfigMap mutation or runtime bypass is introduced.",
-        "- The registry overlay remains the source of deployment authority and the "
-        "control plane must reload its frozen snapshot after merge.",
+        "- The registry overlay remains the source of deployment authority. The "
+        "CES-108 hook is intended to roll the control plane after sync; until live "
+        "verification closes, confirm the rollout or restart manually so the frozen "
+        "snapshot reloads.",
         "",
         "Refs CES-117.",
         "",

--- a/scripts/set_grant.py
+++ b/scripts/set_grant.py
@@ -79,7 +79,9 @@ def main() -> int:
             f"{result.action} {result.capability_id} {result.key_path} in "
             f"{result.config_path}"
         )
-        print("deploy consequence: overlay-only: CP restart required, no re-mint")
+        print(
+            "deploy consequence: overlay-only: verify CP rollout after sync, no re-mint"
+        )
         if args.create_pr:
             if pr_body_path is None:
                 raise GrantEditError("--create-pr requires a PR body path")

--- a/scripts/workload_enablement.py
+++ b/scripts/workload_enablement.py
@@ -211,7 +211,9 @@ def render_workload_enablement_pr_body(result: WorkloadEnablementResult) -> str:
             "## Authority Invariants",
             "- No live ConfigMap, Secret, or Kubernetes object is mutated.",
             "- Secret values are never read or written; only key names are inspected.",
-            "- Deployment-owned overlay edits require the normal PR and control-plane restart.",
+            "- Deployment-owned overlay edits require the normal PR and Argo sync. "
+            "Until CES-108 live verification closes, confirm the control-plane rollout "
+            "or restart manually.",
             "- Workload-release-owned fields remain refused by the ownership map.",
             "- Import and enablement documents are not dispatch authority by themselves.",
             "",

--- a/tests/test_grant_ownership.py
+++ b/tests/test_grant_ownership.py
@@ -89,7 +89,10 @@ class GrantOwnershipTests(unittest.TestCase):
         self.assertEqual(result.action, "unset")
         self.assertEqual(result.old_value, 4000)
         body = pr_body.read_text()
-        self.assertIn("overlay-only: CP restart required, no re-mint", body)
+        self.assertIn(
+            "overlay-only: verify CP rollout after sync, no re-mint",
+            body,
+        )
         self.assertIn("No workload manifest, image, or code digest moves.", body)
 
     def test_set_grant_allows_session_authority_max_operations_overlay_edit(
@@ -111,7 +114,10 @@ class GrantOwnershipTests(unittest.TestCase):
         self.assertEqual(result.action, "set")
         self.assertEqual(result.new_value, 16)
         body = pr_body.read_text()
-        self.assertIn("overlay-only: CP restart required, no re-mint", body)
+        self.assertIn(
+            "overlay-only: verify CP rollout after sync, no re-mint",
+            body,
+        )
         self.assertIn("No workload manifest, image, or code digest moves.", body)
 
     def test_set_grant_refuses_release_owned_output_schema(self) -> None:


### PR DESCRIPTION
## Summary

- Clarifies that registry-overlay syncs auto-roll the control-plane Deployments through the CES-108 PostSync hook, so overlay-only changes no longer require a separate manual rollout step.
- Records the workload-identity secret-path boundary: token re-mints roll workload Deployments via `agent-workloads-secrets`, while the CP-read HMAC verify seed remains a rare operator rotation outside the overlay hook.
- Updates generated grant-ownership docs and helper-generated PR wording so future overlay PRs do not imply a manual CP restart.

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest tests.test_grant_ownership tests.test_workload_enablement` -> 11 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 56 tests OK
- `git diff --check origin/main...HEAD`
- Remote Config Repo CI is green on head `c58c9d1c0721be429d1c36d28c3c5c0e7ced2072`.

## Verification Note

This PR addresses the CES-108 documentation and recorded-decision gaps only. The remaining Done gate is still live verification via the CES-113 registry-digest metric / next overlay-content sync; no live cluster action is performed here.
