### PR TITLE
Add Citrus email runtime secret

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             - secretRef:
                 name: {{ .Values.application.secretName }}
                 optional: true
+            {{- if .Values.application.emailSecretName }}
+            - secretRef:
+                name: {{ .Values.application.emailSecretName }}
+                optional: true
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.targetPort }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 application:
   configMapName: django-config
   secretName: django-secrets
+  emailSecretName: django-email-secrets
   command: >
     python manage.py migrate --noinput &&
     python manage.py collectstatic --noinput &&
@@ -22,6 +23,11 @@ application:
   configData:
     DJANGO_DEBUG: "False"
     ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
+    DEFAULT_FROM_EMAIL: "orders@citrus-grace.com"
+    MEDIA_EMAIL: "media@citrus-grace.com"
+    HELP_EMAIL: "help@citrus-grace.com"
+    ORDERS_EMAIL: "orders@citrus-grace.com"
+    BUSINESS_TIME_ZONE: "America/Chicago"
 
 
 service:

--- a/secrets/citrus/django-email-secrets.enc.yaml
+++ b/secrets/citrus/django-email-secrets.enc.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-email-secrets
+    namespace: default
+type: Opaque
+stringData:
+    EMAIL_HOST_USER: ENC[AES256_GCM,data:bLkLKZGWy8qrac6Ak3lQMd/k6Cwgw8g=,iv:EfLLUGcOVL8tvClRUuEalN+AMBsEz+TEEvE6Tvgrnh0=,tag:HuVPiXG/4R+/BwG6fOCOMw==,type:str]
+    EMAIL_HOST_PASSWORD: ENC[AES256_GCM,data:2WnmSoF07FCNYPEgSYUgIyydvQ==,iv:byS8Ak3XwjsEBZ30LR/1BePdOJjBNFDFCjg7p57zvtU=,tag:/A7uIG9k/n+jUh4faW+3wQ==,type:str]
+    ADMIN_EMAIL: ENC[AES256_GCM,data:Y98MDpd94JVHd5P6sApmp1PDSRaS,iv:YV+sSHNe2WXNi50vL91CUpyhT8MGOVholwHHeIVBF5c=,tag:qY5n9chslGSHDD3+t4t2Mg==,type:str]
+    DEFAULT_FROM_EMAIL: ENC[AES256_GCM,data:1kv/OPgoUztVeH1VbLjBm6OrSRSAtGw=,iv:2EsIMapj3kkcbDYd5Hw3oy4mpEg7dxVvjPHeZCZgUik=,tag:lwnKM9LHcddQoIR7ypU+qA==,type:str]
+    ORDERS_EMAIL: ENC[AES256_GCM,data:Y+KcjkCX77KGgEcokJw37bJwnM2sYFw=,iv:0NmaPf/NEYtS3MtM+dtlufkO9xNNcMHvABXvHJVoq4U=,tag:O6rjiE2wlN0lJ6+v2k9MYQ==,type:str]
+    HELP_EMAIL: ENC[AES256_GCM,data:pn6y///KNc8OH9KcF5dIekKOt0v+,iv:B8RBR7VHkfywNM2QHVxaDRZw1rR4xIjvlMFUE5tdN6k=,tag:OGyY+Qz3oRCjTx/zau3g6w==,type:str]
+    MEDIA_EMAIL: ENC[AES256_GCM,data:55Bn1B5Ewy5YskuLlXvKGQCDxGvN7g==,iv:c06Qv1LeVyjuQsOYd5/XDyl4ULYcV+l1Oazpe06xfSA=,tag:b0seRSXzD2iJThixUVJWwQ==,type:str]
+    BUSINESS_TIME_ZONE: ENC[AES256_GCM,data:XB6iLgonILckf7U5iMbT,iv:WoQagidWV4wq1Ulcz/i/HUTpj8oO7bCNj1Wf+WpnNLE=,tag:zfgWLHyoP1lcdREfXQscPg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNRElaZ0JuaGRITmQ0dndi
+            aHlLbXZPRXVLamFuQklvamhwYy8zZWFUL1dZCnRjTDM5K01mQ25TOHdKRjA0VHp1
+            SG5MZFVwQmx2V2FWMFdZTmhUeEg5Z0UKLS0tIEpNcFVnVTBaa3dmSm1uNjdzazJs
+            ekRrYjU3Z09LMjNNNUFld0MvM28yZW8KwqdBT5JLYrAczHhWfjaviH9I4wCt4nz/
+            uKPrdHfeCrSUZXkBJPWN7P6BtF0poRT9VmyAIEdgwhCXHD7aDNURpA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-25T05:14:09Z"
+    mac: ENC[AES256_GCM,data:qKVwT4j/dshMsnOflrRyQ5or9TPqF2kGBHRwvsdP6XpxbqpQzFMi8nGIXn+qRkVOMDvliGuKgyKADBb1vymH46UaCr2XF1yAfza8W9eIigKfOHcS6wvdSu8CIyLPHWijHd30/tG4YKRxYdDIXCrTw3IekTJCMpw+Izrq+Q/yU74=,iv:4+mE3A6tbCplZx6JzyRxJlBAtjsJB3LDXNQymeQcMD8=,tag:7ZZik9+f6NxvuNebxhUWLQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus/ksops.yaml
+++ b/secrets/citrus/ksops.yaml
@@ -4,3 +4,4 @@ metadata:
   name: citrus-secrets
 files:
   - django-secrets.enc.yaml
+  - django-email-secrets.enc.yaml


### PR DESCRIPTION
## Summary
- add a SOPS-encrypted django-email-secrets Secret for Citrus SMTP and business email settings
- load the email Secret after the existing django-secrets Secret in the Citrus deployment
- add non-secret Citrus email/timezone config to Helm values

## Validation
- helm lint helm/citrus
- helm template citrus helm/citrus