### PR TITLE
CES-236: scale readonly worker replicas

### DIFF
--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -4,7 +4,8 @@ global:
   runtimeSecretName: agent-workloads-secrets
 nameOverride: agent-workloads
 fullnameOverride: agent-workloads
-replicaCount: 1
+# CES-236: keep the readonly-query worker parallel under burst load.
+replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
   tag: sha-0c31c23c1eb2

--- a/tests/test_agent_workloads_networkpolicy.py
+++ b/tests/test_agent_workloads_networkpolicy.py
@@ -134,6 +134,23 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
             },
         )
 
+    def test_workspace_probe_runs_multiple_replicas_for_burst_claims(self) -> None:
+        deployment = _find_doc(
+            self.docs,
+            kind="Deployment",
+            name="agent-workloads",
+        )
+        opencode_deployment = _find_doc(
+            self.docs,
+            kind="Deployment",
+            name="agent-workloads-opencode-proposer",
+        )
+
+        self.assertEqual(self.values["replicaCount"], 2)
+        self.assertEqual(deployment["spec"]["replicas"], 2)
+        self.assertEqual(self.values["opencodeProposer"]["replicaCount"], 1)
+        self.assertEqual(opencode_deployment["spec"]["replicas"], 1)
+
     def test_opencode_apply_executor_runs_without_model_or_provider_credentials(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- scale the main `agent-workloads` readonly-query worker Deployment from 1 to 2 replicas;
- keep the `agent-workloads-opencode-proposer` Deployment at 1 replica;
- add a Helm render contract asserting the intended replica split.

## Validation

- `SOPS_AGE_KEY_FILE=/root/dev/SplatTopConfig/keys/age-private.txt UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_agent_workloads_identity_digests.py`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 57 tests passed
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `helm lint helm/agent-workloads`
- `helm template agent-workloads helm/agent-workloads -f apps/agent-workloads/values.yaml`
- `git diff --check origin/main...HEAD`
- GitHub Actions: full Config Repo CI green on head `39ace400b8ba5ee35a0fa58f11a44daef9c58c41`

Rendered proof:

- `Deployment/agent-workloads` renders `replicas: 2`
- `Deployment/agent-workloads-opencode-proposer` renders `replicas: 1`

## Acceptance still needed

- operator syncs `agent-workloads` through Argo;
- burst N governed readonly jobs and verify p95 queued-to-claim is bounded;
- confirm no double-claim or lease collision, and every parallel job receives its own digest-bound lease;
- confirm per-capability concurrency still respects budget/lease caps.

Refs CES-236.
