### PR TITLE
Deploy Citrus image 580fbc45

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/citrus
-  tag: 2ccb9d4aa1d5eedebcee2ec75d2ccedd63dd7fbc # allow-latest
+  tag: 580fbc45e7be0c8a05e7fad2d8dccdf1de8260ae # allow-latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Manual GitOps image bump for Citrus after merging cesaregarza/Citrus#2.\n\nThe Citrus deploy workflow built and pushed image tag 580fbc45e7be0c8a05e7fad2d8dccdf1de8260ae, but its GitOps update job failed because the broker returned GARZAI_CLUSTER_GITHUB_TOKEN while the workflow expects SPLATTOP_CONFIG_GITHUB_TOKEN or CONFIG_REPO_TOKEN.\n\nValidation:\n- helm lint helm/citrus\n- helm template citrus helm/citrus