### PR TITLE
CES-49: Document Postgres restore runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 
 ## Quick links
 
-- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/developer-cheat-sheet.md`
+- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/developer-cheat-sheet.md`
 - KSOPS deep dive and CMP recipe: `docs/ksops-llm-response.md`
 - Argo objects: `argocd/` (AppProjects, Applications, AppSets)
 - Charts/values: `helm/` and `apps/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,10 @@ Read them in roughly this order when contributing here:
 6. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
 7. `mandate-apply.md` – local declarative enablement planner for Mandate
    workload capability wiring.
-8. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-9. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+8. `runbooks/postgres-restore.md` – DigitalOcean managed Postgres restore
+   procedure for the live Mandate `agent-control-plane` deployment.
+9. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+10. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -1,0 +1,293 @@
+# DigitalOcean Postgres Restore Runbook
+
+This runbook restores the Mandate control database used by the live
+`agent-control-plane` deployment. It is a deployment-owned operational procedure,
+not Mandate authority: it does not grant rights to agents, workers, prompts,
+model output, task payloads, or workload parameters.
+
+The generic recovery contract lives in
+`agent-platform/docs/postgres-restore-contract.md`. This file is the concrete
+DigitalOcean and GitOps instance for GarzAICluster.
+
+Cost-bearing restore drills and live infrastructure mutations require explicit
+operator approval. Codex may update this source-controlled runbook, but must not
+create, fork, delete, or repoint managed database clusters unattended.
+
+## Current Posture
+
+Observed on 2026-06-24 with read-only `doctl` commands against the `cegarza`
+DigitalOcean context:
+
+| Field | Value |
+| --- | --- |
+| Managed database name | `db-postgresql-nyc3-xscraper` |
+| Managed database ID | `3adbbc39-dd07-4c0c-b172-081a247810d6` |
+| Engine/version | PostgreSQL 16 |
+| Region | `nyc3` |
+| Nodes | 1 |
+| Plan | `db-amd-1vcpu-2gb` |
+| Status | online |
+| Latest observed daily backup | `2026-06-24T02:32:18Z` |
+| Observed backup range | `2026-06-17` through `2026-06-24` |
+| Live namespace | `agent-control-plane` |
+| Live Argo apps | `agent-control-plane`, `agent-control-plane-secrets` |
+| Runtime Kubernetes Secret | `agent-control-plane-secrets` |
+| Runtime secret source | `secrets/agent-control-plane/runtime-secret.enc.yaml` |
+| Values overlay | `apps/agent-control-plane/values.yaml` |
+| Chart source | `argocd/applications/agent-control-plane.yaml` |
+| Public hostname | `agent-control-plane.garz.ai` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-c87300b78d5d` |
+
+DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
+restore by forking a new database cluster. Restores must create a new cluster;
+do not restore in place over the current writer.
+
+## Accepted Recovery Targets
+
+Current RPO: restore to the latest available DigitalOcean PITR point inside the
+seven-day native recovery window. If the incident is discovered after that
+window, the native managed-database restore path is insufficient and operators
+must treat it as data loss unless a separate logical export or longer-retention
+snapshot exists.
+
+Current RTO: restore the private deployment within 4 hours from incident
+declaration to a healthy `/readyz` on the restored cluster. This includes the
+time to fork the managed database, update encrypted secrets, let Argo sync, run
+the schema check, and verify service health.
+
+The current API deployment is deliberately single-replica (`replicaCount: 1`),
+and the chart has no API PodDisruptionBudget. The model gateway has its own PDB,
+but the API, local worker, callback adapter, and git deliverer should be treated
+as single-replica services in this deployment. A database restore is therefore a
+service-interruption event, not a zero-downtime operation. This is acceptable for
+the current private deployment and must be revisited before a production pilot.
+
+The callback retry posture fits inside the restore window: the callback adapter
+defaults to 10 attempts, exponential backoff capped at 300 seconds, and a
+60-second delivery lease. Seven-day PITR covers the retry window. Audit
+investigations that need recovery to a pre-incident database state must happen
+inside the same seven-day native recovery window unless longer-retention backup
+tooling is added outside this slice.
+
+## Restore Procedure
+
+### 1. Freeze Writers
+
+Stop all Mandate writers before pointing anything at a restored database. Do not
+delete the existing managed database cluster.
+
+```bash
+kubectl -n agent-control-plane scale deploy/agent-control-plane --replicas=0
+kubectl -n agent-control-plane scale deploy/agent-control-plane-local-worker --replicas=0
+kubectl -n agent-control-plane scale deploy/agent-control-plane-callback-adapter --replicas=0
+kubectl -n agent-control-plane scale deploy/agent-control-plane-model-gateway --replicas=0
+kubectl -n agent-control-plane scale deploy/agent-control-plane-git-deliverer --replicas=0
+```
+
+If Argo reverts these scales, pause auto-sync where it exists or commit a
+temporary values override in this repo. The invariant is that the old and
+restored clusters must not both receive Mandate writes.
+
+### 2. Choose The Restore Point
+
+List the live cluster and backup points:
+
+```bash
+doctl databases list --format ID,Name,Engine,Version,Region,Size,Status
+doctl databases backups 3adbbc39-dd07-4c0c-b172-081a247810d6 --format Created,Size
+```
+
+Use the latest transaction for infrastructure failure recovery. Use an explicit
+timestamp for accidental deletion, bad migration, or operator error recovery.
+
+### 3. Restore To A New Cluster
+
+Restore to a new managed database cluster. Omitting
+`--restore-from-timestamp` restores the latest available point.
+
+```bash
+RESTORE_NAME="mandate-restore-$(date -u +%Y%m%d%H%M)"
+SOURCE_CLUSTER_ID="3adbbc39-dd07-4c0c-b172-081a247810d6"
+
+doctl databases fork "$RESTORE_NAME" \
+  --restore-from-cluster-id "$SOURCE_CLUSTER_ID" \
+  --wait
+```
+
+For a point-in-time restore:
+
+```bash
+doctl databases fork "$RESTORE_NAME" \
+  --restore-from-cluster-id "$SOURCE_CLUSTER_ID" \
+  --restore-from-timestamp "2026-06-21 02:23:04 +0000 UTC" \
+  --wait
+```
+
+Keep the original cluster online until the restored deployment is verified and
+the owner approves cleanup.
+
+### 4. Repoint Encrypted Secrets
+
+Update only Postgres connection strings in the deployment repo's encrypted
+runtime secret. Do not rotate service tokens as part of database restore unless
+token compromise is part of the incident.
+
+```bash
+cd /path/to/GarzAICluster
+export SOPS_AGE_KEY_FILE=keys/age-private.txt
+sops secrets/agent-control-plane/runtime-secret.enc.yaml
+```
+
+Set `AGENT_PLATFORM_DATABASE_URL` to the restored cluster's private connection
+string for the existing Mandate app role. If the restored read-only role is on
+the same managed cluster, update `AGENT_PLATFORM_READONLY_SQL_DATABASE_URL` to
+the restored cluster as well. Preserve the database name, schema, and role
+posture. If the restored cluster does not contain the expected app/read-only
+roles, stop and repair the restored cluster with deployment tooling before
+syncing the application.
+
+Commit the encrypted secret change and sync secrets:
+
+```bash
+argocd app sync agent-control-plane-secrets
+argocd app wait agent-control-plane-secrets --health --sync --timeout 300
+```
+
+### 5. Check Schema Without Mutating It
+
+Run the check-only schema command against the restored database before scaling
+service pods. This command calls `assert_postgres_schema_current` and fails if
+tracked migrations are pending or if an applied migration checksum drifted. It
+does not apply DDL.
+
+```bash
+SCHEMA_CHECK_JOB="mandate-schema-check-$(date -u +%Y%m%d%H%M%S)"
+
+kubectl -n agent-control-plane apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${SCHEMA_CHECK_JOB}
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: schema-check
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-c87300b78d5d
+          envFrom:
+            - secretRef:
+                name: agent-control-plane-secrets
+          command: ["mandate-postgres-schema-check"]
+EOF
+
+kubectl -n agent-control-plane wait --for=condition=complete "job/${SCHEMA_CHECK_JOB}" --timeout=300s
+kubectl -n agent-control-plane logs "job/${SCHEMA_CHECK_JOB}"
+kubectl -n agent-control-plane delete "job/${SCHEMA_CHECK_JOB}"
+```
+
+If migrations are pending, stop the restore and decide whether to run
+`mandate-migrate` with the current image or to roll the app image forward/back
+to one compatible with the restored ledger.
+
+### 6. Verify Rollback Compatibility Before Argo Reverts
+
+Before reverting the Argo app to a prior image, prove the prior image can run
+against the already-expanded schema:
+
+1. Confirm the prior image contains every migration already present in
+   `agent_platform.schema_migrations`.
+2. Run `mandate-postgres-schema-check` with that prior image against the
+   restored database.
+3. Confirm `/readyz` in a one-off pod or temporary deployment before allowing
+   Argo to roll the live deployment.
+
+Do not run reversal DDL to make an old image fit. Use a reviewed forward
+migration or restore to an earlier point inside the PITR window.
+
+### 7. Resume Service
+
+Sync the application and wait for health:
+
+```bash
+argocd app sync agent-control-plane
+argocd app wait agent-control-plane --health --sync --timeout 600
+
+kubectl -n agent-control-plane rollout status deploy/agent-control-plane
+kubectl -n agent-control-plane rollout status deploy/agent-control-plane-local-worker
+kubectl -n agent-control-plane rollout status deploy/agent-control-plane-callback-adapter
+kubectl -n agent-control-plane rollout status deploy/agent-control-plane-model-gateway
+kubectl -n agent-control-plane rollout status deploy/agent-control-plane-git-deliverer
+```
+
+Verify the public and in-cluster health surfaces:
+
+```bash
+kubectl -n agent-control-plane port-forward svc/agent-control-plane 18080:80
+curl -fsS http://127.0.0.1:18080/readyz
+curl -fsS https://agent-control-plane.garz.ai/readyz
+curl -fsS https://agent-control-plane.garz.ai/healthz
+```
+
+Run one low-risk governed smoke through the existing private admin path. The
+safe target is `mandate.deploy.smoke`; `approval.probe` is also acceptable when
+the live Discord approval path is the thing being verified. Confirm the job is
+accepted, leased, completed or correctly approval-gated, output-gated, audited,
+and delivered through callbacks.
+
+### 8. Close Out
+
+After the restored deployment is healthy:
+
+1. Record the restore in the drill ledger below.
+2. Preserve the old cluster until the operator has exported any forensic data
+   needed for the incident review.
+3. Delete the scratch/old cluster only after the owner explicitly approves.
+4. Record any RPO/RTO miss as a production-readiness follow-up.
+
+## Hash-Chain Semantics
+
+Snapshot and PITR restores preserve the `agent_platform.run_events` rows and
+their `previous_event_hash` / `event_hash` chain exactly as of the restore point.
+Chain verification should continue to pass for every retained run whose events
+were included in the restored snapshot.
+
+Partial or row-level recovery is different. If an operator manually copies rows
+between clusters, deletes audit rows, or reconstructs only part of a run, the
+audit hash chain is no longer automatically continuous. The expected behavior is:
+
+1. Do not silently splice rows into the live audit chain.
+2. Verify the restored subset with `audit.digest` or the hash-chain verifier.
+3. Record the recovery boundary in the incident notes, including source cluster,
+   restore timestamp, copied tables, and first affected `run_id`.
+4. Re-anchor future trust by treating the post-recovery event stream as a new
+   operational epoch in the incident report. The code does not yet persist an
+   external anchor; do not claim cryptographic continuity across manual row-level
+   recovery.
+
+## Drill Ledger
+
+| Date | Type | Operator | Restore point | Schema check | `/readyz` | Smoke task | Elapsed RTO | Cleanup |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-06-24 | Read-only posture check | Codex via `doctl` | No restore created; confirmed live cluster metadata and daily backups from 2026-06-17 through 2026-06-24. | Not run | Not run | Not run | Not measured | No scratch resource created |
+
+Live scratch-restore drill status: pending operator approval. A completed drill
+must add a row above with the scratch cluster name, restore point, schema-check
+result, `/readyz` result, smoke-task result, elapsed RTO, and cleanup outcome.
+
+## References
+
+- DigitalOcean PostgreSQL restore docs:
+  `https://docs.digitalocean.com/products/databases/postgresql/how-to/restore-from-backups/`
+- DigitalOcean PostgreSQL limits:
+  `https://docs.digitalocean.com/products/databases/postgresql/details/limits/`
+- Generic Mandate restore contract:
+  `agent-platform/docs/postgres-restore-contract.md`
+- Deployment values:
+  `apps/agent-control-plane/values.yaml`
+- Deployment applications:
+  `argocd/applications/agent-control-plane.yaml` and
+  `argocd/applications/agent-control-plane-secrets.yaml`

