### PR TITLE
CES-167: run control-plane migrations as Argo-only hooks

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-aafdb130d70e
+  tag: sha-e5f987780a88
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -52,7 +52,8 @@ env:
 
 migrations:
   enabled: true
-  useHelmHooks: true
+  useHelmHooks: false
+  useArgoHooks: true
   disableStartupSchemaMigration: true
 
 localWorker:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: aafdb130d70e82498e9d1bb10fc7190ff7249b13
+      targetRevision: e5f987780a8864305b1b962b8edcc0f967359751
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -86,6 +86,14 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {"consequence_class": "reversible_staging"},
         )
 
+    def test_agent_control_plane_migrations_are_argo_only(self) -> None:
+        migrations = self.control_plane_values["migrations"]
+
+        self.assertIs(migrations["enabled"], True)
+        self.assertIs(migrations["useHelmHooks"], False)
+        self.assertIs(migrations["useArgoHooks"], True)
+        self.assertIs(migrations["disableStartupSchemaMigration"], True)
+
     def test_opencode_apply_import_is_executor_only_and_admin_confirmed(self) -> None:
         imports = YAML_PARSER.load(self.data["workload_imports.yaml"])
         imports_by_id = {entry["id"]: entry for entry in imports["imports"]}


### PR DESCRIPTION
## Summary

- Re-pin the live `agent-control-plane` chart source to agent-platform AP #189 merge commit `e5f987780a8864305b1b962b8edcc0f967359751`.
- Update the deployed control-plane image tag to the matching published image `sha-e5f987780a88`.
- Set the deployed migration values to explicit Argo-only hooks: `useHelmHooks: false`, `useArgoHooks: true`.
- Add a regression test that keeps the control-plane values in Argo-only migration mode.

## Why

AP #189 made the Mandate chart suppress Helm hook annotations whenever Argo hook mode is enabled and flipped the chart default to Argo-only migrations. This SplatTopConfig PR now deploys that merged chart/image and keeps the live values explicit, so the migration Job renders as an Argo `PreSync` hook without any `helm.sh/hook` annotations.

## Validation

- AP #189 publish workflow succeeded for `e5f987780a8864305b1b962b8edcc0f967359751`: `registry.digitalocean.com/sendouq/agent-platform:sha-e5f987780a88`.
- `env UV_CACHE_DIR=/tmp/uv-cache-splattopconfig uv run --directory /root/dev/SplatTopConfig-ces167-argo-hooks python scripts/check_control_plane_release_pin.py`
- `env UV_CACHE_DIR=/tmp/uv-cache-splattopconfig uv run --directory /root/dev/SplatTopConfig-ces167-argo-hooks python -m unittest tests.test_agent_control_plane_registry_overlay.AgentControlPlaneRegistryOverlayTests.test_agent_control_plane_migrations_are_argo_only tests.test_control_plane_release_pin`
- `env UV_CACHE_DIR=/tmp/uv-cache-splattopconfig uv run --directory /root/dev/SplatTopConfig-ces167-argo-hooks python scripts/generate_grant_ownership.py --check`
- `env UV_CACHE_DIR=/tmp/uv-cache-splattopconfig uv run --directory /root/dev/SplatTopConfig-ces167-argo-hooks python -m unittest discover -s tests` (46 tests)
- `env UV_CACHE_DIR=/tmp/uv-cache-agent-platform uv run --directory /root/dev/agent-platform --extra dev --with ruamel.yaml python /root/dev/SplatTopConfig-ces167-argo-hooks/scripts/check_agent_control_plane_registry_compat.py --repo-root /root/dev/SplatTopConfig-ces167-argo-hooks --agent-platform-repo /root/dev/agent-platform`
- Rendered the pinned AP #189 Mandate chart with `apps/agent-control-plane/values.yaml`; the migration Job uses image `sha-e5f987780a88` and contains only `argocd.argoproj.io/hook`, `argocd.argoproj.io/hook-delete-policy`, and `argocd.argoproj.io/sync-wave` annotations.
- `git -C /root/dev/SplatTopConfig-ces167-argo-hooks diff --check`

Related agent-platform chart hardening PR: https://github.com/cesaregarza/agent-platform/pull/189

Linear: CES-167