### PR TITLE
Enable opencode proposer to claim opencode_orchestrate jobs

### DIFF
--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -104,7 +104,7 @@ opencodeProposer:
     MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
     MANDATE_MODEL_GATEWAY_BASE_URL: http://agent-control-plane-model-gateway.agent-control-plane.svc.cluster.local/v1
     AGENT_WORKLOADS_WORKER_ID: opencode.proposer
-    AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.opencode_propose,agent_workloads.opencode_task
+    AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.opencode_propose,agent_workloads.opencode_task,agent_workloads.opencode_orchestrate
     AGENT_WORKLOADS_POLL_SECONDS: '2'
     AGENT_WORKLOADS_ENVIRONMENT: production
     AGENT_WORKLOADS_OPENCODE_WORKSPACE_DIR: /workspace/job


### PR DESCRIPTION
The first `opencode_orchestrate` job (`job_9f0cd95`) sat **queued with no claimer**: the proposer worker's `AGENT_WORKLOADS_WORKER_CAPABILITIES` listed only `opencode_propose,opencode_task` — it never polled for orchestrate. The capability is otherwise fully enabled (policy grant #268, registry import, budget, bundle). Adds `agent_workloads.opencode_orchestrate` to the proposer's claim list.

Deployment-env only (not the bundle) → **no re-mint**; the token already authorizes orchestrate (manifest `d60fdc23`). Syncing rolls the proposer, which should then claim the queued parent and run the first opencode→sql delegation in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)