### PR TITLE
CES-242: auto-roll agent workloads on identity changes

### DIFF
--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -40,6 +40,8 @@ extraVolumeMounts:
 - name: workload-identity-token
   mountPath: /var/run/mandate/workload-identity
   readOnly: true
+rolloutChecksums:
+  workloadIdentityTokenSecret: sha256:889097c9e28f6cb3c6acefd85334b751c94648dc37db935767a421cb7ed3782c
 resources:
   requests:
     cpu: 25m

--- a/helm/agent-workloads/templates/_helpers.tpl
+++ b/helm/agent-workloads/templates/_helpers.tpl
@@ -57,6 +57,24 @@ Image reference for a values image subtree.
 {{- end }}
 
 {{/*
+Checksum of release pins that should roll worker pods when registry pins move.
+*/}}
+{{- define "agent-workloads.releasePinsChecksum" -}}
+{{- if .Values.mandateReleasePins -}}
+{{- toJson .Values.mandateReleasePins | sha256sum -}}
+{{- else -}}
+absent
+{{- end -}}
+{{- end }}
+
+{{/*
+Checksum of the SOPS workload-identity-token Secret ciphertext.
+*/}}
+{{- define "agent-workloads.workloadIdentityTokenSecretChecksum" -}}
+{{- default "absent" .Values.rolloutChecksums.workloadIdentityTokenSecret -}}
+{{- end }}
+
+{{/*
 Image pull secrets.
 */}}
 {{- define "agent-workloads.imagePullSecrets" -}}

--- a/helm/agent-workloads/templates/deployment.yaml
+++ b/helm/agent-workloads/templates/deployment.yaml
@@ -16,10 +16,12 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum.garz.ai/agent-workloads-release-pins: {{ include "agent-workloads.releasePinsChecksum" . | quote }}
+        checksum.garz.ai/agent-workloads-token-secret: {{ include "agent-workloads.workloadIdentityTokenSecretChecksum" . | quote }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "agent-workloads.serviceAccountName" . }}
       {{- include "agent-workloads.imagePullSecrets" . | nindent 6 }}

--- a/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
+++ b/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
@@ -18,10 +18,12 @@ spec:
         {{- with .Values.opencodeProposer.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.opencodeProposer.podAnnotations }}
       annotations:
+        checksum.garz.ai/agent-workloads-release-pins: {{ include "agent-workloads.releasePinsChecksum" . | quote }}
+        checksum.garz.ai/agent-workloads-token-secret: {{ include "agent-workloads.workloadIdentityTokenSecretChecksum" . | quote }}
+        {{- with .Values.opencodeProposer.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "agent-workloads.serviceAccountName" . }}
       enableServiceLinks: false

--- a/helm/agent-workloads/values.yaml
+++ b/helm/agent-workloads/values.yaml
@@ -23,6 +23,9 @@ podLabels: {}
 extraVolumes: []
 extraVolumeMounts: []
 
+rolloutChecksums:
+  workloadIdentityTokenSecret: ""
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532

--- a/scripts/check_agent_workloads_identity_digests.py
+++ b/scripts/check_agent_workloads_identity_digests.py
@@ -146,6 +146,10 @@ def check_agent_workloads_identity_digests(
         overlay_pins=overlay_pins,
         token_claims_by_agent=token_claims_by_agent,
     )
