### PR TITLE
CES-318 stopgap (cont.): raise daily aggregate caps above $10 per-job budget

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -367,8 +367,8 @@ data:
       max_cost_usd_per_job: 10.0
       max_runtime_seconds_per_job: 60
       aggregate_budget:
-        platform_daily_usd: 25.0
-        per_capability_daily_usd_default: 5.0
+        platform_daily_usd: 250.0
+        per_capability_daily_usd_default: 100.0
         per_capability_daily_usd:
           agent_workloads.opencode_apply: 1.0
           agent_workloads.opencode_propose: 1.0


### PR DESCRIPTION
Follow-on to #266. Raising the per-job budget to $10 exposed the next budget layer — admission reserves the per-job ceiling against the per-capability daily cap, so $10 > $5/day → `capability daily usd exceeded`. Raises `platform_daily_usd` 25→250 and `per_capability_daily_usd_default` 5→100 (tight opencode overrides preserved). Actuals ~$0.01/job; headroom only. Real fix: CES-318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)