### PR TITLE
Deploy agent-control-plane b6a939800536 + provider pins (CES-302 fix)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-fc1bc136727c
+  tag: sha-b6a939800536
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -39,6 +39,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:07283d0d52bba1369e860ad727891954d65eb2a8e73e928dace753afc3c57ca1","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: fc1bc136727c2fa11e14cb064500dad2f0e1bb7c
+      targetRevision: b6a9398005367e65af7324f6ad489b3036d381d4
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-d3b7fc0b2f66` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-b6a939800536` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-d3b7fc0b2f66
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-b6a939800536
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Bumps image + chart to b6a939800536 (CES-302 provider-pin fix) and sets AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON for the readonly-sql + model_gateway providers (emitted by mandate-provider-fingerprints). Unblocks the CES-276 deploy. No schema change (DB already at fresh 001).