### PR TITLE
Bump CP image tag to sha-b24a1d836f04 (completes #208)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-71fdfa750be3
+  tag: sha-b24a1d836f04
   pullPolicy: IfNotPresent
 
 secretKeys:


### PR DESCRIPTION
#208 bumped the chart `targetRevision` but missed `image.tag` in values.yaml, so the CP kept running `sha-71fdfa750be3`. This bumps the image tag to `sha-b24a1d836f04` to actually deploy CES-136 leg 2 (#195) + CES-232. Image is built + published.