### PR TITLE
Allow registry overlay hook rollout watch

### DIFF
--- a/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
@@ -24,6 +24,9 @@ rules:
       - agent-control-plane-local-worker
       - agent-control-plane-model-gateway
     verbs: ["get", "watch", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary
- add namespace-level list/watch on deployments for the registry overlay restart hook
- keep patch permission scoped to the four named control-plane deployments

## Validation
- kubeconform passed for apps/agent-control-plane-registry-overlay/restart-rbac.yaml
- kubectl apply --dry-run=client passed for apps/agent-control-plane-registry-overlay/restart-rbac.yaml
- git diff --check passed