### PR TITLE
CES-257: preserve observability state identities

### DIFF
--- a/docs/observability-state-preservation.md
+++ b/docs/observability-state-preservation.md
@@ -1,0 +1,71 @@
+# Observability State Preservation
+
+CES-257 chooses the lowest-risk preservation path for the CES-256 observability
+extraction: keep the live Prometheus and Grafana stateful object identities
+unchanged while Argo ownership moves from `splattop-prod` to
+`garz-observability`.
+
+## Decision
+
+Use stable Kubernetes object names and selector labels for the extraction. Do
+not perform a PV retain/re-bind cutover during CES-256.
+
+The production render must keep these identities:
+
+- Prometheus StatefulSet: `splattop-prod-prometheus`
+- Prometheus generated TSDB PVC: `prometheus-data-splattop-prod-prometheus-0`
+- Grafana runtime-state PVC: `splattop-prod-grafana-storage`
+- Stateful selector labels:
+  - `app.kubernetes.io/name: splattop`
+  - `app.kubernetes.io/instance: splattop-prod`
+
+This preserves the existing DO block-storage PV bindings. It also avoids the
+double-billing/orphan risk of accidentally creating fresh volumes during the
+chart extraction.
+
+## Operator Cutover Check
+
+Before syncing `garz-observability`, capture the live bindings:
+
+```bash
+kubectl get pvc -n monitoring \
+  prometheus-data-splattop-prod-prometheus-0 \
+  splattop-prod-grafana-storage \
+  -o wide
+
+kubectl get pvc -n monitoring \
+  prometheus-data-splattop-prod-prometheus-0 \
+  splattop-prod-grafana-storage \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.volumeName}{"\n"}{end}'
+```
+
+Sync `garz-observability` before pruning the moved resources from
+`splattop-prod`. After both Argo apps settle, re-run the same commands and
+confirm the PVC names and `.spec.volumeName` values match the pre-cutover
+capture.
+
+Then confirm no replacement monitoring volumes were created:
+
+```bash
+kubectl get pvc -n monitoring | grep -E 'prometheus|grafana'
+kubectl get pv | grep -E 'prometheus|grafana|splattop-prod'
+```
+
+Acceptance evidence is the before/after PVC-to-PV binding match plus Prometheus
+and Grafana healthy pods using those claims.
+
+## Future Rename Path
+
+A later cleanup may choose to rename the release, chart prefix, selector labels,
+StatefulSet, or PVCs away from `splattop-prod`. That is not part of CES-256 or
+this CES-257 decision. If that rename happens, use a separate PV retain/re-bind
+runbook:
+
+1. Set the existing PVs' reclaim policy to `Retain`.
+2. Scale down Prometheus and Grafana.
+3. Delete the old PVC objects only after recording their bound PV names.
+4. Remove `claimRef` from the retained PVs.
+5. Create new PVCs with the intended names and explicit `volumeName` bindings.
+6. Sync the renamed workloads.
+7. Verify Prometheus history and Grafana runtime state before deleting any old
+   storage artifacts.

--- a/helm/garz-observability/README.md
+++ b/helm/garz-observability/README.md
@@ -8,8 +8,18 @@ for GarzAICluster.
 The chart currently preserves the live `splattop-prod` object name prefix and
 `app.kubernetes.io/name=splattop` / `app.kubernetes.io/instance=splattop-prod`
 selector labels. That lets Argo move ownership out of the SplatTop app chart
-without renaming the Prometheus StatefulSet or Grafana PVC. CES-257 owns the
-explicit state-preserving PV/PVC migration and any later selector cleanup.
+without renaming the Prometheus StatefulSet or Grafana PVC.
+
+CES-257 records the state-preservation choice: do not re-bind storage during the
+extraction. The expected stateful identities are:
+
+- Prometheus StatefulSet: `splattop-prod-prometheus`
+- Prometheus generated TSDB PVC: `prometheus-data-splattop-prod-prometheus-0`
+- Grafana runtime-state PVC: `splattop-prod-grafana-storage`
+
+If a later cleanup renames the chart, release, StatefulSet, selector labels, or
+PVC names, perform an explicit PV retain/re-bind migration first. Do not let a
+Helm rename create replacement volumes implicitly.
 
 ## Production
 

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -1,8 +1,10 @@
 nameOverride: splattop
 fullnameOverride: splattop-prod
 
