### PR TITLE
Suspend Mandate synthetic live verify

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -198,7 +198,7 @@ postgresSweep:
   enabled: true
 
 syntheticLiveVerify:
-  enabled: true
+  enabled: false
   schedule: "*/5 * * * *"
   baseUrl: http://agent-control-plane:80
   actor:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -262,10 +262,10 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "evals.yaml",
         )
 
-    def test_synthetic_live_verify_uses_dedicated_probe_actor(self) -> None:
+    def test_synthetic_live_verify_keeps_dedicated_probe_actor_disabled(self) -> None:
         synthetic = self.control_plane_values["syntheticLiveVerify"]
 
-        self.assertTrue(synthetic["enabled"])
+        self.assertFalse(synthetic["enabled"])
         self.assertEqual(synthetic["schedule"], "*/5 * * * *")
         self.assertEqual(synthetic["baseUrl"], "http://agent-control-plane:80")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- Disable the agent-control-plane synthetic live verify CronJob in production values.
- Keep the postgres sweep CronJob enabled.

## Verification
- `uv run python -m unittest tests.test_agent_control_plane_registry_overlay`
- `helm template agent-control-plane /root/dev/agent-platform/helm/mandate -f /tmp/SplatTopConfig-stop-smoke/apps/agent-control-plane/values.yaml | rg -n "synthetic-live-verify|kind: CronJob|agent-control-plane-postgres-sweep"` renders only the postgres sweep CronJob.
- Live `agent-control-plane-synthetic-live-verify` CronJob was patched to `spec.suspend=true` immediately.
