### PR TITLE
Rotate Citrus SMTP email secret

### DIFF
--- a/secrets/citrus/django-email-secrets.enc.yaml
+++ b/secrets/citrus/django-email-secrets.enc.yaml
@@ -5,14 +5,14 @@ metadata:
     namespace: default
 type: Opaque
 stringData:
-    EMAIL_HOST_USER: ENC[AES256_GCM,data:bLkLKZGWy8qrac6Ak3lQMd/k6Cwgw8g=,iv:EfLLUGcOVL8tvClRUuEalN+AMBsEz+TEEvE6Tvgrnh0=,tag:HuVPiXG/4R+/BwG6fOCOMw==,type:str]
-    EMAIL_HOST_PASSWORD: ENC[AES256_GCM,data:2WnmSoF07FCNYPEgSYUgIyydvQ==,iv:byS8Ak3XwjsEBZ30LR/1BePdOJjBNFDFCjg7p57zvtU=,tag:/A7uIG9k/n+jUh4faW+3wQ==,type:str]
-    ADMIN_EMAIL: ENC[AES256_GCM,data:Y98MDpd94JVHd5P6sApmp1PDSRaS,iv:YV+sSHNe2WXNi50vL91CUpyhT8MGOVholwHHeIVBF5c=,tag:qY5n9chslGSHDD3+t4t2Mg==,type:str]
-    DEFAULT_FROM_EMAIL: ENC[AES256_GCM,data:1kv/OPgoUztVeH1VbLjBm6OrSRSAtGw=,iv:2EsIMapj3kkcbDYd5Hw3oy4mpEg7dxVvjPHeZCZgUik=,tag:lwnKM9LHcddQoIR7ypU+qA==,type:str]
-    ORDERS_EMAIL: ENC[AES256_GCM,data:Y+KcjkCX77KGgEcokJw37bJwnM2sYFw=,iv:0NmaPf/NEYtS3MtM+dtlufkO9xNNcMHvABXvHJVoq4U=,tag:O6rjiE2wlN0lJ6+v2k9MYQ==,type:str]
-    HELP_EMAIL: ENC[AES256_GCM,data:pn6y///KNc8OH9KcF5dIekKOt0v+,iv:B8RBR7VHkfywNM2QHVxaDRZw1rR4xIjvlMFUE5tdN6k=,tag:OGyY+Qz3oRCjTx/zau3g6w==,type:str]
-    MEDIA_EMAIL: ENC[AES256_GCM,data:55Bn1B5Ewy5YskuLlXvKGQCDxGvN7g==,iv:c06Qv1LeVyjuQsOYd5/XDyl4ULYcV+l1Oazpe06xfSA=,tag:b0seRSXzD2iJThixUVJWwQ==,type:str]
-    BUSINESS_TIME_ZONE: ENC[AES256_GCM,data:XB6iLgonILckf7U5iMbT,iv:WoQagidWV4wq1Ulcz/i/HUTpj8oO7bCNj1Wf+WpnNLE=,tag:zfgWLHyoP1lcdREfXQscPg==,type:str]
+    EMAIL_HOST_USER: ENC[AES256_GCM,data:LbBOff3q5HycCqxwt2Gaw2bOmfMKKJo=,iv:AV8+Vqj5ozORytjJ9q0zvYWe0ngUWkUt42ECly38JQs=,tag:EDiqj00Tzl0nK6GSPyWROg==,type:str]
+    EMAIL_HOST_PASSWORD: ENC[AES256_GCM,data:HYb9398PxTpVESNwT+nM0A==,iv:IK+JZK4RXx7jnM/1WHOxiEMSCZWnjg4neYb5UY0aQ9U=,tag:meLxCvu/e5BPQPMXkcNZ6A==,type:str]
+    ADMIN_EMAIL: ENC[AES256_GCM,data:iRy8TdTolsDuDm1uwfos0mD3Bk5H,iv:95UT03T1dWJKz3bTHzmuUDP3NY8rVwIdXxaHr8H/3ws=,tag:bPhi2CAW1E0jHkzShYzO2A==,type:str]
+    DEFAULT_FROM_EMAIL: ENC[AES256_GCM,data:rd70npB6TNqTlfHM7COjXleTjztPTAo=,iv:95DYod0RRZLPAnO//PDFzmTcZ6omVMrkR2N92qG33FY=,tag:FQrj+xOr1+2Okpu6HRj1cQ==,type:str]
+    ORDERS_EMAIL: ENC[AES256_GCM,data:oeBhORPi9TXgwOJ/1f34ogJhsBwAMZ8=,iv:VIwStxaDYrz1jvO4EP0luxBdv4R9Pr4fjlyFMczWVfI=,tag:ISBTkw1g6QfHAGMpdLFA5g==,type:str]
+    HELP_EMAIL: ENC[AES256_GCM,data:hmgn9p35mtxKSR1Sosxg6vTZlSfo,iv:KnmjIX94oAJcHdSUgvnz1kHLNVISLNh2u9m1FXPBNtA=,tag:naxkYiA+EKhEYb7V/+DNXw==,type:str]
+    MEDIA_EMAIL: ENC[AES256_GCM,data:ARbS4FZddB9rA2/AaTrXsedMaxRKCg==,iv:dOnG7jq8+KYBmTqUd+kGu4ATduXAFFRx7d6Aam9ZXJs=,tag:B67dAhWtbaCJtrndbXbGEA==,type:str]
+    BUSINESS_TIME_ZONE: ENC[AES256_GCM,data:V9qfLR5Hak0E+m5bnA34,iv:gfOOpHw9/jk6GRxTpgLsZtrj+EPTe3xYOpzV5Cw4zwk=,tag:6RXt3YgD0ZRXadoZ96yDwQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -22,14 +22,14 @@ sops:
         - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNRElaZ0JuaGRITmQ0dndi
-            aHlLbXZPRXVLamFuQklvamhwYy8zZWFUL1dZCnRjTDM5K01mQ25TOHdKRjA0VHp1
-            SG5MZFVwQmx2V2FWMFdZTmhUeEg5Z0UKLS0tIEpNcFVnVTBaa3dmSm1uNjdzazJs
-            ekRrYjU3Z09LMjNNNUFld0MvM28yZW8KwqdBT5JLYrAczHhWfjaviH9I4wCt4nz/
-            uKPrdHfeCrSUZXkBJPWN7P6BtF0poRT9VmyAIEdgwhCXHD7aDNURpA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3QSs1eE1LS0wrWXYrZUxm
+            YzhETGRlaVpwdVJCL2FUblhZNkFpcU5ZaWlBClA4UXNBa1FDZS9iNWJJNjlOY2ov
+            MDA1M1FzZ0hYUGhndDVqWDdDdGFVZDgKLS0tIEg1NXRSSGw5T2xhUFMzTU44TUIx
+            RTVQc2F6T2p5aksrU0JrbDJzVEZWQ3MK/5cUpmb9NoZEdWfhkfjv072ejbFyB9Ap
+            qGs5C8jda3fDc9nUh+Q31bQs2Zqd+XMpv34CbNMm1Fm+h2EfHQ5xyA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-25T05:14:09Z"
-    mac: ENC[AES256_GCM,data:qKVwT4j/dshMsnOflrRyQ5or9TPqF2kGBHRwvsdP6XpxbqpQzFMi8nGIXn+qRkVOMDvliGuKgyKADBb1vymH46UaCr2XF1yAfza8W9eIigKfOHcS6wvdSu8CIyLPHWijHd30/tG4YKRxYdDIXCrTw3IekTJCMpw+Izrq+Q/yU74=,iv:4+mE3A6tbCplZx6JzyRxJlBAtjsJB3LDXNQymeQcMD8=,tag:7ZZik9+f6NxvuNebxhUWLQ==,type:str]
+    lastmodified: "2026-06-26T04:16:24Z"
+    mac: ENC[AES256_GCM,data:iBwwG8LCv7vQUkxSjGAEy2fw4C6fbJiJBeDssrf/Lu6b86dhr0ywgM/c1r+6IQ5En2ewKywTL79jhjcPkRTyf5A6qbXSBPX7DmHbzC+fWKJhwaA4thJbMyDTwDcURPb7ONBpog6oyyYT22+lgGgESg5+ca6qYccL9dN2Ozn4DL4=,iv:umsrk6pEV7r32r3Ww6aYfKWvbVdYOADclcwwoqRsIS4=,tag:Yp58bCoDXCNals5DTpJOzg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
Rotate the encrypted Citrus django-email-secrets Secret from the updated Citrus .env values.\n\nNo plaintext secret values are committed.\n\nValidation:\n- Verified all expected email keys are present as SOPS ENC values.\n- git diff --check