### PR TITLE
CES-271: bump control plane schema broker fix

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-8623c37099a3
+  tag: sha-e9dd2b1393ef
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 8623c37099a3471fb4c5c4d0a30061f537b82046
+      targetRevision: e9dd2b1393ef09f3fc39c631743d75960be1a0d6
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-8623c37099a3` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-e9dd2b1393ef` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-8623c37099a3
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-e9dd2b1393ef
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary
- pin agent-control-plane Argo source to agent-platform e9dd2b1393ef09f3fc39c631743d75960be1a0d6
- bump the CP runtime image tag to sha-e9dd2b1393ef
- keep the Postgres restore runbook image references aligned with the deployed CP image

## Why
The first CES-271 CP bump fixed admission/broker discovery and worker claims, but the live readonly_query smoke then failed during schema_inspection because the Postgres broker query used unescaped format(%I.%I) placeholders under psycopg. agent-platform #214 fixes that and published this image.

## Verification
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump run python -m unittest discover -s tests
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump run python scripts/check_control_plane_release_pin.py
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump run python scripts/generate_grant_ownership.py --check
- UV_CACHE_DIR=/root/dev/.uv-cache uv --directory /root/dev/.worktrees/agent-platform-cp-e9dd2b13 run --with ruamel.yaml python /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump/scripts/check_agent_control_plane_registry_compat.py --repo-root /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump --agent-platform-repo /root/dev/.worktrees/agent-platform-cp-e9dd2b13
- helm lint /root/dev/.worktrees/agent-platform-cp-e9dd2b13/helm/mandate -f /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump/apps/agent-control-plane/values.yaml
- helm template agent-control-plane /root/dev/.worktrees/agent-platform-cp-e9dd2b13/helm/mandate -f /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump/apps/agent-control-plane/values.yaml --namespace agent-control-plane >/tmp/agent-control-plane-ces271-final.yaml
- git -C /root/dev/.worktrees/garzaicluster-ces271-schema-format-bump diff --check