### PR TITLE
CES-290 bump control plane image to d3b7fc0b

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -32,9 +32,15 @@ data:
         agent_workloads.db_probe:
           description: Imported reversible staging database workspace probe.
           output_schema: agent_workloads_db_probe_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.db_probe
         agent_workloads.readonly_query:
           description: Imported governed readonly SQL query worker.
           output_schema: agent_workloads_readonly_query_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.readonly_query
           model_lease:
             required: true
             allowed_tier: fast
@@ -100,6 +106,9 @@ data:
           description: Imported OpenCode proposer that returns metadata-only proposal
             artifacts.
           output_schema: agent_workloads_opencode_proposal_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_propose
           model_lease:
             required: true
             allowed_tier: fast
@@ -156,6 +165,9 @@ data:
           description: Imported OpenCode answer task that performs bounded local work
             and returns answer text through the output gate.
           output_schema: agent_workloads_opencode_task_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_task
           task_contract:
             input_schema: task_intent
             text: Describe the work to perform in task.text.
@@ -211,6 +223,9 @@ data:
           description: Imported OpenCode orchestrator that may select one server-authorized
             delegated child capability under the parent worker claim.
           output_schema: agent_workloads_opencode_orchestrate_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_orchestrate
           task_contract:
             input_schema: task_intent
             text: Describe the governed work to route or answer in task.text.
@@ -292,6 +307,9 @@ data:
         agent_workloads.opencode_apply:
           description: Imported OpenCode apply executor for approved proposal diffs.
           output_schema: agent_workloads_opencode_apply_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_apply
           approval_mode: admin_confirm
           result_contract:
             output_schema: agent_workloads_opencode_apply_result_v1

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-be04191294c3
+  tag: sha-d3b7fc0b2f66
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: be04191294c33ee79cb0f9e42413853988dbfb7f
+      targetRevision: d3b7fc0b2f66cff6594642d9969710f35d3134de
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -35,6 +35,7 @@ control-plane restart and do not require re-minting.
 | capability | key | owner | consequence |
 | --- | --- | --- | --- |
 | `agent_workloads.db_probe` | `description` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.db_probe` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.db_probe` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `approval_mode` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `artifacts` | `deployment_overlay` | `control_plane_restart` |
@@ -42,6 +43,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_apply` | `disclosure` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `negative_affordances` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.opencode_apply` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `session_authority_budget` | `mixed` | `control_plane_restart` |
@@ -51,6 +53,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_orchestrate` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `model_lease` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_orchestrate` | `negative_affordances` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.opencode_orchestrate` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `session_authority_budget` | `mixed` | `control_plane_restart` |
@@ -61,6 +64,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_propose` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_propose` | `model_lease` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_propose` | `negative_affordances` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.opencode_propose` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_propose` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_propose` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_propose` | `session_authority_budget` | `mixed` | `control_plane_restart` |
@@ -70,6 +74,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_task` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_task` | `model_lease` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_task` | `negative_affordances` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.opencode_task` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_task` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_task` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_task` | `session_authority_budget` | `mixed` | `control_plane_restart` |
@@ -79,6 +84,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.readonly_query` | `broker_lease` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `description` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `model_lease` | `deployment_overlay` | `control_plane_restart` |
+| `agent_workloads.readonly_query` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `session_authority_budget` | `mixed` | `control_plane_restart` |
 

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -40,6 +40,12 @@ capabilities:
         remint_required: true
         digest_moves: true
         source: workload agent.yaml
+      output_gate:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
       output_schema:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
@@ -84,6 +90,12 @@ capabilities:
         remint_required: false
         digest_moves: false
         source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
+      output_gate:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
       output_schema:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
@@ -139,6 +151,12 @@ capabilities:
         digest_moves: false
         source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
       negative_affordances:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
+      output_gate:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
         remint_required: true
@@ -216,6 +234,12 @@ capabilities:
         remint_required: true
         digest_moves: true
         source: workload agent.yaml
+      output_gate:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
       output_schema:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
@@ -277,6 +301,12 @@ capabilities:
         digest_moves: false
         source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
       negative_affordances:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
+      output_gate:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
         remint_required: true
@@ -349,6 +379,12 @@ capabilities:
         digest_moves: true
         source: workload agent.yaml
       negative_affordances:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
+      output_gate:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
         remint_required: true

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-be04191294c3` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-d3b7fc0b2f66` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-be04191294c3
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-d3b7fc0b2f66
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary
- Bump agent-control-plane image tag to `sha-d3b7fc0b2f66` for CES-286 deployment.
- Pin the Argo agent-platform chart source to `d3b7fc0b2f66cff6594642d9969710f35d3134de`.
- Update the Postgres restore runbook current-image/schema-check references to the same CP image.

## Validation
- Confirmed DOCR tag `sha-d3b7fc0b2f66` exists for `agent-platform`.
- `uv run python -m unittest discover -s tests`
- `uv run python scripts/check_control_plane_release_pin.py`
- `helm lint /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml`
- `helm template agent-control-plane /root/dev/agent-platform/helm/mandate -f apps/agent-control-plane/values.yaml` shows model-gateway and other CP workloads using `sha-d3b7fc0b2f66`.
- `git diff --check`

## Operator notes
- Migration `018_output_gate_policy_lease.sql` is additive and runs through the CP startup/migration path.
- Model gateway shares the same image value and will roll with this bump.
- Live acceptance remains operator/critic sync + readonly_query re-smoke per CES-290.