-# Keep live object names/selectors stable while ownership moves from the
-# SplatTop app chart to this cluster-level chart.
+# CES-257 state-preservation decision: keep live object names/selectors stable
+# while ownership moves from the SplatTop app chart to this cluster-level chart.
+# Do not change this without a PV retain/re-bind migration for the Prometheus
+# TSDB PVC and Grafana runtime-state PVC.
 legacySelectorLabels:
   name: splattop
   instance: splattop-prod

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -1,9 +1,11 @@
 nameOverride: splattop
 fullnameOverride: splattop-prod
 
-# Preserve the live selector labels until CES-257 performs the explicit
-# Prometheus/Grafana state-preservation cutover. Changing these labels would
-# force immutable Deployment/StatefulSet selector changes.
+# CES-257 state-preservation decision: keep the live object names and selector
+# labels stable during the observability extraction. The Prometheus TSDB PVC is
+# generated as prometheus-data-splattop-prod-prometheus-0 and Grafana runtime
+# state lives in splattop-prod-grafana-storage; changing these names requires a
+# separate PV retain/re-bind migration.
 legacySelectorLabels:
   name: splattop
   instance: splattop-prod

--- a/tests/test_observability_state_preservation.py
+++ b/tests/test_observability_state_preservation.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+PROMETHEUS_STATEFULSET = "splattop-prod-prometheus"
+PROMETHEUS_TSDB_CLAIM_TEMPLATE = "prometheus-data"
+PROMETHEUS_TSDB_PVC = "prometheus-data-splattop-prod-prometheus-0"
+GRAFANA_DEPLOYMENT = "splattop-prod-grafana"
+GRAFANA_STORAGE_PVC = "splattop-prod-grafana-storage"
+LEGACY_SELECTOR_LABELS = {
+    "app.kubernetes.io/name": "splattop",
+    "app.kubernetes.io/instance": "splattop-prod",
+}
+
+
+def _render_observability_prod() -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "garz-observability",
+            "helm/garz-observability",
+            "-n",
+            "monitoring",
+            "-f",
+            "helm/garz-observability/values-prod.yaml",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        document
+        for document in YAML_PARSER.load_all(result.stdout)
+        if isinstance(document, dict) and document.get("kind")
+    ]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text())
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+def _resource(
+    docs: list[dict[str, Any]],
+    *,
+    kind: str,
+    name: str,
+    namespace: str = "monitoring",
+) -> dict[str, Any]:
+    for document in docs:
+        metadata = document.get("metadata") or {}
+        if (
+            document.get("kind") == kind
+            and metadata.get("name") == name
+            and metadata.get("namespace") == namespace
+        ):
+            return document
+    raise AssertionError(f"{kind}/{namespace}/{name} not rendered")
+
+
+class ObservabilityStatePreservationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.docs = _render_observability_prod()
+        cls.values = _load_yaml(
+            REPO_ROOT / "helm" / "garz-observability" / "values-prod.yaml"
+        )
+        cls.readme = (
+            REPO_ROOT / "docs" / "observability-state-preservation.md"
+        ).read_text()
+
+    def test_prod_values_record_stable_identity_decision(self) -> None:
+        self.assertEqual(self.values["nameOverride"], "splattop")
+        self.assertEqual(self.values["fullnameOverride"], "splattop-prod")
+        self.assertEqual(
+            self.values["legacySelectorLabels"],
+            {"name": "splattop", "instance": "splattop-prod"},
+        )
+
+    def test_prometheus_tsdb_claim_identity_is_preserved(self) -> None:
+        statefulset = _resource(
+            self.docs,
+            kind="StatefulSet",
+            name=PROMETHEUS_STATEFULSET,
+        )
+        self.assertEqual(statefulset["spec"]["serviceName"], PROMETHEUS_STATEFULSET)
+        self.assertEqual(
+            statefulset["spec"]["selector"]["matchLabels"],
+            LEGACY_SELECTOR_LABELS | {"app.kubernetes.io/component": "prometheus"},
+        )
+        self.assertEqual(
+            statefulset["spec"]["template"]["metadata"]["labels"],
+            LEGACY_SELECTOR_LABELS | {"app.kubernetes.io/component": "prometheus"},
+        )
+
+        claim_templates = {
+            template["metadata"]["name"]: template
+            for template in statefulset["spec"]["volumeClaimTemplates"]
+        }
+        prometheus_claim = claim_templates[PROMETHEUS_TSDB_CLAIM_TEMPLATE]
+        self.assertEqual(
+            _statefulset_pvc_name(
+                statefulset_name=PROMETHEUS_STATEFULSET,
+                claim_template=PROMETHEUS_TSDB_CLAIM_TEMPLATE,
+                ordinal=0,
+            ),
+            PROMETHEUS_TSDB_PVC,
+        )
+        self.assertEqual(prometheus_claim["spec"]["accessModes"], ["ReadWriteOnce"])
+        self.assertNotIn("storageClassName", prometheus_claim["spec"])
+        self.assertEqual(
+            prometheus_claim["spec"]["resources"]["requests"]["storage"],
+            "20Gi",
+        )
+
+    def test_grafana_runtime_claim_identity_and_dashboards_are_preserved(self) -> None:
+        grafana = _resource(self.docs, kind="Deployment", name=GRAFANA_DEPLOYMENT)
+        self.assertEqual(
+            grafana["spec"]["selector"]["matchLabels"],
+            LEGACY_SELECTOR_LABELS | {"app.kubernetes.io/component": "grafana"},
+        )
+        storage_volume = _volume(grafana, "grafana-storage")
+        self.assertEqual(
+            storage_volume["persistentVolumeClaim"]["claimName"],
+            GRAFANA_STORAGE_PVC,
+        )
+
+        pvc = _resource(self.docs, kind="PersistentVolumeClaim", name=GRAFANA_STORAGE_PVC)
+        self.assertEqual(pvc["spec"]["accessModes"], ["ReadWriteOnce"])
+        self.assertNotIn("storageClassName", pvc["spec"])
+        self.assertEqual(pvc["spec"]["resources"]["requests"]["storage"], "5Gi")
+
+        configmaps = {
+            document["metadata"]["name"]
+            for document in self.docs
+            if document.get("kind") == "ConfigMap"
+        }
+        self.assertGreaterEqual(
+            configmaps,
+            {
+                "grafana-datasources",
+                "grafana-dashboard-providers",
+                "grafana-dashboard-core",
+                "grafana-dashboard-observability",
+            },
+        )
+
+    def test_runbook_names_the_cutover_bindings_to_verify(self) -> None:
+        self.assertIn(PROMETHEUS_TSDB_PVC, self.readme)
+        self.assertIn(GRAFANA_STORAGE_PVC, self.readme)
+        self.assertIn(".spec.volumeName", self.readme)
+        self.assertIn("no replacement monitoring volumes", self.readme)
+
+
+def _statefulset_pvc_name(
+    *,
+    statefulset_name: str,
+    claim_template: str,
+    ordinal: int,
+) -> str:
+    return f"{claim_template}-{statefulset_name}-{ordinal}"
+
+
+def _volume(deployment: dict[str, Any], name: str) -> dict[str, Any]:
+    for volume in deployment["spec"]["template"]["spec"]["volumes"]:
+        if volume.get("name") == name:
+            return volume
+    raise AssertionError(f"volume {name} not rendered")


