### PR TITLE
CES-96: re-pin agent-workloads sha-eed073dc8b8b

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:5c51f3d6a0c71e796ce271e8e7982090e1228ba6b872eda6e0c08de323f2943d
-      image_digest: sha256:fe7c2125541e86f72cf3d6c07f8b707e4b7d9c9c70f311bc726ae409a35503e9
+      manifest_digest: sha256:5cb7008ad15850e69a89c98e77df6fbf900e99e92a5bbc29809d236e92583a97
+      image_digest: sha256:47e91fdbdacc866f1dbd752769cae8dc50f1ba372e4dced8ad1e2b5baa0b6f1e
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -48,8 +48,8 @@ data:
             session_taint: prod_authority
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:8f00106d46036c0a6ec3ed4a73fa3196c9ecd7ac8ae6dfed3d3a6dffc59a07ed
-      image_digest: sha256:5de4ce74451915e87749295db9bdccb2e8a5b5437722ba6a160bba65c4572032
+      manifest_digest: sha256:3144ebe7887b8a01e4d041bce04a1a9a19bc3e23525a1185aeac69b7c0b235c2
+      image_digest: sha256:32cc38f19461294a1010c11d438a9b1f22e24921f6b21a6551c75e665bb3aa03
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -177,8 +177,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:ece8d60c8469c2059a0c62a54261a49102ef87d090d0a22cb15f3d4d8a23490d
-      image_digest: sha256:fbe99bbf564955b7a4dac7178ba370fb63337d204868348e9d8473dcab910cbd
+      manifest_digest: sha256:64d16082044cde2399ecbd7a9dbb53c018b1956336ac085fead2f1490b6392e4
+      image_digest: sha256:11dc25d224811e57339ee9c3172ba6a929a9f375ee211844aead7d6f4d01fc71
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -437,8 +437,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:98b2ea0fb10da593f83c1373faa86fc652c893fb21877c74d430575512443ac0",
-      "digest": "sha256:5c51f3d6a0c71e796ce271e8e7982090e1228ba6b872eda6e0c08de323f2943d",
+      "code_digest": "sha256:fbe129260dfb0deadd1fb2780af2e8f9e00692bb86ac9eace52e18d49e6db360",
+      "digest": "sha256:5cb7008ad15850e69a89c98e77df6fbf900e99e92a5bbc29809d236e92583a97",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -448,7 +448,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:fe7c2125541e86f72cf3d6c07f8b707e4b7d9c9c70f311bc726ae409a35503e9",
+        "digest": "sha256:47e91fdbdacc866f1dbd752769cae8dc50f1ba372e4dced8ad1e2b5baa0b6f1e",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -478,8 +478,8 @@ data:
           "consequence_class": "reversible_staging"
         }
       },
-      "code_digest": "sha256:6f752da35e78aadbda0258aaa1642ab9534ddae8ab6fc0c86e701ed6d83acd68",
-      "digest": "sha256:8f00106d46036c0a6ec3ed4a73fa3196c9ecd7ac8ae6dfed3d3a6dffc59a07ed",
+      "code_digest": "sha256:2f8f1804e27737a8138a3c2dcb0bc9931167f92d780d646f3d97544294f4ad81",
+      "digest": "sha256:3144ebe7887b8a01e4d041bce04a1a9a19bc3e23525a1185aeac69b7c0b235c2",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -489,7 +489,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:5de4ce74451915e87749295db9bdccb2e8a5b5437722ba6a160bba65c4572032",
+        "digest": "sha256:32cc38f19461294a1010c11d438a9b1f22e24921f6b21a6551c75e665bb3aa03",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -515,8 +515,8 @@ data:
           "consequence_class": "consequential"
         }
       },