--- a/tests/test_postgres_restore_runbook.py
+++ b/tests/test_postgres_restore_runbook.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "postgres-restore.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+ROOT_README = REPO_ROOT / "README.md"
+VALUES = REPO_ROOT / "apps" / "agent-control-plane" / "values.yaml"
+APPLICATION = REPO_ROOT / "argocd" / "applications" / "agent-control-plane.yaml"
+SECRETS_APPLICATION = (
+    REPO_ROOT / "argocd" / "applications" / "agent-control-plane-secrets.yaml"
+)
+RUNTIME_SECRET = REPO_ROOT / "secrets" / "agent-control-plane" / "runtime-secret.enc.yaml"
+
+YAML_PARSER = YAML(typ="safe")
+
+
+class PostgresRestoreRunbookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runbook = RUNBOOK.read_text(encoding="utf-8")
+        cls.normalized = _normalized(cls.runbook)
+        cls.values = _load_yaml(VALUES)
+        cls.application = _load_yaml(APPLICATION)
+        cls.secrets_application = _load_yaml(SECRETS_APPLICATION)
+        cls.runtime_secret = _load_yaml(RUNTIME_SECRET)
+
+    def test_runbook_is_discoverable_from_readmes(self) -> None:
+        self.assertIn(
+            "docs/runbooks/postgres-restore.md",
+            ROOT_README.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "runbooks/postgres-restore.md",
+            DOCS_README.read_text(encoding="utf-8"),
+        )
+
+    def test_runbook_records_live_cluster_posture_and_manifest_refs(self) -> None:
+        image = self.values["image"]
+        image_ref = f"{image['repository']}:{image['tag']}"
+        hostname = self.values["ingress"]["hosts"][0]
+        runtime_secret_name = self.values["global"]["runtimeSecretName"]
+
+        self.assertIn("db-postgresql-nyc3-xscraper", self.runbook)
+        self.assertIn("3adbbc39-dd07-4c0c-b172-081a247810d6", self.runbook)
+        self.assertIn("PostgreSQL 16", self.runbook)
+        self.assertIn("nyc3", self.runbook)
+        self.assertIn("db-amd-1vcpu-2gb", self.runbook)
+        self.assertIn("2026-06-17", self.runbook)
+        self.assertIn("2026-06-24T02:32:18Z", self.runbook)
+
+        self.assertIn(hostname, self.runbook)
+        self.assertIn(runtime_secret_name, self.runbook)
+        self.assertIn(image_ref, self.runbook)
+        self.assertIn("apps/agent-control-plane/values.yaml", self.runbook)
+        self.assertIn("argocd/applications/agent-control-plane.yaml", self.runbook)
+        self.assertIn(
+            "argocd/applications/agent-control-plane-secrets.yaml",
+            self.runbook,
+        )
+        self.assertIn(
+            self.application["metadata"]["name"],
+            self.runbook,
+        )
+        self.assertIn(
+            self.secrets_application["metadata"]["name"],
+            self.runbook,
+        )
+
+        secret_keys = set(self.runtime_secret["stringData"])
+        self.assertIn("AGENT_PLATFORM_DATABASE_URL", secret_keys)
+        self.assertIn("AGENT_PLATFORM_READONLY_SQL_DATABASE_URL", secret_keys)
+        self.assertIn("AGENT_PLATFORM_DATABASE_URL", self.runbook)
+        self.assertIn("AGENT_PLATFORM_READONLY_SQL_DATABASE_URL", self.runbook)
+        self.assertIn("GarzAICluster", self.runbook)
+        self.assertNotIn("SplatTopConfig", self.runbook)
+
+    def test_runbook_preserves_restore_commands_and_recovery_targets(self) -> None:
+        required_phrases = (
+            "latest available DigitalOcean PITR point inside the seven-day native recovery window",
+            "within 4 hours",
+            "replicaCount: 1",
+            "no API PodDisruptionBudget",
+            "doctl databases fork",
+            "--restore-from-cluster-id",
+            "--restore-from-timestamp",
+            "sops secrets/agent-control-plane/runtime-secret.enc.yaml",
+            "argocd app sync agent-control-plane-secrets",
+            "argocd app sync agent-control-plane",
+            "kubectl -n agent-control-plane scale deploy/agent-control-plane --replicas=0",
+            "kubectl -n agent-control-plane scale deploy/agent-control-plane-git-deliverer --replicas=0",
+            "envFrom:",
+            "secretRef:",
+            "mandate-postgres-schema-check",
+            "curl -fsS https://agent-control-plane.garz.ai/readyz",
+            "curl -fsS https://agent-control-plane.garz.ai/healthz",
+            "mandate.deploy.smoke",
+            "audit hash chain",
+            "do not claim cryptographic continuity across manual row-level recovery",
+        )
+        for phrase in required_phrases:
+            self.assertIn(phrase, self.normalized)
+
+    def test_runbook_does_not_claim_operator_drill_completed(self) -> None:
+        self.assertIn(
+            "Live scratch-restore drill status: pending operator approval",
+            self.runbook,
+        )
+        self.assertIn("No scratch resource created", self.runbook)
+        self.assertIn("Cost-bearing restore drills", self.runbook)
+        self.assertIn("must not create, fork, delete, or repoint", self.normalized)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+def _normalized(value: str) -> str:
+    return " ".join(value.split())


