### PR TITLE
CES-313: deploy CES-275 control-plane image (reasoning.effort + max_output_tokens)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-a2eded8fcea9
+  tag: sha-453c40a30e4e
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -40,7 +40,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:193c8067b599d8368afef9a77c94fdaf62e9076420eb9a24bf82c56c90647c9f","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:e1701e859a98b1772b5437619800639d09e9e11591dab63e9abbae8793054d75","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -109,7 +109,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:e7f951a57ab20fab2e86fd74f4d7ac7b035b9fad5f430a2ad974daedadd783f4","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:ce09f622f235528b652c8047d7104c50156d4b6061dfdfe0c279f896a1c0e29d","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: a2eded8fcea90efe75d638204fa9ee68e859e90d
+      targetRevision: 453c40a30e4e35db1bcec046237bf3f1d1b12a8b
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-a2eded8fcea9` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-453c40a30e4e` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-a2eded8fcea9
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-453c40a30e4e
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -476,7 +476,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             api_pins["model_gateway"]["digest"],
-            "sha256:193c8067b599d8368afef9a77c94fdaf62e9076420eb9a24bf82c56c90647c9f",
+            "sha256:e1701e859a98b1772b5437619800639d09e9e11591dab63e9abbae8793054d75",
         )
         self.assertEqual(
             api_pins["readonly-sql-broker"]["digest"],
@@ -487,7 +487,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {
                 "digest": (
                     "sha256:"
-                    "e7f951a57ab20fab2e86fd74f4d7ac7b035b9fad5f430a2ad974daedadd783f4"
+                    "ce09f622f235528b652c8047d7104c50156d4b6061dfdfe0c279f896a1c0e29d"
                 ),
                 "protocol": "model_gateway",
             },


### PR DESCRIPTION
## Summary
- bump `agent-control-plane` to agent-platform `453c40a30e4e35db1bcec046237bf3f1d1b12a8b` / image `sha-453c40a30e4e`
- deploys CES-275 (ap#240): codex backend forwards `reasoning.effort` and `max_output_tokens` so the reasoning model is bounded at the requested effort/cap instead of running unbounded at default-medium
- regenerate both API and standalone model-gateway `model_gateway` pins (`codex_chatgpt.py` changed); readonly-sql pin unchanged
- update Postgres restore runbook image refs

## Provider pins
Regenerated via `mandate-provider-fingerprints` from `453c40a3`, **cross-validated** by reproducing the live `a2eded8f` pins (`193c8067`/`e7f951a5`/`a81a9f8c`) with the same env before generating the new ones:
- API: `model_gateway sha256:e1701e85…`, `readonly-sql-broker sha256:a81a9f8c…` (unchanged)
- standalone gateway override: `model_gateway sha256:ce09f622…`

## Validation
- `uv run python -m unittest tests.test_agent_control_plane_registry_overlay` → 12 passed (pin assertions updated)
- agent-platform CI + publish workflow succeeded for `453c40a3`; image tag `sha-453c40a30e4e` published

## Deploy
Operator-gated. After merge: app-of-apps refresh to propagate `targetRevision`, sync `agent-control-plane`, then live-verify readonly_query (draft should now be bounded + complete; check it passes the model draft instead of `model_lease_violation`).

CES-313 (deploys CES-275)