### PR TITLE
CES-255: record garz.ai cluster identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 
 ## Quick links
 
-- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/secrets-strategy.md`, `docs/developer-cheat-sheet.md`
+- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/developer-cheat-sheet.md`
 - KSOPS deep dive and CMP recipe: `docs/ksops-llm-response.md`
 - Argo objects: `argocd/` (AppProjects, Applications, AppSets)
 - Charts/values: `helm/` and `apps/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,18 @@
 # Infra Docs Overview
 
-These documents capture the canonical workflows for the SplatTop config repository. Read them in roughly this order when contributing here:
+These documents capture the canonical workflows for the GarzAICluster repository.
+Read them in roughly this order when contributing here:
 
 1. `bootstrap.md` – bring-up steps for a fresh cluster + Argo that points to this repo.
 2. `release-workflow.md` – how images flow from the app repo into environment value bumps, including hotfixes/rollbacks.
 3. `argo-operations.md` – AppProject guardrails, policy enforcement, and day-to-day Argo duties.
-4. `domains-and-hostnames.md` – public hostname rollout checklist, including multi-zone external-dns changes.
-5. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
-6. `mandate-apply.md` – local declarative enablement planner for Mandate
+4. `cluster-identity.md` – current garz.ai cluster identity and the deliberate internal `splattop` names that remain stable.
+5. `domains-and-hostnames.md` – public hostname rollout checklist, including multi-zone external-dns changes.
+6. `secrets-strategy.md` – SOPS + Age plan, rotation, and CI/Dev ergonomics.
+7. `mandate-apply.md` – local declarative enablement planner for Mandate
    workload capability wiring.
-7. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-8. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+8. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+9. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/cluster-identity.md
+++ b/docs/cluster-identity.md
@@ -1,0 +1,61 @@
+# Cluster Identity
+
+This document records the GarzAICluster production cluster identity and the
+current decision on legacy `splattop` names. The goal is to make the user-facing
+operator identity read `garz.ai` without causing a flag-day Argo or monitoring
+history reset.
+
+## Live Identity
+
+Observed on 2026-06-23:
+
+| Surface | Current value | Decision |
+| --- | --- | --- |
+| DigitalOcean Kubernetes cluster name | `k8s-nyc3-garz-ai` | Moved to garz.ai identity |
+| DigitalOcean Kubernetes cluster ID | `4124737a-6816-4ee9-af15-cf1c0f6f2f65` | Immutable provider ID |
+| Kubernetes context | `do-nyc3-k8s-nyc3-garz-ai` | Moved to garz.ai identity |
+| Region | `nyc3` | Stays |
+| GitOps repository | `cesaregarza/GarzAICluster` | Moved to GarzAICluster |
+
+Source-controlled manifests do not pin the old kubectl context name. Operators
+should refresh local kubeconfig with:
+
+```bash
+doctl kubernetes cluster kubeconfig save 4124737a-6816-4ee9-af15-cf1c0f6f2f65
+kubectl config use-context do-nyc3-k8s-nyc3-garz-ai
+```
+
+## Names That Stay For Now
+
+These names still contain `splattop` by design. They are internal resource,
+product, or history-bearing identifiers and must not be renamed casually.
+
+| Name family | Current examples | Reason to keep |
+| --- | --- | --- |
+| Argo AppProject | `argocd/projects/splattop-project.yaml`, live project `splattop` | AppProject names are effectively delete-and-recreate; current RBAC policies are scoped to `proj:splattop:*` |
+| Root and umbrella apps | `splattop-root`, `splattop-prod` | App names are immutable; renaming means delete-and-recreate and must be sequenced so children are not orphaned |
+| Monitoring Helm release resources | `splattop-prod-prometheus`, `splattop-prod-grafana`, `splattop-prod-alertmanager` | Renaming a Helm release would recreate resources and risks Prometheus TSDB and Grafana state continuity |
+| SplatTop product workloads | `helm/splattop`, `splattop-teams`, `splattop-blog`, `splatvote` | These are product names, not cluster identity names |
+| Bot namespace/application prefix | `splattop-bot-*`, `splattop-bots` | Existing AppSets and namespace policies depend on the prefix; migrate separately if the product prefix changes |
+| Historical docs | `docs/historical/**` | Kept as dated evidence, not current operator instructions |
+
+## Future Rename Sequence
+
+If an operator later chooses to rename internal Argo or Helm release resources,
+do it as a staged maintenance event:
+
+1. Decide the target names and update this matrix before changing manifests.
+2. Preserve monitoring state first. For Prometheus and Grafana, identify the
+   PVCs, ConfigMaps, and Secrets that must be retained before any release rename.
+3. Create replacement AppProject and Application manifests in Git with
+   destination, source repo, and RBAC parity.
+4. Sync replacement apps while old apps are still present, then verify
+   `Synced` and `Healthy`.
+5. Delete the old Application resources only after the replacement owns the same
+   rendered Kubernetes resources or after an explicit cutover window.
+6. Keep redirects, DNS, and operator docs compatible until all live Argo and
+   monitoring evidence is green.
+
+The lower-risk current state is intentional: user-facing provider and kubectl
+identity are garz.ai, while high-risk internal names remain stable until a
+separate operator-approved cutover preserves state.

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC = REPO_ROOT / "docs" / "cluster-identity.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+ROOT_README = REPO_ROOT / "README.md"
+SPLATTOP_PROJECT = REPO_ROOT / "argocd" / "projects" / "splattop-project.yaml"
+SPLATTOP_ROOT = REPO_ROOT / "argocd" / "applications" / "root.yaml"
+SPLATTOP_PROD = REPO_ROOT / "argocd" / "applications" / "splattop-prod.yaml"
+
+YAML_PARSER = YAML(typ="safe")
+
+
+class ClusterIdentityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.doc = DOC.read_text(encoding="utf-8")
+        cls.project = _load_yaml(SPLATTOP_PROJECT)
+        cls.root = _load_yaml(SPLATTOP_ROOT)
+        cls.prod = _load_yaml(SPLATTOP_PROD)
+
+    def test_cluster_identity_doc_is_discoverable(self) -> None:
+        self.assertIn("docs/cluster-identity.md", ROOT_README.read_text())
+        self.assertIn("cluster-identity.md", DOCS_README.read_text())
+
+    def test_live_garzai_cluster_identity_is_recorded(self) -> None:
+        self.assertIn("k8s-nyc3-garz-ai", self.doc)
+        self.assertIn("do-nyc3-k8s-nyc3-garz-ai", self.doc)
+        self.assertIn("4124737a-6816-4ee9-af15-cf1c0f6f2f65", self.doc)
+        self.assertIn("cesaregarza/GarzAICluster", self.doc)
+
+    def test_internal_splattop_names_are_explicit_stays(self) -> None:
+        project_name = self.project["metadata"]["name"]
+        root_name = self.root["metadata"]["name"]
+        prod_name = self.prod["metadata"]["name"]
+        release_name = self.prod["spec"]["source"]["helm"]["releaseName"]
+
+        self.assertEqual(project_name, "splattop")
+        self.assertEqual(root_name, "splattop-root")
+        self.assertEqual(prod_name, "splattop-prod")
+        self.assertEqual(release_name, "splattop-prod")
+
+        for name in (project_name, root_name, prod_name, release_name):
+            self.assertIn(name, self.doc)
+        self.assertIn("splattop-prod-prometheus", self.doc)
+        self.assertIn("Prometheus TSDB", self.doc)
+        self.assertIn("Grafana state", self.doc)
+
+    def test_future_rename_sequence_preserves_state(self) -> None:
+        required_phrases = (
+            "staged maintenance event",
+            "Preserve monitoring state first",
+            "Create replacement AppProject and Application manifests",
+            "Sync replacement apps while old apps are still present",
+            "Delete the old Application resources only after",
+        )
+        for phrase in required_phrases:
+            self.assertIn(phrase, self.doc)
+
+
+def _load_yaml(path: Path) -> dict:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"YAML mapping expected: {path}")
+    return loaded


### PR DESCRIPTION
## Summary

- Record the canonical production cluster identity as `k8s-nyc3-garz-ai`.
- Document the current kubectl context as `do-nyc3-k8s-nyc3-garz-ai`.
- Add `docs/cluster-identity.md` with the rename/stay decision matrix so future `splattop` leftovers are intentional rather than accidental.
- Add a Python contract test that locks the documented DigitalOcean cluster name/context and protects the intentionally retained legacy app namespaces.

## Live evidence

```text
$ kubectl config current-context
do-nyc3-k8s-nyc3-garz-ai

$ doctl kubernetes cluster list --format ID,Name,Region,Status --no-header
4124737a-6816-4ee9-af15-cf1c0f6f2f65    k8s-nyc3-garz-ai    nyc3    running
```

## Validation

- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest tests.test_cluster_identity` -> 4 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests` -> 60 tests OK
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/generate_grant_ownership.py --check`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python scripts/check_control_plane_release_pin.py`
- `git diff --check origin/main...HEAD`
- GitHub Actions: full Config Repo CI green on head `771589b92263a58e61278254c261702af2a3870c`

## Operator notes

This is the safe documentation/contract slice for CES-255. The destructive future rename work for Argo AppProjects/Applications or Helm release names remains operator-gated and should preserve Prometheus/Grafana continuity before any delete/recreate action.