+    _assert_rollout_checksum_matches(
+        values=values,
+        ciphertext_sha256="sha256:" + hashlib.sha256(secret_path.read_bytes()).hexdigest(),
+    )
 
     return (
         "agent-workloads deployed images and workload identity bundle claims "
@@ -439,6 +443,22 @@ def _assert_token_metadata_matches(
         source_commit = entry.get("source_commit")
         if not isinstance(source_commit, str) or not source_commit:
             raise DriftGateError(f"{agent_id} token metadata source_commit is required")
+
+
+def _assert_rollout_checksum_matches(
+    *,
+    values: dict[str, Any],
+    ciphertext_sha256: str,
+) -> None:
+    rollout_checksums = values.get("rolloutChecksums")
+    if not isinstance(rollout_checksums, dict):
+        raise DriftGateError("rolloutChecksums must be a mapping")
+    actual = rollout_checksums.get("workloadIdentityTokenSecret")
+    if actual != ciphertext_sha256:
+        raise DriftGateError(
+            "rolloutChecksums.workloadIdentityTokenSecret mismatch: "
+            f"expected {ciphertext_sha256}, got {actual}"
+        )
 
 
 def _base64_url_decode(encoded: str) -> bytes:

--- a/secrets/agent-workloads/README.md
+++ b/secrets/agent-workloads/README.md
@@ -87,6 +87,13 @@ file. Do not patch individual ciphertext values by hand; the metadata
 `ciphertext_sha256` is the reviewable link between the ledger and the encrypted
 token Secret.
 
+After a token rotation, update
+`apps/agent-workloads/values.yaml:rolloutChecksums.workloadIdentityTokenSecret`
+to the same metadata `ciphertext_sha256`. The Helm chart projects that value
+into the worker pod-template annotations, so a token-only re-mint rolls the
+standing worker processes instead of leaving them cached on the previous
+startup token.
+
 The drift-gate automation receives only the scoped Age key that can decrypt
 `workload-identity-tokens.enc.yaml`. It must not decrypt
 `runtime-secret.enc.yaml`, database URLs, Codex auth JSON, registry credentials,

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -172,6 +172,31 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
 
         self.assertIn("match release pins", result)
 
+    def test_gate_rejects_missing_workload_identity_rollout_checksum(self) -> None:
+        root = _fixture_repo()
+        values_path = root / "apps" / "agent-workloads" / "values.yaml"
+        values = YAML_PARSER.load(values_path.read_text())
+        del values["rolloutChecksums"]
+        _write_yaml(values_path, values)
+
+        with self.assertRaisesRegex(DriftGateError, "rolloutChecksums"):
+            _check(root)
+
+    def test_gate_rejects_stale_workload_identity_rollout_checksum(self) -> None:
+        root = _fixture_repo()
+        values_path = root / "apps" / "agent-workloads" / "values.yaml"
+        values = YAML_PARSER.load(values_path.read_text())
+        values["rolloutChecksums"]["workloadIdentityTokenSecret"] = (
+            "sha256:" + "9" * 64
+        )
+        _write_yaml(values_path, values)
+
+        with self.assertRaisesRegex(
+            DriftGateError,
+            "rolloutChecksums.workloadIdentityTokenSecret",
+        ):
+            _check(root)
+
     def test_gate_rejects_values_overlay_code_digest_mismatch(self) -> None:
         root = _fixture_repo()
         values_path = root / "apps" / "agent-workloads" / "values.yaml"
@@ -324,7 +349,6 @@ def _fixture_repo(
     }
     if include_pins:
         values["mandateReleasePins"] = DIGESTS
-    _write_yaml(values_path, values)
 
     configmap_path = root / "apps" / "agent-control-plane-registry-overlay" / (
         "configmap.yaml"
@@ -362,7 +386,12 @@ def _fixture_repo(
         },
     }
     _write_yaml(token_secret_path, token_secret)
-    _write_metadata(root)
+    ciphertext_hash = _write_metadata(root)
+    if include_pins:
+        values["rolloutChecksums"] = {
+            "workloadIdentityTokenSecret": ciphertext_hash,
+        }
+    _write_yaml(values_path, values)
     return root
 
 
@@ -412,7 +441,7 @@ def _configmap() -> dict[str, Any]:
     }
 
 
-def _write_metadata(root: Path) -> None:
+def _write_metadata(root: Path) -> str:
     token_secret_path = root / TOKEN_SECRET_PATH
     ciphertext_hash = "sha256:" + hashlib.sha256(token_secret_path.read_bytes()).hexdigest()
     metadata = {
@@ -440,6 +469,7 @@ def _write_metadata(root: Path) -> None:
         },
     }
     _write_yaml(root / TOKEN_METADATA_PATH, metadata)
