### PR TITLE
Add Citrus Stripe runtime secrets

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,6 +19,9 @@ creation_rules:
   - path_regex: ^secrets/garz-ai/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+  - path_regex: ^secrets/citrus/.*\.enc\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
   - path_regex: ^secrets/spotify-hot-100/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt

--- a/argocd/applications/citrus-secrets.yaml
+++ b/argocd/applications/citrus-secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citrus-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    targetRevision: main
+    path: secrets/citrus
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/secrets/citrus/README.md
+++ b/secrets/citrus/README.md
@@ -1,0 +1,7 @@
+# Citrus Secrets
+
+Encrypted runtime secrets consumed by the `citrus-secrets` Argo CD app.
+
+- `django-secrets.enc.yaml`: Django and Stripe runtime environment for the Citrus Helm release.
+
+Regenerate from `/root/dev/Citrus/.env` with the repo SOPS age key. Commit only encrypted `.enc.yaml` files.

--- a/secrets/citrus/django-secrets.enc.yaml
+++ b/secrets/citrus/django-secrets.enc.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-secrets
+    namespace: default
+type: Opaque
+stringData:
+    STRIPE_PUBLIC_KEY: ENC[AES256_GCM,data:9nkkf+RBca9eY+4gmijgJDgE2Uz69VCe8HLY4CH0DCLBuS7XaypgNSJfidHkKACLictl771Cp7EC8biTwI9EtoKth9cz5dlj0VK8YTQxqZ+WrYHuJyvgzcEvBxNl+Ghd5GMaIZJLiRH4hMw=,iv:cM5GUqeETtH6fB6f5/LO5SjHn3kdJbCgUw0sTLDwFCo=,tag:9nIym7wGU/MFmSxy69kFww==,type:str]
+    STRIPE_PUBLISHABLE_KEY: ENC[AES256_GCM,data:/3ebZWNbYVKF64ztFLq2J7vl/qjaENkq8Yx4O+wwaFc4PA4Zt37mcqL3YSSTYI9lmbOiYBR6WgWS7v0EKdfncHVXyTk506XBhz+WGdkvLtRgQDOWPq8dkgoncQKpiMyp2uW9l0jIOFbKswQ=,iv:er4XBZIGY4aW62zvl8GOUSzIwaYGg+p1FW1kTucul4s=,tag:p+TKjZ7l69QvwWQt6RKtiQ==,type:str]
+    STRIPE_SECRET_KEY: ENC[AES256_GCM,data:xHtIYVy5oV7JnQZ6NayOK41QWUrEX8uO0upqC2C+fOtIaAtRm8wLpIAAlqg6HGvR8iNVOQJ0f3UdO9zLaBTbHyvPRY4wRZKiq3pw992sFevUBht+npdlxSrLOiJC0FvOEi4Ex8TYo8VdHMI=,iv:jWqSVDiB7Euyuu8VldUF6tbkjaQa/XrHAGTqoC8ZA+M=,tag:ETIukBQX6nVKH7FOriSK6g==,type:str]
+    STRIPE_WEBHOOK_SECRET: ENC[AES256_GCM,data:MlGEXYy7s/csiYhNWjFqNP6UXCqNCKxEXGO2mQcOxQkjQfIflUw=,iv:i2PUk7MiaD4pI0I+D3ZHsuYIesnOgVYOj/pLy8llBxo=,tag:WmMRbqfzWXWmvi0382IPQg==,type:str]
+    STRIPE_WEBHOOK_SECRET_DEV: ENC[AES256_GCM,data:X1tiXKQEXw7kmZD5L+mfJ6OYbQeLS79WCEDWqM/QE+iYOeezhw4=,iv:P7Fs5hGEI0D9xCIMgmxMc/rbh7PUEFyVeFGtojKvZ28=,tag:Qt9XePTEKGk7hmpUo0n82Q==,type:str]
+    STRIPE_WEBHOOK_SECRET_PROD: ENC[AES256_GCM,data:GkirzmsJFo6Hy0hzkIGcSzD70TTLH3oHYvJuOrZkCYb8Q8ZK570=,iv:uPpDsPZrq8fv0JrpP3ZF6/bf8B3DIlDoYo6oNbGD890=,tag:TI/fJsuY8oXj0FDonE9RYA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaWkZrNncxLzRMT2ErTnRJ
+            T3VHSGt1aktSTTZCeW5QbEJuVjMzNnFFZno4Cm5uejBNVUxYMW4xUGJtb1Z4Ymo0
+            c29rckxYaitiemlFcHFESXZSRXhDZE0KLS0tIDBmRzJjQXo3Mks3UUhlZk11NExq
+            K3RoZU45blpDaWQ5RFZiSzMyTHI5Qk0KDnbJZlDx+CsRNWp/tIAG7HvbKiKYjRlo
+            Bf6cHTb07Vr3NveKFUoGL9eF9amRH070A3PQZwvpn5dmTSj0npy2cg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-17T03:39:53Z"
+    mac: ENC[AES256_GCM,data:SXBh/zcp85mG5r3LEdOdfoUYDkPkhoy8D/fS4gZG3boILN38C9NfLpBwVqHOY4LjWKYwKZ/ZbtEmpB8VVO0hcKT3tyAIX3exo+Z0esDNDk+KJEE7BMcXiV8c5lh+Is/tW6duSFJTrbqVfi4/sSaaq9dqNHuXXzaWun7wrpg151Q=,iv:MP331nvxUFx0BHw/N8KgyMhrAxl7xI0SRAbkfzY/4ew=,tag:KdWRgt4W8K2HQHRFRcF6jA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus/ksops.yaml
+++ b/secrets/citrus/ksops.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: citrus-secrets
+files:
+  - django-secrets.enc.yaml

--- a/secrets/citrus/kustomization.yaml
+++ b/secrets/citrus/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+generators:
+  - ksops.yaml


### PR DESCRIPTION
Adds the SOPS-encrypted Citrus django-secrets manifest and an Argo CD secrets Application so Stripe runtime configuration is managed through GitOps.