### PR TITLE
CES-258: re-scope observability content

### DIFF
--- a/docs/developer-cheat-sheet.md
+++ b/docs/developer-cheat-sheet.md
@@ -22,21 +22,21 @@ cd GarzAICluster
 helm lint helm/splattop
 helm template helm/splattop -f helm/splattop/values-dev.yaml > /tmp/dev.yaml
 kubeconform -strict /tmp/dev.yaml
-uv run python scripts/validate_prometheus_config.py --values helm/splattop/values-prod.yaml
+uv run python scripts/validate_prometheus_config.py --values helm/garz-observability/values-prod.yaml
 trufflehog filesystem --no-update --only-verified --fail .
 ```
 
 ## Observability Assets
 
-- Grafana dashboard JSON lives in `helm/splattop/files/grafana/dashboards/`.
-- Dashboard mounting is wired in `helm/splattop/templates/monitoring-grafana-configmaps.yaml`.
-- Alert rules live in `helm/splattop/templates/monitoring-prometheus-rules-configmap.yaml`.
+- Grafana dashboard JSON lives in `helm/garz-observability/files/grafana/dashboards/`.
+- Dashboard mounting is wired in `helm/garz-observability/templates/monitoring-grafana-configmaps.yaml`.
+- Cluster observability alert rules live in `helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml`.
 - The `Hot Paths & Snapshots` dashboard is the first place to look for:
   - lookup snapshot freshness/build outcomes,
   - main `/player/{id}` pipeline timings and payload sizes,
   - public `comp.splat.top` player summary/history/results latency and cache behavior.
 - After touching alerts or dashboards, rerun:
-  - `uv run python scripts/validate_prometheus_config.py --values helm/splattop/values-prod.yaml`
+  - `uv run python scripts/validate_prometheus_config.py --values helm/garz-observability/values-prod.yaml`
 
 ## Coordinating with App Repo
 

--- a/docs/domains-and-hostnames.md
+++ b/docs/domains-and-hostnames.md
@@ -19,7 +19,7 @@ Use this checklist when adding a new public hostname or rolling out another DNS 
 ## App-specific follow-up
 
 - `helm/splattop-blog/values-prod.yaml`: update `blog.health.hostHeader`, `blog.env.ALLOWED_HOSTS`, and `blog.env.CSRF_TRUSTED_ORIGINS` when the new hostname is canonical.
-- `helm/splattop/values-prod.yaml`: update `monitoring.grafana.serverDomain` and `monitoring.grafana.serverRootUrl` only if the new Grafana host becomes canonical. If it should just redirect, use vanity hosts.
+- `helm/garz-observability/values-prod.yaml`: update `monitoring.grafana.serverDomain` and `monitoring.grafana.serverRootUrl` only if the new Grafana host becomes canonical. If it should just redirect, use vanity hosts.
 - `helm/garz-ai`: serves FastAPI-backed garz.ai pages, including JustFlip/Habit Taper legal pages at `justflip.garz.ai` and `habit-taper.garz.ai`.
 - Citrus (new): DNS is outside Cloudflare for this cluster, so update app ingress and application settings only (do not change `external-dns` filters) and provision the following records manually:
   - `citrus-grace.com` A 143.244.222.41

--- a/helm/garz-observability/README.md
+++ b/helm/garz-observability/README.md
@@ -28,6 +28,19 @@ The `garz-observability` Argo application renders this chart with
 annotation-based `kubernetes-pods` Prometheus scrape config, alert rules,
 Grafana dashboards, Grafana ingress, Alertmanager, network policies, and PDBs.
 
+The Prometheus rule ConfigMap is split by ownership:
+
+- `cluster-mandate-alerts.yaml` owns cluster, Mandate, Prometheus,
+  Alertmanager, and Grafana health alerts.
+- `splattop-app-alerts.yaml` keeps the existing SplatTop application alerts in
+  this chart for now, so the observability extraction has no alert gap. Those
+  app alerts are deliberately named and grouped separately until SplatTop owns a
+  rule-mount path.
+
+The public Grafana host is `grafana.garz.ai`. The previous
+`grafana.splat.top` hostname is kept as a redirect-only vanity host during the
+rename window.
+
 Required pre-existing secrets:
 
 - `grafana-admin-credentials`

--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -34,6 +34,9 @@ data:
         kubernetes_sd_configs:
           - role: endpoints
         relabel_configs:
+          - action: replace
+            target_label: observability_scope
+            replacement: splattop-app
           - action: keep
             source_labels: [__meta_kubernetes_namespace]
             regex: {{ .Release.Namespace | quote }}
@@ -59,6 +62,9 @@ data:
         kubernetes_sd_configs:
           - role: pod
         relabel_configs:
+          - action: replace
+            target_label: observability_scope
+            replacement: cluster-annotation
           - action: keep
             source_labels:
               - __meta_kubernetes_pod_annotation_prometheus_io_scrape

--- a/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
@@ -9,9 +9,64 @@ metadata:
   labels:
     {{- include "garzObservability.componentLabels" (dict "component" "prometheus-rules" "root" .) | nindent 4 }}
 data:
-  critical-alerts.yaml: |
+  cluster-mandate-alerts.yaml: |
     groups:
-      - name: splattop-critical
+      - name: garzai-cluster-mandate-critical
+        rules:
+          - alert: PrometheusTSDBCapacityHigh
+            expr: |
+              max by (persistentvolumeclaim) (
+                kubelet_volume_stats_used_bytes{namespace="monitoring", persistentvolumeclaim=~"prometheus-data.*"}
+                  /
+                kubelet_volume_stats_capacity_bytes{namespace="monitoring", persistentvolumeclaim=~"prometheus-data.*"}
+              ) > 0.85
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: Prometheus TSDB nearing capacity
+              description: PVC usage for Prometheus exceeded 85% for 15 minutes; consider scaling storage or reducing retention.
+
+          - alert: AlertmanagerDown
+            expr: sum(up{job="alertmanager"}) == 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: Alertmanager is unreachable
+              description: Prometheus could not scrape the Alertmanager endpoints for 5 minutes.
+
+          - alert: MandateSyntheticLiveVerifyFailed
+            expr: |
+              max by (namespace, owner_name) (
+                kube_job_status_failed{namespace="agent-control-plane"}
+                  * on (namespace, job_name) group_left(owner_name)
+                    kube_job_owner{
+                      namespace="agent-control-plane",
+                      owner_kind="CronJob",
+                      owner_name="agent-control-plane-synthetic-live-verify"
+                    }
+              ) > 0
+            for: 2m
+            labels:
+              severity: critical
+              service: mandate
+            annotations:
+              summary: Mandate synthetic live verify failed
+              description: The scheduled Mandate synthetic live verify CronJob has a failed Job; inspect the agent-control-plane synthetic-live-verify logs before the next deploy.
+
+          - alert: GrafanaDown
+            expr: sum(up{job="grafana"}) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: Grafana is unreachable
+              description: Grafana metrics endpoint has been unreachable for 5 minutes.
+
+  splattop-app-alerts.yaml: |
+    groups:
+      - name: splattop-app-critical
         rules:
           - alert: FastAPIDown
             expr: sum(up{job="fastapi"}) == 0
@@ -112,55 +167,4 @@ data:
             annotations:
               summary: API usage queue backlog
               description: api_usage_queue_length exceeded 100 items for 15 minutes; batch flusher may be stalled.
-
-          - alert: PrometheusTSDBCapacityHigh
-            expr: |
-              max by (persistentvolumeclaim) (
-                kubelet_volume_stats_used_bytes{namespace="monitoring", persistentvolumeclaim=~"prometheus-data.*"}
-                  /
-                kubelet_volume_stats_capacity_bytes{namespace="monitoring", persistentvolumeclaim=~"prometheus-data.*"}
-              ) > 0.85
-            for: 15m
-            labels:
-              severity: warning
-            annotations:
-              summary: Prometheus TSDB nearing capacity
-              description: PVC usage for Prometheus exceeded 85% for 15 minutes; consider scaling storage or reducing retention.
-
-          - alert: AlertmanagerDown
-            expr: sum(up{job="alertmanager"}) == 0
-            for: 5m
-            labels:
-              severity: critical
-            annotations:
-              summary: Alertmanager is unreachable
-              description: Prometheus could not scrape the Alertmanager endpoints for 5 minutes.
-
-          - alert: MandateSyntheticLiveVerifyFailed
-            expr: |
-              max by (namespace, owner_name) (
-                kube_job_status_failed{namespace="agent-control-plane"}
-                  * on (namespace, job_name) group_left(owner_name)
-                    kube_job_owner{
-                      namespace="agent-control-plane",
-                      owner_kind="CronJob",
-                      owner_name="agent-control-plane-synthetic-live-verify"
-                    }
-              ) > 0
-            for: 2m
-            labels:
-              severity: critical
-              service: mandate
-            annotations:
-              summary: Mandate synthetic live verify failed
-              description: The scheduled Mandate synthetic live verify CronJob has a failed Job; inspect the agent-control-plane synthetic-live-verify logs before the next deploy.
-
-          - alert: GrafanaDown
-            expr: sum(up{job="grafana"}) == 0
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: Grafana is unreachable
-              description: Grafana metrics endpoint has been unreachable for 5 minutes.
 {{- end }}

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -43,8 +43,8 @@ monitoring:
           app.kubernetes.io/name: splattop
   grafana:
     enabled: true
-    serverDomain: grafana.splat.top
-    serverRootUrl: https://grafana.splat.top/
+    serverDomain: grafana.garz.ai
+    serverRootUrl: https://grafana.garz.ai/
     plugins:
     - marcusolsson-hourly-heatmap-panel
     ingress:
@@ -54,7 +54,7 @@ monitoring:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         nginx.ingress.kubernetes.io/ssl-redirect: "false"
       hosts:
-      - host: grafana.splat.top
+      - host: grafana.garz.ai
         paths:
         - path: /
           pathType: Prefix
@@ -63,8 +63,13 @@ monitoring:
           serviceNameOverride: grafana
       tls:
         enabled: true
-        secretName: grafana-tls
-    vanityHosts: []
+        secretName: grafana-garz-ai-tls
+    vanityHosts:
+    - host: grafana.splat.top
+      target: https://grafana.garz.ai/
+      nameOverride: grafana-splat-top-redirect
+      tlsSecretName: grafana-tls
+      cloudflareProxied: true
     datasourcesConfigMapName: grafana-datasources
     dashboardProvidersConfigMapName: grafana-dashboard-providers
     dashboards:

--- a/tests/test_observability_content_scope.py
+++ b/tests/test_observability_content_scope.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+CLUSTER_ALERTS = {
+    "PrometheusTSDBCapacityHigh",
+    "AlertmanagerDown",
+    "MandateSyntheticLiveVerifyFailed",
+    "GrafanaDown",
+}
+SPLATTOP_APP_ALERTS = {
+    "FastAPIDown",
+    "FastAPIFiveHundreds",
+    "FastAPIHighLatencyP95",
+    "LookupSQLiteSnapshotStale",
+    "CompetitionPlayerSummaryLatencyHigh",
+    "CeleryTaskFailures",
+    "CeleryWorkersStuck",
+    "APIUsageQueueBacklog",
+}
+
+
+def _render_observability_prod() -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "garz-observability",
+            "helm/garz-observability",
+            "-n",
+            "monitoring",
+            "-f",
+            "helm/garz-observability/values-prod.yaml",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        document
+        for document in YAML_PARSER.load_all(result.stdout)
+        if isinstance(document, dict) and document.get("kind")
+    ]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text())
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+def _resource(
+    docs: list[dict[str, Any]],
+    *,
+    kind: str,
+    name: str,
+    namespace: str = "monitoring",
+) -> dict[str, Any]:
+    for document in docs:
+        metadata = document.get("metadata") or {}
+        if (
+            document.get("kind") == kind
+            and metadata.get("name") == name
+            and metadata.get("namespace") == namespace
+        ):
+            return document
+    raise AssertionError(f"{kind}/{namespace}/{name} not rendered")
+
+
+class ObservabilityContentScopeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.docs = _render_observability_prod()
+        cls.values = _load_yaml(
+            REPO_ROOT / "helm" / "garz-observability" / "values-prod.yaml"
+        )
+        cls.rules_configmap = _resource(
+            cls.docs,
+            kind="ConfigMap",
+            name="prometheus-rules",
+        )
+        cls.prometheus_configmap = _resource(
+            cls.docs,
+            kind="ConfigMap",
+            name="prometheus-config",
+        )
+
+    def test_alert_rules_are_split_without_dropping_existing_alerts(self) -> None:
+        rule_files = self.rules_configmap["data"]
+
+        self.assertIn("cluster-mandate-alerts.yaml", rule_files)
+        self.assertIn("splattop-app-alerts.yaml", rule_files)
+        self.assertNotIn("critical-alerts.yaml", rule_files)
+        self.assertEqual(
+            _alert_names(rule_files["cluster-mandate-alerts.yaml"]),
+            CLUSTER_ALERTS,
+        )
+        self.assertEqual(
+            _alert_names(rule_files["splattop-app-alerts.yaml"]),
+            SPLATTOP_APP_ALERTS,
+        )
+
+    def test_scrape_jobs_delineate_cluster_annotation_and_splattop_app_targets(
+        self,
+    ) -> None:
+        prometheus_config = YAML_PARSER.load(
+            self.prometheus_configmap["data"]["prometheus.yml"]
+        )
+        scrape_configs = {
+            config["job_name"]: config
+            for config in prometheus_config["scrape_configs"]
+        }
+
+        self.assertIn("kubernetes-pods", scrape_configs)
+        self.assertIn("fastapi", scrape_configs)
+        self.assertEqual(
+            _relabel_replacement(
+                scrape_configs["kubernetes-pods"],
+                "observability_scope",
+            ),
+            "cluster-annotation",
+        )
+        self.assertEqual(
+            _relabel_replacement(scrape_configs["fastapi"], "observability_scope"),
+            "splattop-app",
+        )
+
+    def test_grafana_canonical_host_is_garzai_with_old_host_redirect(self) -> None:
+        grafana_values = self.values["monitoring"]["grafana"]
+        self.assertEqual(grafana_values["serverDomain"], "grafana.garz.ai")
+        self.assertEqual(grafana_values["serverRootUrl"], "https://grafana.garz.ai/")
+
+        canonical = _resource(self.docs, kind="Ingress", name="grafana-ingress")
+        self.assertEqual(
+            canonical["spec"]["rules"][0]["host"],
+            "grafana.garz.ai",
+        )
+        self.assertEqual(
+            canonical["spec"]["tls"][0]["secretName"],
+            "grafana-garz-ai-tls",
+        )
+
+        redirect = _resource(
+            self.docs,
+            kind="Ingress",
+            name="grafana-splat-top-redirect",
+        )
+        self.assertEqual(redirect["spec"]["rules"][0]["host"], "grafana.splat.top")
+        annotations = redirect["metadata"]["annotations"]
+        self.assertEqual(
+            annotations["nginx.ingress.kubernetes.io/permanent-redirect"],
+            "https://grafana.garz.ai/",
+        )
+        self.assertEqual(
+            redirect["spec"]["tls"][0]["secretName"],
+            "grafana-tls",
+        )
+
+
+def _alert_names(rule_file: str) -> set[str]:
+    payload = YAML_PARSER.load(rule_file)
+    return {
+        rule["alert"]
+        for group in payload["groups"]
+        for rule in group["rules"]
+        if "alert" in rule
+    }
+
+
+def _relabel_replacement(scrape_config: dict[str, Any], target_label: str) -> str:
+    for relabel in scrape_config.get("relabel_configs", []):
+        if relabel.get("target_label") == target_label:
+            return relabel["replacement"]
+    raise AssertionError(
+        f"{scrape_config['job_name']} does not set relabel target {target_label}"
+    )


### PR DESCRIPTION
## Summary

- Re-scope observability content after the chart extraction.
- Split Prometheus rule files into cluster/Mandate and SplatTop app groups.
- Update docs and tests so the extracted observability chart owns only the intended monitoring content.
- Move the public Grafana vanity host to `grafana.garz.ai` while keeping the previous host as a redirect.

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 63 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `helm lint helm/garz-observability -f helm/garz-observability/values-prod.yaml`
- `helm template garz-observability helm/garz-observability -n monitoring -f helm/garz-observability/values-prod.yaml`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/validate_prometheus_config.py --chart-dir helm/garz-observability -f helm/garz-observability/values-prod.yaml --namespace monitoring --label prod`
- `git diff --check origin/codex/ces-257-observability-state...HEAD`
- Stacked PR scan check is green on head `29c8a2c65b8676c835e1884d23675f7516a1f474`

Rendered proof:

- Promtool validates `cluster-mandate-alerts.yaml` with 4 rules.
- Promtool validates `splattop-app-alerts.yaml` with 8 rules.
- Prometheus config still renders both `kubernetes-pods` annotation discovery and the app-specific `fastapi` job.
- Grafana renders with `grafana.garz.ai` and a redirect from the previous host.

## Notes

Stacked on #229. Still draft/operator-gated with the rest of the observability extraction train.
