### PR TITLE
CES-318 stopgap: raise readonly_query job budget to $10 (unblock governed rail)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -49,7 +49,7 @@ data:
             max_prompt_tokens: 12000
             max_completion_tokens: 32000
             max_total_tokens: 44000
-            max_cost_usd: 0.25
+            max_cost_usd: 10.0
           session_authority_budget:
             max_operations: 4
             session_taint: prod_authority
@@ -81,7 +81,7 @@ data:
             - aggregate_summary
             max_rows: 50
             max_runtime_seconds: 120
-            max_cost_usd: 0.05
+            max_cost_usd: 10.0
             statement_timeout_ms: 60000
             max_concurrency: 1
     - id: opencode.proposer
@@ -364,7 +364,7 @@ data:
             session_taint: prod_authority
   policy.prod.yaml: |
     defaults:
-      max_cost_usd_per_job: 0.25
+      max_cost_usd_per_job: 10.0
       max_runtime_seconds_per_job: 60
       aggregate_budget:
         platform_daily_usd: 25.0


### PR DESCRIPTION
## What
Raises the three `MIN(cost_candidates)` inputs for `agent_workloads.readonly_query` so its per-job budget becomes \$10 instead of the current \$0.05:
- `readonly_query` `model_lease.max_cost_usd`: 0.25 → 10.0
- `readonly_query` `broker_lease.max_cost_usd`: 0.05 → 10.0
- global `defaults.max_cost_usd_per_job`: 0.25 → 10.0

## Why
Post-CES-275 deploy (CES-315), `readonly_query` clears the token cap but fails budget **preflight**: job budget = `MIN(0.25 policy, 0.25 model, 0.05 broker) = $0.05`, and the worst-case model reservation (~\$0.078 for the full 32000-token grant) exceeds it → `model call would exceed job budget` (live: `job_5cac48e6`). Actual draft is ~\$0.01, so this refuses affordable work. Blocking the governed path just leaks the query to ungoverned psql.

This is a **stopgap**. The real fix — one lease-level grant, enforce on actuals (not worst-case reservation), until-completed vs kill-immediately — is **CES-318**.

## Blast radius
- Capabilities with their own `model_lease.max_cost_usd` (0.25) stay capped at 0.25 via the MIN — unchanged.
- Only lease-less admin/deterministic capabilities widen to \$10 (no real spend — harmless).
- Daily aggregate (`per_capability_daily_usd_default: 5.0`) unchanged: it accrues **actual** (~\$0.01/job), not the per-job ceiling, so it won't bind.

## Deploy
Operator-gated: merge → sync `agent-control-plane-registry-overlay` → CP re-reads on restart (CES-108 hook may not fire; `kubectl rollout restart agent-control-plane` if needed). No image/pin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)