### PR TITLE
CES-275: raise readonly_query completion-token + cost lease caps

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -47,9 +47,9 @@ data:
             allowed_profiles:
             - openai.gpt-5.3-codex-spark
             max_prompt_tokens: 12000
-            max_completion_tokens: 1200
-            max_total_tokens: 13200
-            max_cost_usd: 0.05
+            max_completion_tokens: 32000
+            max_total_tokens: 44000
+            max_cost_usd: 0.25
           session_authority_budget:
             max_operations: 4
             session_taint: prod_authority


### PR DESCRIPTION
## Why
`agent_workloads.readonly_query` failed live with:
```
model_lease_violation: provider completion token usage exceeded requested cap
```
The lease capped `max_completion_tokens` at **1200**, but the SQL-draft model (`gpt-5.3-codex-spark`) emits up to `max_reasoning_tokens=2048` of reasoning alone — so completion usage blows past 1200 and the broker rejects. This is the next (and currently last) wall on Joy's query path after CES-308/309/310.

## Change (registry overlay)
`apps/agent-control-plane-registry-overlay/configmap.yaml`, readonly_query `model_lease`:
- `max_completion_tokens` 1200 → **32000**
- `max_total_tokens` 13200 → **44000** (12000 prompt + 32000 completion)
- `max_cost_usd` 0.05 → **0.25** (policy per-job ceiling; 32k completion tokens would otherwise re-bind on the old cost cap)

## Notes
- Overlay-only: this is the effective prod config (the restart-hook reloads the registry on ConfigMap change). agent-platform base `registries/workload_imports.yaml` should be reconciled to match in a follow-up so future images carry it.
- Watching `agent-workloads-identity-digest-drift` CI — if the lease cap feeds the worker identity digest, a re-mint is coupled (will flag if so).
- Deploy + live readonly_query re-verification to follow (operator-approved test).

CES-275