### PR TITLE
Bump CP to sha-6e8cd225756c (CES-136 channel-type fix #197)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-ec8a3fd020a1
+  tag: sha-6e8cd225756c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: ec8a3fd020a13b6b0542c20716672eab2043f6e9
+      targetRevision: 6e8cd225756c8a5a3eca14234f839e554bb3c486
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps chart `targetRevision` + `image.tag` to `6e8cd225`. Carries agent-platform **#197**: `_discord_surface_channel` resolves `parent_id` only for thread types (10/11/12); regular channels keep their raw channel_id even with a category parent. Fixes the post-#196 approval 403 (verified by live execution). Final leg-2 fix — a live approve click should resolve after this.