### PR TITLE
CES-271: bump control plane broker fix

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-369ebe8c8f30
+  tag: sha-8623c37099a3
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 369ebe8c8f3046a5833a9e03539e79bec5e832f2
+      targetRevision: 8623c37099a3471fb4c5c4d0a30061f537b82046
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-369ebe8c8f30` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-8623c37099a3` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-369ebe8c8f30
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-8623c37099a3
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary
- pin agent-control-plane Argo source to agent-platform 8623c37099a3471fb4c5c4d0a30061f537b82046
- bump the CP runtime image tag to sha-8623c37099a3
- keep the Postgres restore runbook image references aligned with the deployed CP image

## Why
CES-271 regressed after the remint because the control plane did not advertise the preset-routed readonly SQL broker for analytical-only deployments. agent-platform #213 merged the broker fix and published this image.

## Verification
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-cp-bump run python -m unittest discover -s tests
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-cp-bump run python scripts/check_control_plane_release_pin.py
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-cp-bump run python scripts/generate_grant_ownership.py --check
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/agent-platform-cp-8623c370 run --with ruamel.yaml python /root/dev/.worktrees/garzaicluster-ces271-cp-bump/scripts/check_agent_control_plane_registry_compat.py --repo-root /root/dev/.worktrees/garzaicluster-ces271-cp-bump --agent-platform-repo /root/dev/.worktrees/agent-platform-cp-8623c370
- helm lint /root/dev/.worktrees/agent-platform-cp-8623c370/helm/mandate -f /root/dev/.worktrees/garzaicluster-ces271-cp-bump/apps/agent-control-plane/values.yaml
- helm template agent-control-plane /root/dev/.worktrees/agent-platform-cp-8623c370/helm/mandate -f /root/dev/.worktrees/garzaicluster-ces271-cp-bump/apps/agent-control-plane/values.yaml --namespace agent-control-plane >/tmp/agent-control-plane-ces271.yaml
- git -C /root/dev/.worktrees/garzaicluster-ces271-cp-bump diff --check