### PR TITLE
CES-113/CES-268: bump control plane image and metrics scrape

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -8,9 +8,18 @@ fullnameOverride: agent-control-plane
 
 replicaCount: 1
 
+apiPodAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9090"
+  prometheus.io/path: /metrics
+
+metrics:
+  enabled: true
+  port: 9090
+
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-c87300b78d5d
+  tag: sha-08c75f113697
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -148,8 +157,18 @@ networkPolicy:
           matchLabels:
             app.kubernetes.io/name: opencode-proposer
             app.kubernetes.io/instance: agent-workloads
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: splattop
+            app.kubernetes.io/instance: splattop-prod
+            app.kubernetes.io/component: prometheus
     ports:
       - port: 8000
+        protocol: TCP
+      - port: 9090
         protocol: TCP
   egress:
     dns:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: c87300b78d5dc7fa362c77ec8c3ed062ca990a90
+      targetRevision: 08c75f113697af572b3c5e9c4c9db629f5cea6a0
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-c87300b78d5d` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-08c75f113697` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-c87300b78d5d
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-08c75f113697
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary

- deploy-lock-visible CP bump for CES-268: pin `agent-control-plane` to agent-platform `08c75f113697af572b3c5e9c4c9db629f5cea6a0` and image tag `sha-08c75f113697`;
- keep the CES-113 metrics scrape wiring in the same CP roll:
  - enable the chart's dedicated in-cluster metrics listener on port `9090`;
  - annotate the API pod for the existing `kubernetes-pods` Prometheus discovery job;
  - allow Prometheus through the control-plane NetworkPolicy on port `9090` while leaving public app traffic on `8000`.

The public app-port `/metrics` route remains AUDIT_READ-protected. Prometheus scrapes the dedicated in-cluster metrics listener added by agent-platform #205, which emits `mandate_control_registry_snapshot_info{digest="sha256:..."} 1`.

## CES-268 deploy lock

Do not sync this before the CES-263 prod DB role hardening is applied. The target CP image contains fail-closed readonly SQL conformance checks; deploying it against an un-hardened prod readonly role can fail every `readonly_sql` / `readonly_query` request closed.

Required order:

1. Operator runs the CES-263 prod DB role provisioner for the approved readonly relations.
2. Merge/sync this CP bump.
3. Critic/operator live-verifies CES-261/CES-262/CES-263/CES-113 acceptance.

## Validation

- DOCR has target tag `agent-platform:sha-08c75f113697` (built 2026-06-24 03:56Z).
- `uv --directory ... run python -m unittest tests.test_control_plane_release_pin`
- `uv --directory ... run python scripts/check_control_plane_release_pin.py`
- `helm lint /root/dev/.worktrees/agent-platform-08c75f/helm/mandate -f apps/agent-control-plane/values.yaml`
- `helm template` using exact chart commit `08c75f113697af572b3c5e9c4c9db629f5cea6a0` shows:
  - all CP workloads render `registry.digitalocean.com/sendouq/agent-platform:sha-08c75f113697`;
  - API pod annotations include `prometheus.io/scrape: "true"`, `prometheus.io/port: "9090"`, `prometheus.io/path: /metrics`;
  - API container exposes `containerPort: 9090` named `metrics`.
- `git diff --check`

## Operator gate

After merge and only after the CES-263 role apply, sync `agent-control-plane` and live-verify:

1. `mandate_control_registry_snapshot_info` returns a non-empty Prometheus sample.
2. The `digest` label equals the booted control-plane RegistrySnapshot digest.
3. A CTE/window/SRF readonly_sql query plans/runs through the AST-bound path.
4. Heavy analytical readonly_sql returns within the analytical lease or fails with the typed timeout/concurrency error.
5. CP logs do not show `readonly_sql_*_not_restricted` fail-closed reasons.