### PR TITLE
Enable opencode_orchestrate for admin binding (+$10 budget) to test the opencode->sql path

### DIFF
--- a/apps/agent-control-plane-registry-overlay/configmap.yaml
+++ b/apps/agent-control-plane-registry-overlay/configmap.yaml
@@ -269,7 +269,7 @@ data:
             allowed_tier: fast
             allowed_profiles:
             - openai.gpt-5.3-codex-spark
-            max_cost_usd: 0.25
+            max_cost_usd: 10.0
           session_authority_budget:
             max_operations: 8
             session_taint: prod_authority
@@ -397,6 +397,7 @@ data:
             - agent_workloads.opencode_apply
             - agent_workloads.opencode_propose
             - agent_workloads.opencode_task
+            - agent_workloads.opencode_orchestrate
           approval_overrides:
             approval.probe: admin_confirm
             agent_workloads.opencode_apply: admin_confirm


### PR DESCRIPTION
`opencode_orchestrate` is imported and its only delegable child is `readonly_query` (the opencode→sql path), but it was **missing from the `private-admin-controlled-capabilities` allow list**, so the capability listing filtered it out of the host's view — that's why Halcyon showed propose/task/apply but not orchestrate (fail-closed capability visibility, working as designed).

- Grants `agent_workloads.opencode_orchestrate` in the admin binding allow list.
- Raises its `model_lease.max_cost_usd` 0.25 → 10.0 to pre-empt the CES-318 worst-case-reservation budget wall (child `readonly_query` already at $10).

Parent/child budget composition is still untested — this gives the orchestrate→sql path its first live run. Operator-gated overlay change; merge → sync → CP restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)