### PR TITLE
CES-231: re-pin control-plane to sha-dc7ca284d64c (deploy-smoke output-release fix)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-3e7c69c956e3
+  tag: sha-dc7ca284d64c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 3e7c69c956e3d2b2d1d01cf17008fb230b9d3fd2
+      targetRevision: dc7ca284d64c6cee922b77355c82800613cdb016
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
**Operator-gated CP-bump — draft for your go.** Re-pins the control plane to the image carrying ap#192 (CES-231).

## What this deploys
ap#192 (merge `dc7ca284d64c`): `mandate.deploy.smoke` result key neutralized (`lease`→`lease_observed`) + `PLATFORM_AUTHORITY_RESULT_KEYS` denylist hardened, so the smoke result passes the `patch_aware` output gate. **Unblocks CES-154** — the synthetic-live-verify probe can finally go green.

## Change (2-file pin, same commit)
- `apps/agent-control-plane/values.yaml`: `image.tag` → `sha-dc7ca284d64c`
- `argocd/applications/agent-control-plane.yaml`: `targetRevision` → `dc7ca284d64c6cee922b77355c82800613cdb016`

## Provenance
Image **DOCR-verified**: `sha-dc7ca284d64c` → `sha256:d08ad3c206aa7e7c834559c61f552f86187dc29b65869e98407c19bd5e077585`, published 2026-06-17 22:56:45Z by the `Publish Mandate Control Plane Image` run on the merge commit. Tag ↔ targetRevision ↔ merge SHA all consistent.

## No re-mint / no migration
- **CP-only** change (agent-platform built-in worker + denylist) — no agent-workloads source change → `code_digest` unchanged → **no workload-identity re-mint**, drift gate untouched.
- **No new migration** (016 already applied at #197) → the Argo PreSync migration hook will not fire; this is a clean image swap. (So CES-167's hook-ordering residual is NOT exercised here — it waits for the next migration-bearing bump.)

## Deploy steps (on your go)
1. Merge → hard-refresh + sync `splattop-root` (app-of-apps) to the merge SHA.
2. Sync `agent-control-plane` to the merge SHA → poll Synced/Healthy on `sha-dc7ca284d64c`.
3. Un-suspend `agent-control-plane-synthetic-live-verify` CronJob → trigger probe → confirm `mandate.deploy.smoke` job `succeeded` / `output_gate_status=passed` → **closes CES-154 + CES-231**.

Near-zero-downtime (replicas=1 surge-first). No worker restart needed.