### PR TITLE
CES-267: bump workflow fetches DOCR token from broker (retire static DIGITALOCEAN_ACCESS_TOKEN)

### DIFF
--- a/.github/workflows/bump-image.yml
+++ b/.github/workflows/bump-image.yml
@@ -154,6 +154,9 @@ jobs:
     needs: detect-intent
     runs-on: ubuntu-latest
     environment: config
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       bot: ${{ steps.out.outputs.bot }}
       image: ${{ steps.out.outputs.image }}
@@ -168,15 +171,23 @@ jobs:
           curl -sSL -o /tmp/go-containerregistry.tar.gz https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz
           sudo tar -C /usr/local/bin -xzf /tmp/go-containerregistry.tar.gz crane
 
+      - name: Fetch DOCR credentials from broker
+        id: docr-creds
+        uses: cesaregarza/.github/actions/fetch-broker-credentials@main
+        with:
+          broker-url: https://credentials.garz.ai
+          audience: https://credentials.garz.ai/v1
+          capability: digitalocean-registry-write
+
       - name: Authenticate to DigitalOcean Registry
         env:
-          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          DIGITALOCEAN_REGISTRY_TOKEN: ${{ fromJson(steps.docr-creds.outputs.secrets-json).DIGITALOCEAN_REGISTRY_TOKEN }}
         run: |
-          if [ -z "$DIGITALOCEAN_ACCESS_TOKEN" ]; then
-            echo "DIGITALOCEAN_ACCESS_TOKEN is required to query image digests" >&2
+          if [ -z "$DIGITALOCEAN_REGISTRY_TOKEN" ]; then
+            echo "DIGITALOCEAN_REGISTRY_TOKEN is required to query image digests" >&2
             exit 1
           fi
-          echo "$DIGITALOCEAN_ACCESS_TOKEN" | crane auth login registry.digitalocean.com -u doctl --password-stdin
+          echo "$DIGITALOCEAN_REGISTRY_TOKEN" | crane auth login registry.digitalocean.com -u doctl --password-stdin
 
       - name: Install yq
         run: |


### PR DESCRIPTION
## Why
The `resolve-and-verify` job in `bump-image.yml` authenticated to DOCR with a static `secrets.DIGITALOCEAN_ACCESS_TOKEN` that has **expired** → `crane digest` returns **401**, breaking every tag-mode bot bump (blocked agent-8s v1.2.0 / issue #207). Yesterday's digest-mode bumps passed because they skip `crane digest`.

## Change
- Add `permissions: { id-token: write, contents: read }` to the `resolve-and-verify` job (OIDC for the broker; checkout).
- Add a `cesaregarza/.github/actions/fetch-broker-credentials@main` step requesting capability **`digitalocean-registry-write`** — least-authority that works (registry-scoped read for the digest lookup; **no** `digitalocean-k8s-deploy` cluster authority).
- Feed `fromJson(steps.docr-creds.outputs.secrets-json).DIGITALOCEAN_REGISTRY_TOKEN` into the existing `crane auth login … -u doctl` (login mechanism unchanged; only the token source moves to the broker).
- No remaining `secrets.DIGITALOCEAN_ACCESS_TOKEN` reference.

## Pairs with / sequencing
- Broker policy grant: **github-credential-broker#10** (adds the matching `digitalocean-registry-write` grant for this workflow_ref + `environment: config`).
- After **both** merge, the operator deploys the policy (`scripts/deploy-policy.sh` over Tailscale SSH — not automatic), then re-`/approve` issue #207.

## Assumption to confirm
The DO registry token authenticates via `crane auth login … -u doctl --password-stdin` (same as the prior DO API token). If `digitalocean-registry-write` is a DOCR-generated docker credential rather than a DO API token, the login `-u` may need adjusting — easy to verify on first run.

Draft — operator-gated repo. CES-267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)