### PR TITLE
Fix registry overlay restart hook image

### DIFF
--- a/apps/agent-control-plane-registry-overlay/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-hook.yaml
@@ -24,7 +24,7 @@ spec:
         - name: rollout-restart
           # CES-108: the control plane boot-caches the registry snapshot; an
           # overlay sync without a rollout leaves stale authority serving.
-          image: rancher/kubectl:v1.33.4@sha256:5c0d769f262a320aef3a37e74188ebd5376e8acf2db85421a9cc138df1fcb6fb
+          image: alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
           command:
             - /bin/sh
             - -ec


### PR DESCRIPTION
## Summary
- replace the registry overlay restart hook image with a pinned  image that includes 
- preserves the existing shell-based rollout restart/status script and RBAC

## Validation
- docker run --rm --entrypoint /bin/sh alpine/k8s:1.33.4 -ec 'kubectl version --client=true --output=yaml >/dev/null && echo shell-ok'
- kubeconform -schema-location default -strict -summary -exit-on-error apps/agent-control-plane-registry-overlay/restart-hook.yaml
- kubectl create --dry-run=client -f apps/agent-control-plane-registry-overlay/restart-hook.yaml -o yaml >/tmp/restart-hook-dryrun.yaml
- git diff --check