### PR DESCRIPTION
## Summary

- Adds `docs/runbooks/postgres-restore.md` for the deployment-owned DigitalOcean managed Postgres restore path for agent-control-plane.
- Records the live cluster posture from read-only `doctl` evidence: database id/name, engine/version, region, plan, backup range, current image, Argo apps, SOPS secret path, hostname, and single-replica/no-API-PDB recovery posture.
- Documents RPO/RTO, writer freeze, `doctl databases fork`, SOPS secret repoint, Argo secret/app sync, check-only schema verification via a Kubernetes Job using `mandate-postgres-schema-check`, service resume, readyz/hostname health checks, smoke-task verification, and hash-chain recovery semantics.
- Links the runbook from the root and docs READMEs.
- Adds a Python contract test to keep the runbook tied to the current manifests, GarzAICluster naming, and to prevent claiming the scratch restore was completed.

## Current read-only evidence

- `doctl databases list --format ID,Name,Engine,Version,Region,Size,NumNodes,Status --no-header` -> `3adbbc39-dd07-4c0c-b172-081a247810d6    db-postgresql-nyc3-xscraper    pg    16    nyc3    db-amd-1vcpu-2gb    1    online`
- `doctl databases backups 3adbbc39-dd07-4c0c-b172-081a247810d6 -o json` -> visible backup window `2026-06-17T02:30:45Z` through `2026-06-24T02:32:18Z`; latest backup size `64.291084` GiB.

No restore cluster was created and no live database/secret/Argo state was mutated.

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 60 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `git diff --check origin/main...HEAD`
- GitHub Actions green on refreshed head `6b138af2a6e854d311a497d249caa533bbaf8636`.

## Remaining operator step

Draft until the cost-bearing live scratch-restore drill is executed and the ledger is updated with restore point, schema-check result, readyz, smoke task, elapsed RTO, and cleanup outcome.

Refs CES-49.
