### PR TITLE
CES-154: re-pin control-plane to sha-aafdb130d70e (NetworkPolicy fix + applies 015 via CES-167 hook)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-fdefab075aeb
+  tag: sha-aafdb130d70e
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: fdefab075aeba6d9c69001a939b8edfb6cdb39c3
+      targetRevision: aafdb130d70e82498e9d1bb10fc7190ff7249b13
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## What
Bumps the `agent-control-plane` CP pin to commit `aafdb130` — **both** the chart `targetRevision` and the image `tag` (`sha-aafdb130d70e`), same commit per the deploy invariant.

- `apps/agent-control-plane/values.yaml`: `tag` `sha-fdefab075aeb` → `sha-aafdb130d70e`
- `argocd/applications/agent-control-plane.yaml`: `targetRevision` `fdefab0…` → `aafdb130…`

## Why
Deploys the **ap#186 synthetic-live-verify NetworkPolicy fix** (CES-154) — the chart change that lets the CES-154 CronJob probe reach the CP. (ap#187 added `helm/mandate/**` to the publish path filter so this chart-only change produced a pinnable image.)

## ⚠️ Migration-bearing — applies 015 via the CES-167 PreSync hook
`aafdb130` carries migration **`015_job_lease_broker_envelope.sql`** (CES-162); prod DB is at **`001-014`**. The chart at `aafdb130` renders the **CES-167 Argo PreSync hook** (`useArgoHooks: true`, `argoHook: PreSync`), so on sync `mandate-migrate` applies `015` **before** the new pods roll. This is the first real live-test of CES-167.

Safe: old CP (`fdefab0`) keeps serving through the surge-first rollout (no outage); if the PreSync hook doesn't fire, the new pods crash-loop `pending: 015` while the old serves, and I apply `015` via the proven manual `mandate-migrate` Job.

## Provenance
`sha-aafdb130d70e` DOCR-verified (manifest `sha256:b5ce238d3f62…`, published from the merged `aafdb130` commit, run 27672514694 / completed-success).

## After merge (I drive, operator-gated)
1. Sync `splattop-root` → `agent-control-plane`; watch the PreSync `mandate-migrate` hook apply `015` (→ CES-167 live-verify), new CP healthy on `sha-aafdb130d70e`, schema `001-015`.
2. Un-suspend `agent-control-plane-synthetic-live-verify` CronJob.
3. Sync `splattop` app (the `MandateSyntheticLiveVerifyFailed` rule).
4. Re-verify: probe POSTs `/v1/tasks` (NetworkPolicy now allows it) → `mandate.deploy.smoke` green → CES-154 Done; CES-167 Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)