### PR TITLE
CES-229: bump control plane to c1ba967

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-c87300b78d5d
+  tag: sha-c1ba967183c4
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: c87300b78d5dc7fa362c77ec8c3ed062ca990a90
+      targetRevision: c1ba967183c409c4e8a63bf4cb01c95b779e1283
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## Summary

Bumps the agent-control-plane Argo chart source and runtime image tag to agent-platform `c1ba967183c409c4e8a63bf4cb01c95b779e1283` / `sha-c1ba967183c4`.

This deploys the already-merged CES-229 CP-side handoff from agent-platform #199, plus the later mainline CP changes included in that published image.

## Validation

- Confirmed `c1ba967` is newer than the current config-repo main CP pin `c87300b`.
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 56 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `PYTHONPATH=/root/dev/.worktrees/garzaicluster-ces229-cp-bump/.venv/lib/python3.13/site-packages /root/dev/.worktrees/agent-platform-cp-c1ba967/.venv/bin/python scripts/check_agent_control_plane_registry_compat.py --repo-root /root/dev/.worktrees/garzaicluster-ces229-cp-bump --agent-platform-repo /root/dev/.worktrees/agent-platform-cp-c1ba967`
- `git diff --check origin/main...HEAD`

## Deploy note

Operator-gated. After merge/sync, CES-229 still needs fresh live verify: approve -> apply -> released delivery_pending -> git deliverer pushes `mandate/opencode-apply/<action_id>` to `mandate-sandbox` -> draft PR recorded and surfaced, with credential boundary and digest/idempotency checks.
