### PR TITLE
CES-254: rename config repo references to GarzAICluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to SplatTopConfig
+# Contributing to GarzAICluster
 
 Thanks for helping keep our GitOps pipeline healthy! This repo is lightweight by design; every change goes through PR review with platform ownership (see `.github/CODEOWNERS`).
 
 ## Quick Start
 
-1. Clone both repos (`SplatTop` and `SplatTopConfig`) so you can coordinate code + config changes.
+1. Clone both repos (`SplatTop` and `GarzAICluster`) so you can coordinate code + config changes.
 2. Read through:
    - `docs/bootstrap.md` – environment bring-up and required secrets.
    - `docs/release-workflow.md` – how images/digests move between repos.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SplatTopConfig
+# GarzAICluster
 
 Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets workflow, and runbooks live here (not in the app repo).
 
@@ -39,4 +39,4 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 ## Request a bump
 
 Want your bot deployed? Use our one-click form:  
-👉 **[Request a bump](https://github.com/cesaregarza/SplatTopConfig/issues/new?template=bump-bot.yml)**
+👉 **[Request a bump](https://github.com/cesaregarza/GarzAICluster/issues/new?template=bump-bot.yml)**

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -1,6 +1,6 @@
 # Mandate Agent Control Plane
 
-This directory holds the SplatTopConfig-owned values overlay for the reusable
+This directory holds the GarzAICluster-owned values overlay for the reusable
 Mandate chart from `agent-platform/helm/mandate`. The live Argo Application is
 `argocd/applications/agent-control-plane.yaml`.
 

--- a/apps/bots/agent-8s-dev.yaml
+++ b/apps/bots/agent-8s-dev.yaml
@@ -1,5 +1,5 @@
 botName: "agent-8s-dev"
-repoURL: "https://github.com/cesaregarza/SplatTopConfig.git"
+repoURL: "https://github.com/cesaregarza/GarzAICluster.git"
 chartPath: "apps/agent-8s"
 targetRevision: "main"
 valuesFile: "values.dev.yaml"

--- a/apps/bots/agent-8s.yaml
+++ b/apps/bots/agent-8s.yaml
@@ -1,5 +1,5 @@
 botName: "agent-8s"
-repoURL: "https://github.com/cesaregarza/SplatTopConfig.git"
+repoURL: "https://github.com/cesaregarza/GarzAICluster.git"
 chartPath: "apps/agent-8s"
 targetRevision: "main"
 valuesFile: "values.yaml"

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -74,7 +74,7 @@ kubectl apply -f argocd/applications/splattop-prod.yaml
 
 4. Create the production application via UI:
    - Project: `splattop`
-   - Repository: `https://github.com/cesaregarza/SplatTopConfig`
+   - Repository: `https://github.com/cesaregarza/GarzAICluster`
    - Path: `helm/splattop`
    - Cluster: `in-cluster`
    - Namespace: `default`

--- a/argocd/applications/agent-control-plane-registry-overlay.yaml
+++ b/argocd/applications/agent-control-plane-registry-overlay.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: apps/agent-control-plane-registry-overlay
   destination:

--- a/argocd/applications/agent-control-plane-secrets.yaml
+++ b/argocd/applications/agent-control-plane-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/agent-control-plane
   destination:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -17,10 +17,10 @@ spec:
         releaseName: agent-control-plane
         valueFiles:
           - $values/apps/agent-control-plane/values.yaml
-    - repoURL: https://github.com/cesaregarza/SplatTopConfig
+    - repoURL: https://github.com/cesaregarza/GarzAICluster
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/cesaregarza/SplatTopConfig
+    - repoURL: https://github.com/cesaregarza/GarzAICluster
       targetRevision: main
       path: apps/agent-control-plane-runtime-controls
   destination:

--- a/argocd/applications/agent-workloads-secrets.yaml
+++ b/argocd/applications/agent-workloads-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/agent-workloads
   destination:

--- a/argocd/applications/agent-workloads.yaml
+++ b/argocd/applications/agent-workloads.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/agent-workloads
     helm:

--- a/argocd/applications/argocd-repositories.yaml
+++ b/argocd/applications/argocd-repositories.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/argocd
   destination:

--- a/argocd/applications/citrus-secrets.yaml
+++ b/argocd/applications/citrus-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/citrus
   destination:

--- a/argocd/applications/citrus.yaml
+++ b/argocd/applications/citrus.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/citrus
     helm:

--- a/argocd/applications/external-dns.yaml
+++ b/argocd/applications/external-dns.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: infra/external-dns
   destination:

--- a/argocd/applications/garz-ai-secrets.yaml
+++ b/argocd/applications/garz-ai-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/garz-ai
   destination:

--- a/argocd/applications/garz-ai.yaml
+++ b/argocd/applications/garz-ai.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/garz-ai
     helm:

--- a/argocd/applications/root.yaml
+++ b/argocd/applications/root.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: argocd/applications
   destination:

--- a/argocd/applications/skyquiet-server-secrets.yaml
+++ b/argocd/applications/skyquiet-server-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/skyquiet-server
   destination:

--- a/argocd/applications/skyquiet-server.yaml
+++ b/argocd/applications/skyquiet-server.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/skyquiet-server
     helm:

--- a/argocd/applications/splattop-blog-prod.yaml
+++ b/argocd/applications/splattop-blog-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/splattop-blog
     helm:

--- a/argocd/applications/splattop-blog-secrets.yaml
+++ b/argocd/applications/splattop-blog-secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/splattop-blog-prod
   destination:

--- a/argocd/applications/splattop-bots.yaml
+++ b/argocd/applications/splattop-bots.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: argocd/appsets
   destination:

--- a/argocd/applications/splattop-prod-comp-auth-secrets.yaml
+++ b/argocd/applications/splattop-prod-comp-auth-secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/splattop-prod-comp-auth
   destination:

--- a/argocd/applications/splattop-prod.yaml
+++ b/argocd/applications/splattop-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/splattop
     helm:

--- a/argocd/applications/splattop-teams-prod.yaml
+++ b/argocd/applications/splattop-teams-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/splattop-teams
     helm:

--- a/argocd/applications/splattop-teams-secrets.yaml
+++ b/argocd/applications/splattop-teams-secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/splattop-teams-prod
   destination:

--- a/argocd/applications/splatvote-prod.yaml
+++ b/argocd/applications/splatvote-prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig.git
+    repoURL: https://github.com/cesaregarza/GarzAICluster.git
     targetRevision: main
     path: helm/splatvote
     helm:

--- a/argocd/applications/splatvote-secrets.yaml
+++ b/argocd/applications/splatvote-secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/splatvote-prod
   destination:

--- a/argocd/applications/spotify-hot-100-secrets.yaml
+++ b/argocd/applications/spotify-hot-100-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: secrets/spotify-hot-100
   destination:

--- a/argocd/applications/spotify-hot-100.yaml
+++ b/argocd/applications/spotify-hot-100.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/spotify-hot-100
     helm:

--- a/argocd/applications/vanity-hosts.yaml
+++ b/argocd/applications/vanity-hosts.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: splattop
   source:
-    repoURL: https://github.com/cesaregarza/SplatTopConfig
+    repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: helm/vanity-hosts
     helm:

--- a/argocd/appsets/bots-apps.yaml
+++ b/argocd/appsets/bots-apps.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: https://github.com/cesaregarza/SplatTopConfig
+        repoURL: https://github.com/cesaregarza/GarzAICluster
         revision: main
         files:
           - path: apps/bots/*.yaml

--- a/argocd/appsets/bots-netpol.yaml
+++ b/argocd/appsets/bots-netpol.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: https://github.com/cesaregarza/SplatTopConfig
+        repoURL: https://github.com/cesaregarza/GarzAICluster
         revision: main
         files:
           - path: apps/bots/*.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       project: splattop-bots
       source:
-        repoURL: https://github.com/cesaregarza/SplatTopConfig
+        repoURL: https://github.com/cesaregarza/GarzAICluster
         targetRevision: main
         path: helm/bot-netpol
         helm:

--- a/argocd/appsets/bots-secrets.yaml
+++ b/argocd/appsets/bots-secrets.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: https://github.com/cesaregarza/SplatTopConfig
+        repoURL: https://github.com/cesaregarza/GarzAICluster
         revision: main
         files:
           - path: apps/bots/*.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       project: splattop-bots
       source:
-        repoURL: https://github.com/cesaregarza/SplatTopConfig
+        repoURL: https://github.com/cesaregarza/GarzAICluster
         targetRevision: main
         path: 'secrets/bots/{{botName}}'
       destination:

--- a/argocd/projects/splattop-project.yaml
+++ b/argocd/projects/splattop-project.yaml
@@ -9,7 +9,7 @@ spec:
   description: SplatTop production project (default + monitoring namespaces)
 
   sourceRepos:
-    - https://github.com/cesaregarza/SplatTopConfig
+    - https://github.com/cesaregarza/GarzAICluster
     - https://github.com/cesaregarza/agent-platform
     - git@github.com:cesaregarza/agent-platform.git
 

--- a/docs/agent-control-plane-openclaw-rollout.md
+++ b/docs/agent-control-plane-openclaw-rollout.md
@@ -7,7 +7,7 @@ Control Plane, not by calling workload containers directly.
 
 - `agent-platform` owns the reusable Mandate control-plane API chart at
   `helm/mandate`.
-- `SplatTopConfig` owns the live values overlay, Argo Application, namespace,
+- `GarzAICluster` owns the live values overlay, Argo Application, namespace,
   image tag, runtime secret, DNS, and TLS.
 - The live Kubernetes release, namespace, and hostname remain
   `agent-control-plane` for continuity, even though the deployed runtime is

--- a/docs/argo-operations.md
+++ b/docs/argo-operations.md
@@ -5,7 +5,7 @@ This guide covers day-to-day management of Argo CD once it tracks the config rep
 ## AppProjects & RBAC
 
 - Production is the only environment managed from this repo today. The manifest lives at `argocd/projects/splattop-project.yaml`.
-- The project pins `sourceRepos` to `https://github.com/cesaregarza/SplatTopConfig` and limits destinations to the `default` (app) and `monitoring` namespaces on the in-cluster API server.
+- The project pins `sourceRepos` to `https://github.com/cesaregarza/GarzAICluster` and limits destinations to the `default` (app) and `monitoring` namespaces on the in-cluster API server.
 - Resource whitelists mirror the previous settings so Helm can continue to manage monitoring/cluster objects required by prod.
 - A weekday sync window (Mon–Fri, cron `0 15 * * 1-5`, `duration: 11h`) blocks off-hours deploys.
 - Only the `splattop-admins` group is bound (role `proj:splattop:admin`). Set `policy.default: role:readonly` in `argocd-rbac-cm` so casual logins stay read-only.
@@ -22,7 +22,7 @@ All of the details are codified inside `argocd/applications/splattop-prod.yaml`;
 ## Repository & Registry Credentials
 
 1. **Config repo**
-   - Create a read-only deploy key dedicated to Argo (`argocd-repo-splattopconfig` secret in the `argocd` namespace).
+   - Create a read-only deploy key dedicated to Argo (`argocd-repo-garzaicluster` secret in the `argocd` namespace).
    - Reference it from `argocd-cm.repositories` so no developer PATs are needed inside the control plane.
 2. **Container registry**
    - Mirror the existing DOCR `regcred` into the `argocd` namespace for metadata lookups, and keep per-namespace pull secrets for workloads.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -4,7 +4,7 @@ Use this runbook when standing up a brand-new cluster or when rehydrating Argo t
 
 ## Prerequisites
 
-- GitHub repo: `SplatTopConfig` (private) with `main` branch.
+- GitHub repo: `GarzAICluster` (private) with `main` branch.
 - GitHub App or fine-grained PAT that has `contents:write` on this repo only (used by automation).
 - Container registry credentials (DigitalOcean registry) and S3/DO Spaces credentials for i18n sync jobs.
 - Age key pair for SOPS (public key checked into the repo, private key stored offline + in 1Password).
@@ -13,7 +13,7 @@ Use this runbook when standing up a brand-new cluster or when rehydrating Argo t
 
 1. **Clone repos locally**
    - `git clone git@github.com:SplatTop/SplatTop.git`
-   - `git clone git@github.com:SplatTop/SplatTopConfig.git`
+   - `git clone git@github.com:SplatTop/GarzAICluster.git`
 2. **Install tooling**
    - Helm, kubectl, argocd CLI, sops, age, jq, yq.
 3. **Create deploy key for Argo**
@@ -28,7 +28,7 @@ Use this runbook when standing up a brand-new cluster or when rehydrating Argo t
    - Apply upstream manifests or helm install.
    - Login (`argocd admin initial-password`) and change the admin password (store in `.env` per plan).
 6. **Register this config repo**
-   - `argocd repo add git@github.com:SplatTop/SplatTopConfig.git --ssh-private-key-path ~/.ssh/splattop-config`
+   - `argocd repo add git@github.com:SplatTop/GarzAICluster.git --ssh-private-key-path ~/.ssh/splattop-config`
    - Verify Argo can list charts: `argocd repo list`.
 7. **Apply AppProjects**
    - `kubectl apply -f argocd/projects/`.

--- a/docs/bump-howto.md
+++ b/docs/bump-howto.md
@@ -1,7 +1,7 @@
 # How to request a bot deploy bump
 
 ### Easiest (one click)
-- Open the **[Bump a bot image form](https://github.com/cesaregarza/SplatTopConfig/issues/new?template=bump-bot.yml)**.
+- Open the **[Bump a bot image form](https://github.com/cesaregarza/GarzAICluster/issues/new?template=bump-bot.yml)**.
 - Choose your bot, paste a **tag** (e.g., `v1.2.3`) or a **digest**.
 - We’ll resolve to the canonical digest, open a PR, and mention you.
 

--- a/docs/developer-cheat-sheet.md
+++ b/docs/developer-cheat-sheet.md
@@ -6,8 +6,8 @@ Quick reference for engineers touching the config repo after the split.
 
 ```bash
 git clone git@github.com:SplatTop/SplatTop.git
-git clone git@github.com:SplatTop/SplatTopConfig.git
-tree -L 1 SplatTopConfig
+git clone git@github.com:SplatTop/GarzAICluster.git
+tree -L 1 GarzAICluster
 ```
 
 - `helm/` – charts per service (api, react, celery, monitoring).
@@ -18,7 +18,7 @@ tree -L 1 SplatTopConfig
 ## Validating Changes Locally
 
 ```bash
-cd SplatTopConfig
+cd GarzAICluster
 helm lint helm/splattop
 helm template helm/splattop -f helm/splattop/values-dev.yaml > /tmp/dev.yaml
 kubeconform -strict /tmp/dev.yaml
@@ -60,7 +60,7 @@ trufflehog filesystem --no-update --only-verified --fail .
 - Only the prod AppProject (`argocd/projects/splattop-project.yaml`) is managed here today; it targets the `default` + `monitoring` namespaces.
 - `splattop-admins` is the sole write-capable group (role `proj:splattop:admin`). Everyone else falls back to `policy.default: role:readonly`.
 - Prod syncs are manual and constrained to the Mon–Fri 15:00–02:00 UTC window. Outside that window the UI/CLI will reject sync attempts automatically.
-- Argo reads this repo via the `argocd-repo-splattopconfig` deploy key secret. Update/rotate it via `kubectl -n argocd create secret generic ... --dry-run=client -o yaml | kubectl apply -f -` and record the change in `docs/argo-operations.md`.
+- Argo reads this repo via the `argocd-repo-garzaicluster` deploy key secret. Update/rotate it via `kubectl -n argocd create secret generic ... --dry-run=client -o yaml | kubectl apply -f -` and record the change in `docs/argo-operations.md`.
 
 ## Troubleshooting
 
@@ -71,7 +71,7 @@ trufflehog filesystem --no-update --only-verified --fail .
 ## Editing Secrets
 
 ```bash
-cd SplatTopConfig
+cd GarzAICluster
 printf '%s\n' "$SOPS_AGE_KEY" > ~/.config/sops/age/keys.txt  # contents from GH secret
 export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
 sops k8s/secrets.enc.yaml

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -4,7 +4,7 @@ This file is generated from the agent-workloads release applier contract and
 the deployment registry overlay. Do not hand-edit it; run
 `scripts/generate_grant_ownership.py` instead.
 
-Changing a deployment-owned key edits the SplatTopConfig registry overlay and
+Changing a deployment-owned key edits the GarzAICluster registry overlay and
 requires a control-plane restart. It does not move workload image, manifest,
 or code digests, and it does not require workload identity token re-minting.
 

--- a/docs/historical/agent-platform/openclaw-mcp-rollout-2026-05-27.md
+++ b/docs/historical/agent-platform/openclaw-mcp-rollout-2026-05-27.md
@@ -73,7 +73,7 @@ status: success
 image: registry.digitalocean.com/sendouq/agent-platform:sha-c06fd9aa810e
 ```
 
-### SplatTopConfig
+### GarzAICluster
 
 Commits:
 

--- a/docs/historical/agent-platform/openclaw-mvp-deployment.md
+++ b/docs/historical/agent-platform/openclaw-mvp-deployment.md
@@ -8,9 +8,9 @@ Mandate without exposing raw broker or worker tools to the model.
 ## What Can Be Deployed First
 
 Deploy the Mandate API and local deterministic worker from
-`mandate-agent-control-plane` into Kubernetes through `SplatTopConfig`. The
+`mandate-agent-control-plane` into Kubernetes through `GarzAICluster`. The
 chart lives in `helm/mandate`; the live values, runtime secret, DNS, TLS, and
-Argo Application belong in `SplatTopConfig`.
+Argo Application belong in `GarzAICluster`.
 
 The initial OpenClaw-facing capability surface should be limited to:
 

--- a/docs/mandate-apply.md
+++ b/docs/mandate-apply.md
@@ -3,7 +3,7 @@
 `scripts/mandate_apply.py` is the first local CES-123 enablement planner for
 Mandate workload capabilities. It consumes one declarative
 `MandateWorkloadEnablement` YAML document and reconciles only the
-deployment-owned edges that SplatTopConfig is allowed to own.
+deployment-owned edges that GarzAICluster is allowed to own.
 
 Dry-run is the default. Use `--write` only on a branch intended for a normal PR.
 The tool never mutates the live cluster, never edits SOPS secret values, never

--- a/docs/model-gateway-controls.md
+++ b/docs/model-gateway-controls.md
@@ -4,7 +4,7 @@ This runbook covers the deployment-owned controls mounted into the Mandate
 model-gateway and API pods from the
 `agent-control-plane-model-gateway-controls` ConfigMap.
 
-Mandate owns the enforcement code. SplatTopConfig owns the live files that make
+Mandate owns the enforcement code. GarzAICluster owns the live files that make
 the controls operable in this cluster.
 
 ## Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "splattopconfig-scripts"
+name = "garzaicluster-scripts"
 version = "0.1.0"
-description = "Helper scripts for the SplatTopConfig repo."
+description = "Helper scripts for the GarzAICluster repo."
 authors = [
   { name = "SplatTop contributors" }
 ]

--- a/scripts/bootstrap_bot.py
+++ b/scripts/bootstrap_bot.py
@@ -60,7 +60,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--repo-url",
-        default="https://github.com/cesaregarza/SplatTopConfig.git",
+        default="https://github.com/cesaregarza/GarzAICluster.git",
         help="Repo URL for the chart (default: this repo).",
     )
     parser.add_argument(

--- a/scripts/generate_grant_ownership.py
+++ b/scripts/generate_grant_ownership.py
@@ -17,13 +17,13 @@ from scripts.grant_ownership import (
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Generate or check the SplatTopConfig grant ownership map."
+        description="Generate or check the GarzAICluster grant ownership map."
     )
     parser.add_argument(
         "--repo-root",
         type=Path,
         default=Path.cwd(),
-        help="Path to the SplatTopConfig checkout.",
+        help="Path to the GarzAICluster checkout.",
     )
     parser.add_argument(
         "--agent-workloads-repo",

--- a/scripts/grant_ownership.py
+++ b/scripts/grant_ownership.py
@@ -283,7 +283,7 @@ def render_ownership_markdown(ownership: dict[str, Any]) -> str:
         "the deployment registry overlay. Do not hand-edit it; run",
         "`scripts/generate_grant_ownership.py` instead.",
         "",
-        "Changing a deployment-owned key edits the SplatTopConfig registry overlay and",
+        "Changing a deployment-owned key edits the GarzAICluster registry overlay and",
         "requires a control-plane restart. It does not move workload image, manifest,",
         "or code digests, and it does not require workload identity token re-minting.",
         "",
@@ -427,7 +427,7 @@ def apply_grant_edit(
         raise GrantEditError(
             f"{capability_id} {key_path} is {owner}-owned. Edit "
             f"agent-workloads/{source_path}; consequence: workload digest moves, "
-            "SplatTopConfig must re-pin the release, and workload identity tokens must "
+            "GarzAICluster must re-pin the release, and workload identity tokens must "
             "be re-minted."
         )
 

--- a/scripts/mandate_apply.py
+++ b/scripts/mandate_apply.py
@@ -26,7 +26,7 @@ def main() -> int:
         "--repo-root",
         type=Path,
         default=Path.cwd(),
-        help="Path to the SplatTopConfig checkout.",
+        help="Path to the GarzAICluster checkout.",
     )
     parser.add_argument(
         "--write",

--- a/scripts/set_grant.py
+++ b/scripts/set_grant.py
@@ -31,7 +31,7 @@ def main() -> int:
         "--repo-root",
         type=Path,
         default=Path.cwd(),
-        help="Path to the SplatTopConfig checkout.",
+        help="Path to the GarzAICluster checkout.",
     )
     parser.add_argument(
         "--agent-workloads-repo",

--- a/tests/test_agent_control_plane_registry_compat.py
+++ b/tests/test_agent_control_plane_registry_compat.py
@@ -292,7 +292,7 @@ def _write_control_plane_application(repo: Path, target_revision: str) -> None:
                         "path": "helm/mandate",
                     },
                     {
-                        "repoURL": "https://github.com/cesaregarza/SplatTopConfig",
+                        "repoURL": "https://github.com/cesaregarza/GarzAICluster",
                         "targetRevision": "main",
                         "ref": "values",
                     },

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -447,7 +447,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(len(raw_sources), 1)
         self.assertEqual(
             raw_sources[0]["repoURL"],
-            "https://github.com/cesaregarza/SplatTopConfig",
+            "https://github.com/cesaregarza/GarzAICluster",
         )
 
     def test_control_plane_pin_understands_opencode_executor_imports(self) -> None:

--- a/tests/test_control_plane_release_pin.py
+++ b/tests/test_control_plane_release_pin.py
@@ -78,7 +78,7 @@ def _fixture_repo(*, target_revision: str, image_tag: str) -> Path:
                         "path": "helm/mandate",
                     },
                     {
-                        "repoURL": "https://github.com/cesaregarza/SplatTopConfig",
+                        "repoURL": "https://github.com/cesaregarza/GarzAICluster",
                         "targetRevision": "main",
                         "ref": "values",
                     },

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 ]
 
 [[package]]
-name = "splattopconfig-scripts"
+name = "garzaicluster-scripts"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Rename in-repo `SplatTopConfig` references to `GarzAICluster`, including Argo `repoURL` values, ApplicationSet generators, docs, scripts, package metadata, and tests.
- Update config repo URL expectations to `https://github.com/cesaregarza/GarzAICluster` / `.git` where appropriate.

## Validation
- `env UV_CACHE_DIR=/root/dev/.uv-cache uv run --directory /root/dev/SplatTopConfig python -m pytest -q` -> 52 passed
- `git diff --check`
- `rg -n "SplatTopConfig|splattopconfig" --glob '!**/.git/**'` -> no hits

## Merge/sync preconditions
- Do not merge/sync this until the GitHub repo has actually been renamed from `cesaregarza/SplatTopConfig` to `cesaregarza/GarzAICluster`.
- Broker policy must be deployed first so the renamed repo's CI OIDC claim can obtain `sops-drift-gate-decrypt` and `mandate-contracts-read`.
- After merge, verify Argo apps are Synced/Healthy and no app source points at the old redirect.

Refs CES-254 / CES-115.