### PR TITLE
CES-154: bump control plane to synthetic NetworkPolicy fix

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-fdefab075aeb
+  tag: sha-aafdb130d70e
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: fdefab075aeba6d9c69001a939b8edfb6cdb39c3
+      targetRevision: aafdb130d70e82498e9d1bb10fc7190ff7249b13
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## Summary
- Bump the agent-control-plane Helm source to `aafdb130d70e82498e9d1bb10fc7190ff7249b13`.
- Bump the deployed control-plane image tag to `sha-aafdb130d70e`.
- Picks up the CES-154 NetworkPolicy fix for synthetic live-verify pods plus the publish workflow path fix that produced the matching runtime image.

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache-splattop uv run python scripts/check_control_plane_release_pin.py`
- `env UV_CACHE_DIR=/tmp/uv-cache-splattop uv run python scripts/check_agent_control_plane_registry_compat.py --agent-platform-repo /root/dev/agent-platform-aafdb130`
- `env UV_CACHE_DIR=/tmp/uv-cache-splattop uv run python -m unittest discover -s tests`
- `git diff --check`
- `helm lint /root/dev/agent-platform-aafdb130/helm/mandate -f apps/agent-control-plane/values.yaml`
- `helm template agent-control-plane /root/dev/agent-platform-aafdb130/helm/mandate -f apps/agent-control-plane/values.yaml --show-only templates/networkpolicy.yaml`

Publish workflow `27672514694` completed successfully for `aafdb130d70e82498e9d1bb10fc7190ff7249b13`, producing `registry.digitalocean.com/sendouq/agent-platform:sha-aafdb130d70e`.

After merge/sync, unsuspend the CES-154 synthetic live-verify CronJob and verify the probe can POST `/v1/tasks`.