### PR TITLE
CES-245: bump control-plane image

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-532443f0d927
+  tag: sha-c87300b78d5d
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 532443f0d927fe694a8967f5454616d290b3eea4
+      targetRevision: c87300b78d5dc7fa362c77ec8c3ed062ca990a90
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## Summary
- Pin the `agent-control-plane` Argo source to agent-platform `c87300b78d5dc7fa362c77ec8c3ed062ca990a90`, the CES-245 merge commit.
- Update the Mandate runtime image tag to `sha-c87300b78d5d` so chart and image pins stay matched.

## Validation
- `env UV_CACHE_DIR=/root/dev/.uv-cache uv run --directory /root/dev/SplatTopConfig python -m pytest tests/test_control_plane_release_pin.py tests/test_agent_control_plane_registry_overlay.py::AgentControlPlaneRegistryOverlayTests::test_control_plane_pin_understands_opencode_executor_imports -q` -> 4 passed
- `git -C /root/dev/SplatTopConfig diff --check`

Refs CES-245.