-      "code_digest": "sha256:1274f4f90542689deaca6ec1d10553d58f14aa893c2b551951fb72b382405636",
-      "digest": "sha256:ece8d60c8469c2059a0c62a54261a49102ef87d090d0a22cb15f3d4d8a23490d",
+      "code_digest": "sha256:7b2a3371b59b968eb815102ea0e58d56962296f7c4d769861457249890016e1f",
+      "digest": "sha256:64d16082044cde2399ecbd7a9dbb53c018b1956336ac085fead2f1490b6392e4",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -526,7 +526,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:fbe99bbf564955b7a4dac7178ba370fb63337d204868348e9d8473dcab910cbd",
+        "digest": "sha256:11dc25d224811e57339ee9c3172ba6a929a9f375ee211844aead7d6f4d01fc71",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 1
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-afb597299740
-  digest: sha256:fe7c2125541e86f72cf3d6c07f8b707e4b7d9c9c70f311bc726ae409a35503e9
+  tag: sha-eed073dc8b8b
+  digest: sha256:47e91fdbdacc866f1dbd752769cae8dc50f1ba372e4dced8ad1e2b5baa0b6f1e
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-afb597299740
-    digest: sha256:5de4ce74451915e87749295db9bdccb2e8a5b5437722ba6a160bba65c4572032
+    tag: sha-eed073dc8b8b
+    digest: sha256:32cc38f19461294a1010c11d438a9b1f22e24921f6b21a6551c75e665bb3aa03
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-afb597299740
-    digest: sha256:fbe99bbf564955b7a4dac7178ba370fb63337d204868348e9d8473dcab910cbd
+    tag: sha-eed073dc8b8b
+    digest: sha256:11dc25d224811e57339ee9c3172ba6a929a9f375ee211844aead7d6f4d01fc71
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -221,14 +221,14 @@ opencodeApplyExecutor:
       memory: 512Mi
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:98b2ea0fb10da593f83c1373faa86fc652c893fb21877c74d430575512443ac0
-    manifestDigest: sha256:5c51f3d6a0c71e796ce271e8e7982090e1228ba6b872eda6e0c08de323f2943d
-    imageDigest: sha256:fe7c2125541e86f72cf3d6c07f8b707e4b7d9c9c70f311bc726ae409a35503e9
+    codeDigest: sha256:fbe129260dfb0deadd1fb2780af2e8f9e00692bb86ac9eace52e18d49e6db360
+    manifestDigest: sha256:5cb7008ad15850e69a89c98e77df6fbf900e99e92a5bbc29809d236e92583a97
+    imageDigest: sha256:47e91fdbdacc866f1dbd752769cae8dc50f1ba372e4dced8ad1e2b5baa0b6f1e
   opencode.apply_executor:
-    codeDigest: sha256:1274f4f90542689deaca6ec1d10553d58f14aa893c2b551951fb72b382405636
-    manifestDigest: sha256:ece8d60c8469c2059a0c62a54261a49102ef87d090d0a22cb15f3d4d8a23490d
-    imageDigest: sha256:fbe99bbf564955b7a4dac7178ba370fb63337d204868348e9d8473dcab910cbd
+    codeDigest: sha256:7b2a3371b59b968eb815102ea0e58d56962296f7c4d769861457249890016e1f
+    manifestDigest: sha256:64d16082044cde2399ecbd7a9dbb53c018b1956336ac085fead2f1490b6392e4
+    imageDigest: sha256:11dc25d224811e57339ee9c3172ba6a929a9f375ee211844aead7d6f4d01fc71
   opencode.proposer:
-    codeDigest: sha256:6f752da35e78aadbda0258aaa1642ab9534ddae8ab6fc0c86e701ed6d83acd68
-    manifestDigest: sha256:8f00106d46036c0a6ec3ed4a73fa3196c9ecd7ac8ae6dfed3d3a6dffc59a07ed
-    imageDigest: sha256:5de4ce74451915e87749295db9bdccb2e8a5b5437722ba6a160bba65c4572032
+    codeDigest: sha256:2f8f1804e27737a8138a3c2dcb0bc9931167f92d780d646f3d97544294f4ad81
+    manifestDigest: sha256:3144ebe7887b8a01e4d041bce04a1a9a19bc3e23525a1185aeac69b7c0b235c2
+    imageDigest: sha256:32cc38f19461294a1010c11d438a9b1f22e24921f6b21a6551c75e665bb3aa03


### PR DESCRIPTION
## Summary
- Re-pin SplatTopConfig to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `eed073dc8b8b4e85b32f8e260b223b13e91a168c`
- Publish run id: `27926802376`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:47e91fdbdacc866f1dbd752769cae8dc50f1ba372e4dced8ad1e2b5baa0b6f1e` | `sha256:5cb7008ad15850e69a89c98e77df6fbf900e99e92a5bbc29809d236e92583a97` | `sha256:fbe129260dfb0deadd1fb2780af2e8f9e00692bb86ac9eace52e18d49e6db360` |
| `opencode.apply_executor` | `sha256:11dc25d224811e57339ee9c3172ba6a929a9f375ee211844aead7d6f4d01fc71` | `sha256:64d16082044cde2399ecbd7a9dbb53c018b1956336ac085fead2f1490b6392e4` | `sha256:7b2a3371b59b968eb815102ea0e58d56962296f7c4d769861457249890016e1f` |
| `opencode.proposer` | `sha256:32cc38f19461294a1010c11d438a9b1f22e24921f6b21a6551c75e665bb3aa03` | `sha256:3144ebe7887b8a01e4d041bce04a1a9a19bc3e23525a1185aeac69b7c0b235c2` | `sha256:2f8f1804e27737a8138a3c2dcb0bc9931167f92d780d646f3d97544294f4ad81` |

## Safety
- This PR does not mint workload identity tokens.
- The SplatTopConfig drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.