### PR TITLE
Bump CP to sha-ec8a3fd020a1 (CES-136 leg 2 final — #196)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-b24a1d836f04
+  tag: sha-ec8a3fd020a1
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: b24a1d836f04a86356378964e6b8445c063c378c
+      targetRevision: ec8a3fd020a13b6b0542c20716672eab2043f6e9
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps both the chart `targetRevision` and `image.tag` to `ec8a3fd0` / `sha-ec8a3fd020a1`.

Carries agent-platform **#196** (CES-136 leg 2 final): `_same_surface_authority` now compares conversation authority by canonical genuine `guild_id`/`channel_id` instead of the divergent `target_ref` (submit stores an Edge-hashed ref; the approval click carries the raw channel id). Reviewed non-weakening (adds guild_id, fail-closes when provenance absent, leaves `surface_scope_digest` for stored/audit). Structural fix — ends the field-by-field surface drift so the approval click finally resolves.