### PR TITLE
CES-311 deploy CES-309 control-plane image

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-b6a939800536
+  tag: sha-62725b00e3ca
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -108,6 +108,8 @@ gitDeliverer:
 modelGateway:
   enabled: true
   replicaCount: 1
+  env:
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:c979193f60517a1351e1e6f45631aab5ca23bb0f6cf62415519a0a1c6f9b9f84","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: b6a9398005367e65af7324f6ad489b3036d381d4
+      targetRevision: 62725b00e3cafe8f5d32340f45bf32634d88237c
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-b6a939800536` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-62725b00e3ca` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-b6a939800536
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-62725b00e3ca
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -459,6 +459,40 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "https://github.com/cesaregarza/GarzAICluster",
         )
 
+    def test_model_gateway_provider_pins_are_scoped_to_gateway_process(self) -> None:
+        values = self.control_plane_values
+        api_pins = json.loads(values["env"]["AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON"])
+        gateway_pins = json.loads(
+            values["modelGateway"]["env"]["AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON"]
+        )
+
+        self.assertEqual(
+            set(api_pins),
+            {"model_gateway", "readonly-sql-broker"},
+        )
+        self.assertEqual(
+            set(gateway_pins),
+            {"model_gateway"},
+        )
+        self.assertEqual(
+            api_pins["model_gateway"]["digest"],
+            "sha256:07283d0d52bba1369e860ad727891954d65eb2a8e73e928dace753afc3c57ca1",
+        )
+        self.assertEqual(
+            api_pins["readonly-sql-broker"]["digest"],
+            "sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c",
+        )
+        self.assertEqual(
+            gateway_pins["model_gateway"],
+            {
+                "digest": (
+                    "sha256:"
+                    "c979193f60517a1351e1e6f45631aab5ca23bb0f6cf62415519a0a1c6f9b9f84"
+                ),
+                "protocol": "model_gateway",
+            },
+        )
+
     def test_control_plane_pin_understands_opencode_executor_imports(self) -> None:
         sources = self.control_plane_application["spec"]["sources"]
         mandate_source = next(


### PR DESCRIPTION
## Summary
- bump `agent-control-plane` to agent-platform `62725b00e3cafe8f5d32340f45bf32634d88237c` / image `sha-62725b00e3ca`
- use `62725b0` instead of bare `0c652409` because AP main now includes CES-310 #238, avoiding the known model-gateway crash path while still deploying the CES-309 worker-lease fix from `0c652409`
- keep the API process full provider pin set and add the scoped model-gateway-only pin override now supported by the merged chart
- update the Postgres restore runbook image references to the new control-plane image

## Provider pins
- API `AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON`: `model_gateway:sha256:07283d0d52bba1369e860ad727891954d65eb2a8e73e928dace753afc3c57ca1`, `readonly-sql-broker:sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c`
- standalone gateway override: `model_gateway:sha256:c979193f60517a1351e1e6f45631aab5ca23bb0f6cf62415519a0a1c6f9b9f84`

## Validation
- confirmed AP publish workflow succeeded for `62725b00e3cafe8f5d32340f45bf32634d88237c` and published tag `sha-62725b00e3ca`
- generated provider fingerprints with `mandate-provider-fingerprints` from exact AP commit `62725b0`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests`
- `helm lint /root/dev/.worktrees/agent-platform-ces311-fingerprint-627/helm/mandate -f apps/agent-control-plane/values.yaml`
- `helm template mandate /root/dev/.worktrees/agent-platform-ces311-fingerprint-627/helm/mandate -f apps/agent-control-plane/values.yaml`
- `git diff --check`

## Deploy handoff
Operator-gated only. No Argo sync or prod deploy was performed. After merge, sync `agent-control-plane` and run the CES-309 readonly_query live verification; expected result is claims accepted and jobs reaching output release instead of `job_lease_expired`.

This includes the gateway scoped-pin config from CES-310 because the chart support is now on agent-platform main; it may supersede the standalone GarzAICluster CES-310 config PR if this lands first.

CES-311