### PR TITLE
CES-313 hotfix: deploy CES-275 max_output_tokens fix (ap@0e36df08)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-453c40a30e4e
+  tag: sha-0e36df08a36b
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -40,7 +40,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:e1701e859a98b1772b5437619800639d09e9e11591dab63e9abbae8793054d75","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2d097ec2451096da626540c2b85a9e5531cdafa27482dd318afcd19310da2125","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -109,7 +109,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:ce09f622f235528b652c8047d7104c50156d4b6061dfdfe0c279f896a1c0e29d","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:6ce3a3a26c7a00f7f49a537538525925355a55e3507784e2f396224f113515bd","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 453c40a30e4e35db1bcec046237bf3f1d1b12a8b
+      targetRevision: 0e36df08a36b86629d62a624c094b77bd7819d36
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-453c40a30e4e` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-0e36df08a36b` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-453c40a30e4e
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-0e36df08a36b
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -476,7 +476,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             api_pins["model_gateway"]["digest"],
-            "sha256:e1701e859a98b1772b5437619800639d09e9e11591dab63e9abbae8793054d75",
+            "sha256:2d097ec2451096da626540c2b85a9e5531cdafa27482dd318afcd19310da2125",
         )
         self.assertEqual(
             api_pins["readonly-sql-broker"]["digest"],
@@ -487,7 +487,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {
                 "digest": (
                     "sha256:"
-                    "ce09f622f235528b652c8047d7104c50156d4b6061dfdfe0c279f896a1c0e29d"
+                    "6ce3a3a26c7a00f7f49a537538525925355a55e3507784e2f396224f113515bd"
                 ),
                 "protocol": "model_gateway",
             },


### PR DESCRIPTION
## Why (hotfix)
The current live image `sha-453c40a30e4e` forwards `max_output_tokens`, which the codex/ChatGPT Responses backend **rejects with 400** — every codex model call is currently failing. ap#241 (`0e36df08`) drops that forwarding (keeps `reasoning.effort`). This deploys the fix and restores model inference.

## Change
- image `sha-453c40a30e4e` → `sha-0e36df08a36b`; chart `targetRevision` → `0e36df08`
- regenerated `model_gateway` pins (codex_chatgpt.py changed); readonly-sql unchanged
  - API `model_gateway` `2d097ec2…`, standalone gateway `6ce3a3a2…`
  - **cross-validated** by reproducing the live `a2eded8f` pins (`193c8067`/`e7f951a5`/`a81a9f8c`) with the same fingerprint env before generating these

## Validation
- `uv run python -m unittest tests.test_agent_control_plane_registry_overlay` → 12 passed
- agent-platform CI + publish succeeded for `0e36df08`; tag `sha-0e36df08a36b` published

CES-313 / CES-275