### PR DESCRIPTION
## Summary

- Preserve the live observability state identities after the chart extraction.
- Document the state-bearing objects and the operator migration expectations.
- Add tests that protect Prometheus/Grafana storage and service identity assumptions.

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 60 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `helm lint helm/garz-observability -f helm/garz-observability/values-prod.yaml`
- `helm template garz-observability helm/garz-observability -n monitoring -f helm/garz-observability/values-prod.yaml`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/validate_prometheus_config.py --chart-dir helm/garz-observability -f helm/garz-observability/values-prod.yaml --namespace monitoring --label prod`
- `git diff --check origin/codex/ces-256-observability-extract...HEAD`
- Stacked PR scan check is green on head `2ca0fbe86c2175bca9acfa7f8e9eb8c36cd0ca5b`

Rendered proof:

- `StatefulSet/splattop-prod-prometheus` and `serviceName: splattop-prod-prometheus` are preserved.
- Prometheus generated TSDB PVC name stays tied to `prometheus-data-splattop-prod-prometheus-0`.
- `Deployment/splattop-prod-grafana` is preserved.
- `PersistentVolumeClaim/splattop-prod-grafana-storage` is preserved.
- `Deployment/splattop-prod-alertmanager` is preserved.

## Notes

Stacked on #228. Still draft/operator-gated until the observability extraction migration plan is reviewed end to end.
