### PR TITLE
Bump CP to sha-532443f0d927 + enable durable Codex auth PVC (CES-241 redo)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-cee8a690bc9f
+  tag: sha-532443f0d927
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -96,6 +96,12 @@ gitDeliverer:
 modelGateway:
   enabled: true
   replicaCount: 1
+  codexAuthPersistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: do-block-storage
+    size: 1Gi
 
 service:
   type: ClusterIP

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: cee8a690bc9fa36ee348559125611d6f1adcbf1a
+      targetRevision: 532443f0d927fe694a8967f5454616d290b3eea4
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Re-applies the image bump + PVC that #215's conflict resolution dropped (it merged only the re-minted secret). targetRevision/tag → `532443f0d927` (merged ap#202 durable store); enables `modelGateway.codexAuthPersistence` with **ReadWriteOnce + do-block-storage + 1Gi** (DO block storage, single-replica gateway → RWO not the chart's RWX default; DO 1Gi minimum). Fresh `CODEX_AUTH_JSON` is already in the secret, so on rollout the gateway bootstraps from it → persists to the PVC → durable across restarts. Closes the CES-241 deploy.