### PR TITLE
CES-167+154+230: re-pin control-plane to sha-3e7c69c956e3 (Argo-only migrations, applies 016)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-aafdb130d70e
+  tag: sha-3e7c69c956e3
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -52,7 +52,8 @@ env:
 
 migrations:
   enabled: true
-  useHelmHooks: true
+  useHelmHooks: false
+  useArgoHooks: true
   disableStartupSchemaMigration: true
 
 localWorker:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: aafdb130d70e82498e9d1bb10fc7190ff7249b13
+      targetRevision: 3e7c69c956e3d2b2d1d01cf17008fb230b9d3fd2
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## What
Consolidated CP-bump to commit `3e7c69c9` — chart `targetRevision` + image both `sha-3e7c69c956e3` (same commit, per the deploy invariant). **No worker re-mint** — CP-only image; doesn't touch agent-workloads images/overlay pins/identity tokens (drift gate stays green).

- `values.yaml`: `tag` `sha-aafdb130d70e` → `sha-3e7c69c956e3`; `migrations.useHelmHooks: true`→`false` + add `useArgoHooks: true` (**folds #196**)
- `agent-control-plane.yaml`: `targetRevision` `aafdb130` → `3e7c69c9`

## Carries (all merged + gated this session)
- **CES-167** Argo-only migration hook fix (ap#189) — makes the PreSync hook actually fire under Argo (the dual helm+argo annotation was being dropped).
- **CES-154** NetworkPolicy ingress (ap#186) + egress (ap#191) for the synthetic probe.
- **CES-230 Slice A** (ap#190) — neutral internal authority (no behavior change).
- **CES-229** git-deliverer code (ap#188) — **disabled-by-default**, not enabled here.
- Migration **016** (git delivery records).

## ⚠️ Migration-bearing (016) — the CES-167 live test
Prod is at schema `015`; `3e7c69c9` carries `016`. With `useHelmHooks:false useArgoHooks:true`, the migration Job renders **Argo-only**, so on sync the **PreSync hook should fire + apply `016` automatically** — this is the live verification of the CES-167 fix. If the hook still doesn't fire (regression), old CP keeps serving (surge-first, no outage) and I apply `016` via the manual `mandate-migrate` Job.

## Provenance
`sha-3e7c69c956e3` DOCR-verified (manifest `sha256:2e04feb0…`, = `latest`, published off the merged `3e7c69c9` commit).

## After merge (I drive)
1. Sync `splattop-root` → `agent-control-plane`; **watch the PreSync `mandate-migrate` hook apply `016`** (CES-167✓), new CP Healthy on `sha-3e7c69c956e3` at schema `001-016`, no crash-loop.
2. Un-suspend `agent-control-plane-synthetic-live-verify` CronJob; re-verify the probe POSTs `/v1/tasks` → `mandate.deploy.smoke` green (CES-154✓).
3. Sync `splattop` app for the `MandateSyntheticLiveVerifyFailed` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)