### PR TITLE
Bump agent-control-plane to sha-b24a1d83 (CES-136 leg 2 + CES-232)

### DIFF
--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 71fdfa750be3cad4ccc3765b01dd208db2ab52d5
+      targetRevision: b24a1d836f04a86356378964e6b8445c063c378c
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps the CP Argo app `targetRevision` `71fdfa750be3` → `b24a1d836f04` (agent-platform main).

**Carries:**
- **CES-136 leg 2** (agent-platform #195): align approval resolver surface digest — thread-posted approval clicks now derive surface authority from the parent channel so the resolve-path `surface_scope_digest` matches the submit (fixes the live approval 403). Reviewed clean + non-weakening. Adds WARNING logging of the AdmissionError reason + both digests.
- **CES-232**: workload-identity fail-closed config validator (has been waiting for its own CP bump since the 71fdfa75 deploy).

Image `sha-b24a1d836f04` is built + published (Publish workflow green). Deploy = merge + Argo-sync `agent-control-plane`. Leg 1 (approval loader) is already live on the droplet; this lands leg 2 so a live approve click can resolve end-to-end → closes CES-136, unblocks CES-105/229.