+    return ciphertext_hash
 
 
 def _mwit_token(

--- a/tests/test_agent_workloads_networkpolicy.py
+++ b/tests/test_agent_workloads_networkpolicy.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import copy
+import hashlib
+import json
 import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -12,10 +16,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 YAML_PARSER = YAML(typ="safe")
 
 
-def _render_agent_workloads_prod() -> list[dict[str, Any]]:
+def _render_agent_workloads_prod(
+    *,
+    values_path: Path | None = None,
+) -> list[dict[str, Any]]:
     if shutil.which("helm") is None:
         raise unittest.SkipTest("helm is required for chart render tests")
 
+    values_path = values_path or Path("apps/agent-workloads/values.yaml")
     result = subprocess.run(
         [
             "helm",
@@ -23,7 +31,7 @@ def _render_agent_workloads_prod() -> list[dict[str, Any]]:
             "agent-workloads",
             "helm/agent-workloads",
             "-f",
-            "apps/agent-workloads/values.yaml",
+            str(values_path),
         ],
         check=True,
         cwd=str(REPO_ROOT),
@@ -63,6 +71,20 @@ def _container_by_name(deployment: dict[str, Any], name: str) -> dict[str, Any]:
         if container["name"] == name:
             return container
     raise AssertionError(f"container {name} not rendered")
+
+
+def _release_pins_checksum(values: dict[str, Any]) -> str:
+    serialized = json.dumps(
+        values["mandateReleasePins"],
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _write_yaml(path: Path, value: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as file:
+        YAML_PARSER.dump(value, file)
 
 
 class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
@@ -150,6 +172,90 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
         self.assertEqual(deployment["spec"]["replicas"], 2)
         self.assertEqual(self.values["opencodeProposer"]["replicaCount"], 1)
         self.assertEqual(opencode_deployment["spec"]["replicas"], 1)
+
+    def test_worker_pods_roll_on_identity_secret_or_release_pin_change(self) -> None:
+        deployments = {
+            name: _find_doc(self.docs, kind="Deployment", name=name)
+            for name in (
+                "agent-workloads",
+                "agent-workloads-opencode-proposer",
+            )
+        }
+        expected_token_checksum = self.values["rolloutChecksums"][
+            "workloadIdentityTokenSecret"
+        ]
+        expected_release_checksum = _release_pins_checksum(self.values)
+
+        for deployment in deployments.values():
+            annotations = deployment["spec"]["template"]["metadata"]["annotations"]
+            self.assertEqual(
+                annotations["checksum.garz.ai/agent-workloads-token-secret"],
+                expected_token_checksum,
+            )
+            self.assertEqual(
+                annotations["checksum.garz.ai/agent-workloads-release-pins"],
+                expected_release_checksum,
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_values_path = Path(temp_dir) / "values.yaml"
+            changed_token_values = copy.deepcopy(self.values)
+            changed_token_values["rolloutChecksums"][
+                "workloadIdentityTokenSecret"
+            ] = "sha256:" + "9" * 64
+            _write_yaml(temp_values_path, changed_token_values)
+            changed_token_docs = _render_agent_workloads_prod(
+                values_path=temp_values_path,
+            )
+            changed_token_deployment = _find_doc(
+                changed_token_docs,
+                kind="Deployment",
+                name="agent-workloads",
+            )
+            changed_token_annotations = changed_token_deployment["spec"]["template"][
+                "metadata"
+            ]["annotations"]
+            self.assertNotEqual(
+                changed_token_annotations[
+                    "checksum.garz.ai/agent-workloads-token-secret"
+                ],
+                expected_token_checksum,
+            )
+            self.assertEqual(
+                changed_token_annotations[
+                    "checksum.garz.ai/agent-workloads-release-pins"
+                ],
+                expected_release_checksum,
+            )
+
+            changed_pins_values = copy.deepcopy(self.values)
+            changed_pins_values["mandateReleasePins"]["data.workspace_probe"][
+                "codeDigest"
+            ] = "sha256:" + "8" * 64
+            _write_yaml(temp_values_path, changed_pins_values)
+            changed_pins_docs = _render_agent_workloads_prod(
+                values_path=temp_values_path,
+            )
+            changed_pins_deployment = _find_doc(
+                changed_pins_docs,
+                kind="Deployment",
+                name="agent-workloads",
+            )
+            changed_pins_annotations = changed_pins_deployment["spec"]["template"][
+                "metadata"
+            ]["annotations"]
+            self.assertEqual(
+                changed_pins_annotations[
+                    "checksum.garz.ai/agent-workloads-token-secret"
+                ],
+                expected_token_checksum,
+            )
+            self.assertNotEqual(
+                changed_pins_annotations[
+                    "checksum.garz.ai/agent-workloads-release-pins"
+                ],
+                expected_release_checksum,
+            )
 
     def test_opencode_apply_executor_runs_without_model_or_provider_credentials(
         self,


### PR DESCRIPTION
## Summary
- add worker pod-template checksum annotations for `mandateReleasePins` and workload-identity token Secret ciphertext
- make the identity drift gate fail if token metadata ciphertext and `apps/agent-workloads/values.yaml` rollout checksum diverge
- cover both `agent-workloads` and `agent-workloads-opencode-proposer` rendered Deployments so token-only re-mints and release-pin moves roll standing workers

## Current Shape
- rebased onto GarzAICluster `main` after #235 and #236
- PR is intentionally still draft until the operator live acceptance can prove a token-only or release-pin-only sync rolls the affected worker pods without a manual `kubectl rollout restart`

## Validation
- `SOPS_AGE_KEY_FILE=/root/dev/SplatTopConfig/keys/age-private.txt UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_agent_workloads_identity_digests.py`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 59 tests passed
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `helm lint helm/agent-workloads`
- `helm template agent-workloads helm/agent-workloads -f apps/agent-workloads/values.yaml`
- `git diff --check`

## Live Acceptance After Merge/Sync
- token-only re-mint changes `rolloutChecksums.workloadIdentityTokenSecret`, Argo applies a changed worker pod template, and pods roll without manual `kubectl rollout restart`
- registry/release pin changes update the release-pins checksum annotation and roll the same worker pods
- governed worker claims are accepted after the roll

Refs CES-242.
