### PR TITLE
Deploy agent-control-plane fc1bc136727c (CES-276 restructure + Discord-free schema)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-d3b7fc0b2f66
+  tag: sha-fc1bc136727c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: d3b7fc0b2f66cff6594642d9969710f35d3134de
+      targetRevision: fc1bc136727c2fa11e14cb064500dad2f0e1bb7c
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Bumps image + chart to `fc1bc136727c` — the full CES-276 release-ownership wave. Schema already wiped (`DROP SCHEMA agent_platform CASCADE`) so the squashed Discord-free `001` applies clean on sync (PreSync migrate). Manual Argo sync to follow.