### PR TITLE
CES-312 deploy CES-237 control-plane image

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-62725b00e3ca
+  tag: sha-a2eded8fcea9
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -40,7 +40,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:07283d0d52bba1369e860ad727891954d65eb2a8e73e928dace753afc3c57ca1","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:193c8067b599d8368afef9a77c94fdaf62e9076420eb9a24bf82c56c90647c9f","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -109,7 +109,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:c979193f60517a1351e1e6f45631aab5ca23bb0f6cf62415519a0a1c6f9b9f84","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:e7f951a57ab20fab2e86fd74f4d7ac7b035b9fad5f430a2ad974daedadd783f4","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 62725b00e3cafe8f5d32340f45bf32634d88237c
+      targetRevision: a2eded8fcea90efe75d638204fa9ee68e859e90d
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-62725b00e3ca` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-a2eded8fcea9` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-62725b00e3ca
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-a2eded8fcea9
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -476,7 +476,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             api_pins["model_gateway"]["digest"],
-            "sha256:07283d0d52bba1369e860ad727891954d65eb2a8e73e928dace753afc3c57ca1",
+            "sha256:193c8067b599d8368afef9a77c94fdaf62e9076420eb9a24bf82c56c90647c9f",
         )
         self.assertEqual(
             api_pins["readonly-sql-broker"]["digest"],
@@ -487,7 +487,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {
                 "digest": (
                     "sha256:"
-                    "c979193f60517a1351e1e6f45631aab5ca23bb0f6cf62415519a0a1c6f9b9f84"
+                    "e7f951a57ab20fab2e86fd74f4d7ac7b035b9fad5f430a2ad974daedadd783f4"
                 ),
                 "protocol": "model_gateway",
             },


### PR DESCRIPTION
## Summary
- bump `agent-control-plane` to agent-platform `a2eded8fcea90efe75d638204fa9ee68e859e90d` / image `sha-a2eded8fcea9`
- deploys the CES-237 codex `response_format` -> Responses API `text.format` forwarding fix
- regenerate both API and standalone model-gateway provider pins because `mandate/adapters/model/codex_chatgpt.py` changed
- update the Postgres restore runbook image references to the new control-plane image

## Provider pins
- API `AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON`: `model_gateway:sha256:193c8067b599d8368afef9a77c94fdaf62e9076420eb9a24bf82c56c90647c9f`, `readonly-sql-broker:sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c`
- standalone gateway override: `model_gateway:sha256:e7f951a57ab20fab2e86fd74f4d7ac7b035b9fad5f430a2ad974daedadd783f4`

## Validation
- confirmed AP CI and publish workflow succeeded for `a2eded8fcea90efe75d638204fa9ee68e859e90d`; published image tag is `sha-a2eded8fcea9`
- generated provider fingerprints with `mandate-provider-fingerprints` from exact AP commit `a2eded8`
- `UV_CACHE_DIR=/root/dev/.uv-cache uv run python -m unittest discover -s tests`
- `helm lint /root/dev/.worktrees/agent-platform-ces312-fingerprint-a2eded8/helm/mandate -f apps/agent-control-plane/values.yaml`
- `helm template mandate /root/dev/.worktrees/agent-platform-ces312-fingerprint-a2eded8/helm/mandate -f apps/agent-control-plane/values.yaml`
- `git diff --check`

## Deploy handoff
Operator-gated only. No Argo sync or prod deploy was performed. After merge, sync `agent-control-plane` and run the CES-312 readonly_query live verification; expected result is the SQL draft model call producing the strict `{sql, ...}` schema shape instead of free-forming into `model_lease_violation`.

CES-312