### PR TITLE
Preserve CP TEMP privilege during secret provisioning

### DIFF
--- a/scripts/provision_agent_control_plane_secrets.py
+++ b/scripts/provision_agent_control_plane_secrets.py
@@ -209,6 +209,7 @@ def run_sql(admin_url: str, database: str, schema: str, role: str, password: str
             EXECUTE format('REVOKE ALL ON DATABASE %I FROM %I', db_name, role_name);
             EXECUTE format('GRANT CONNECT ON DATABASE %I TO %I', db_name, role_name);
             EXECUTE format('GRANT CREATE ON DATABASE %I TO %I', db_name, role_name);
+            EXECUTE format('GRANT TEMPORARY ON DATABASE %I TO %I', db_name, role_name);
 
             EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
             EXECUTE format('ALTER SCHEMA %I OWNER TO %I', schema_name, role_name);

--- a/tests/test_provision_agent_control_plane_secrets.py
+++ b/tests/test_provision_agent_control_plane_secrets.py
@@ -1,0 +1,18 @@
+import inspect
+import unittest
+
+from scripts import provision_agent_control_plane_secrets as provision
+
+
+class RuntimeRoleSqlTests(unittest.TestCase):
+    def test_runtime_role_keeps_temporary_database_privilege(self) -> None:
+        source = inspect.getsource(provision.run_sql)
+
+        self.assertIn("REVOKE ALL ON DATABASE %I FROM %I", source)
+        self.assertIn("GRANT CONNECT ON DATABASE %I TO %I", source)
+        self.assertIn("GRANT CREATE ON DATABASE %I TO %I", source)
+        self.assertIn("GRANT TEMPORARY ON DATABASE %I TO %I", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- grant TEMPORARY on the bots database to the CP runtime role during secret provisioning
- add a regression test so future rotations do not drop the grant again

## Verification
- uv run python -m unittest discover -s tests
- live repair verified: CP role can CREATE TEMP TABLE; one-off postgres sweep completed successfully