### PR TITLE
Bump CP to sha-cee8a690bc9f (batch: CES-136-deny/233-CP/154/235-CP)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-6e8cd225756c
+  tag: sha-cee8a690bc9f
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 6e8cd225756c8a5a3eca14234f839e554bb3c486
+      targetRevision: cee8a690bc9fa36ee348559125611d6f1adcbf1a
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps targetRevision + image.tag to `cee8a690`. Carries the merged Claude-gated agent-platform batch: CES-136 #198 (deny tests+diagnostics, tightens admission), CES-233 #200 (tolerate additive projection fields — CP side), CES-154 #194 (silence successful probe), CES-235 #201 (long-poll claims). Excludes CES-229 ap#199 (authority conflict). Image built+published. Live-verify after sync: deny click resolves+cancels; long-poll dispatch <100ms; probe silent-success.