### PR TITLE
[codex] Fix registry overlay kustomize render

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,38 @@ jobs:
       - name: Check deployed registry compatibility
         uses: cesaregarza/.github/actions/agent-control-plane-registry-compat-gate@a1d2fb4a6b288066574b1ac53074ac62e920a07f
 
+  agent-control-plane-registry-overlay-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install kustomize
+        env:
+          KUSTOMIZE_VERSION: v5.4.3
+        run: |
+          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+            --output kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          gzip -t kustomize.tar.gz
+          tar -xzf kustomize.tar.gz
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          kustomize version
+
+      - name: Check registry overlay kustomize render
+        run: uv run python scripts/check_agent_control_plane_registry_overlay_render.py
+
   helm-and-kubeconform:
     runs-on: ubuntu-latest
     strategy:

--- a/apps/agent-control-plane-registry-overlay/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-hook.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: registry-overlay-restart-
+  name: agent-control-plane-registry-overlay-restart
   namespace: agent-control-plane
   labels:
     app.kubernetes.io/name: agent-control-plane

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Validate the registry overlay kustomize render against the pre-refactor golden."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_OVERLAY_DIR = Path("apps/agent-control-plane-registry-overlay")
+REGISTRY_OVERLAY_CONFIGMAP_NAME = "agent-control-plane-registry-overlay"
+GOLDEN_CONFIGMAP_PATH = Path(
+    "tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml"
+)
+
+YAML_PARSER = YAML(typ="safe")
+
+
+class RegistryOverlayRenderError(RuntimeError):
+    """Raised when the registry overlay cannot render or drifts from the golden."""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run real kustomize build for the control-plane registry overlay "
+            "and compare the generated ConfigMap data to the committed golden."
+        )
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--kustomize", default="kustomize")
+    parser.add_argument(
+        "--golden-configmap",
+        type=Path,
+        default=None,
+        help="Optional path to the pre-refactor registry overlay ConfigMap golden.",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    golden_path = (
+        args.golden_configmap.resolve()
+        if args.golden_configmap is not None
+        else repo_root / GOLDEN_CONFIGMAP_PATH
+    )
+    try:
+        check_registry_overlay_render(
+            repo_root=repo_root,
+            kustomize=args.kustomize,
+            golden_configmap_path=golden_path,
+        )
+    except RegistryOverlayRenderError as exc:
+        print(f"registry overlay render gate failed: {exc}", file=sys.stderr)
+        return 1
+    print("registry overlay kustomize render matches the committed ConfigMap golden.")
+    return 0
+
+
+def check_registry_overlay_render(
+    *,
+    repo_root: Path,
+    kustomize: str,
+    golden_configmap_path: Path,
+) -> None:
+    rendered = _kustomize_build(
+        repo_root=repo_root,
+        overlay_dir=repo_root / REGISTRY_OVERLAY_DIR,
+        kustomize=kustomize,
+    )
+    rendered_configmap = _extract_registry_configmap(rendered)
+    golden_configmap = _load_yaml(golden_configmap_path)
+    _assert_configmap_identity_matches(rendered_configmap, golden_configmap)
+    _assert_configmap_data_matches(rendered_configmap, golden_configmap)
+
+
+def _kustomize_build(*, repo_root: Path, overlay_dir: Path, kustomize: str) -> str:
+    try:
+        result = subprocess.run(
+            [kustomize, "build", str(overlay_dir.relative_to(repo_root))],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RegistryOverlayRenderError(
+            f"kustomize binary not found: {kustomize}"
+        ) from exc
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        raise RegistryOverlayRenderError(f"kustomize build failed: {stderr}")
+    if not result.stdout.strip():
+        raise RegistryOverlayRenderError("kustomize build produced no output")
+    return result.stdout
+
+
+def _extract_registry_configmap(rendered: str) -> dict[str, Any]:
+    for document in YAML_PARSER.load_all(rendered):
+        if not isinstance(document, dict):
+            continue
+        if document.get("kind") != "ConfigMap":
+            continue
+        metadata = document.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        if metadata.get("name") == REGISTRY_OVERLAY_CONFIGMAP_NAME:
+            return document
+    raise RegistryOverlayRenderError(
+        f"rendered {REGISTRY_OVERLAY_CONFIGMAP_NAME} ConfigMap not found"
+    )
+
+
+def _assert_configmap_identity_matches(
+    rendered_configmap: dict[str, Any],
+    golden_configmap: dict[str, Any],
+) -> None:
+    rendered_identity = _configmap_identity(rendered_configmap)
+    golden_identity = _configmap_identity(golden_configmap)
+    if rendered_identity == golden_identity:
+        return
+    raise RegistryOverlayRenderError(
+        "rendered ConfigMap identity drifted from golden:\n"
+        + _json_diff(golden_identity, rendered_identity)
+    )
+
+
+def _configmap_identity(configmap: dict[str, Any]) -> dict[str, Any]:
+    metadata = configmap.get("metadata")
+    if not isinstance(metadata, dict):
+        raise RegistryOverlayRenderError("ConfigMap metadata must be a mapping")
+    return {
+        "apiVersion": configmap.get("apiVersion"),
+        "kind": configmap.get("kind"),
+        "metadata": {
+            "name": metadata.get("name"),
+            "namespace": metadata.get("namespace"),
+            "labels": metadata.get("labels") or {},
+        },
+    }
+
+
+def _assert_configmap_data_matches(
+    rendered_configmap: dict[str, Any],
+    golden_configmap: dict[str, Any],
+) -> None:
+    rendered_data = _configmap_data(rendered_configmap, label="rendered")
+    golden_data = _configmap_data(golden_configmap, label="golden")
+    rendered_keys = set(rendered_data)
+    golden_keys = set(golden_data)
+    if rendered_keys != golden_keys:
+        raise RegistryOverlayRenderError(
+            "rendered ConfigMap data keys drifted from golden: "
+            f"expected {sorted(golden_keys)}, got {sorted(rendered_keys)}"
+        )
+    for key in sorted(golden_keys):
+        rendered_value = rendered_data[key]
+        golden_value = golden_data[key]
+        if rendered_value == golden_value:
+            continue
+        raise RegistryOverlayRenderError(
+            f"rendered ConfigMap data drifted from golden: {key}\n"
+            + _text_diff(
+                golden_value,
+                rendered_value,
+                fromfile=f"golden:{key}",
+                tofile=f"rendered:{key}",
+            )
+        )
+
+
+def _configmap_data(configmap: dict[str, Any], *, label: str) -> dict[str, str]:
+    data = configmap.get("data")
+    if not isinstance(data, dict):
+        raise RegistryOverlayRenderError(f"{label} ConfigMap data must be a mapping")
+    strings: dict[str, str] = {}
+    for key, value in data.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise RegistryOverlayRenderError(
+                f"{label} ConfigMap data entries must be strings"
+            )
+        strings[key] = value
+    return strings
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise RegistryOverlayRenderError(f"YAML mapping expected: {path}")
+    return loaded
+
+
+def _json_diff(expected: Any, rendered: Any) -> str:
+    expected_text = json.dumps(expected, indent=2, sort_keys=True) + "\n"
+    rendered_text = json.dumps(rendered, indent=2, sort_keys=True) + "\n"
+    return _text_diff(
+        expected_text,
+        rendered_text,
+        fromfile="golden",
+        tofile="rendered",
+    )
+
+
+def _text_diff(expected: str, rendered: str, *, fromfile: str, tofile: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=fromfile,
+            tofile=tofile,
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -1,0 +1,664 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-control-plane-registry-overlay
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay
+data:
+  workload_imports.yaml: |
+    schema_version: workload-imports.v1
+    imports:
+    - id: data.workspace_probe
+      manifest_path: registries/imports/agent-data.workspace_probe.json
+      manifest_digest: sha256:ad0fc7d1a71d263d7da00cc1adb61251ba4b79937bc1aa3b7d69f7c6ba3c9877
+      image_digest: sha256:cd2b2b3aa851833c8718b5d92541fb9822b1594d9b6983aebf0b6615215aed9a
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/db-workspace-probe/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: database_only
+        service_account_ref: agent-workloads-worker
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 120
+        model_call: true
+        readonly_sql_broker: true
+      capabilities:
+        agent_workloads.db_probe:
+          description: Imported reversible staging database workspace probe.
+          output_schema: agent_workloads_db_probe_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.db_probe
+        agent_workloads.readonly_query:
+          description: Imported governed readonly SQL query worker.
+          output_schema: agent_workloads_readonly_query_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.readonly_query
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_prompt_tokens: 12000
+            max_completion_tokens: 32000
+            max_total_tokens: 44000
+            max_cost_usd: 10.0
+          session_authority_budget:
+            max_operations: 4
+            session_taint: prod_authority
+          artifacts:
+            allowed: false
+            broker_required: true
+          broker:
+            allowed_broker: readonly-sql-broker
+            allowed_presets:
+            - analytical-read
+          broker_lease:
+            required: true
+            preset: analytical-read
+            allowed_source_schemas:
+            - xscraper
+            allowed_tables:
+            - xscraper.players
+            - xscraper.player_latest
+            - xscraper.player_season
+            - xscraper.season_results
+            - xscraper.weapon_leaderboard
+            - xscraper.aliases
+            - xscraper.schedules
+            allowed_operations:
+            - describe_schema
+            - describe_table
+            - select_limited
+            - explain_safe
+            - aggregate_summary
+            max_rows: 50
+            max_runtime_seconds: 120
+            max_cost_usd: 10.0
+            statement_timeout_ms: 60000
+            max_concurrency: 1
+    - id: opencode.proposer
+      manifest_path: registries/imports/agent-opencode.proposer.json
+      manifest_digest: sha256:dc60ee7feec97a7f407a0fc4752eac99ac3b4dc9ae99974db7a2fb9f60238f14
+      image_digest: sha256:40fd41fa823bb5a8aea790d66c4331ea3b1436b5ba3cc55c1dc4e001ccae1808
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-proposer/agent.yaml
+      agent:
+        execution_posture: hosted_harness
+        network_access: broker_only
+        service_account_ref: opencode-proposer
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 900
+        model_gateway_token: true
+      capabilities:
+        agent_workloads.opencode_propose:
+          description: Imported OpenCode proposer that returns metadata-only proposal
+            artifacts.
+          output_schema: agent_workloads_opencode_proposal_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_propose
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 0.25
+          session_authority_budget:
+            max_operations: 100
+            session_taint: prod_authority
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed:
+            - opencode_proposal
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+          result_contract:
+            output_schema: agent_workloads_opencode_proposal_result_v1
+            released_result_fields:
+            - output_text
+            - proposal_digest
+            - proposal_path
+            - changed_files
+            - diff_sha256
+            - diff_truncated
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
+          disclosure_summary:
+            summary: OpenCode proposal diffs remain metadata-only for the governed apply
+              arc.
+            released_result: Proposal digest, file metadata, and immutable base repo/ref/commit/tree
+              metadata only.
+            released_artifacts: Proposal artifact metadata only; diff bytes are withheld
+              from released output after platform capture.
+            artifact_classes_allowed:
+            - opencode_proposal
+            withheld:
+            - proposal diff bytes
+            - raw task inputs
+            - internal sources and broker internals
+          negative_affordances:
+          - Returns metadata only; cannot show proposal diff bytes.
+          - Must not be used for answer-style tasks.
+        agent_workloads.opencode_task:
+          description: Imported OpenCode answer task that performs bounded local work
+            and returns answer text through the output gate.
+          output_schema: agent_workloads_opencode_task_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_task
+          task_contract:
+            input_schema: task_intent
+            text: Describe the work to perform in task.text.
+            required_hints: []
+            optional_hints: []
+            routing_guidance: Use for work requests that need a governed OpenCode answer,
+              not for code-change proposals or apply operations.
+          result_contract:
+            output_schema: agent_workloads_opencode_task_result_v1
+            released_result_fields:
+            - schema_version
+            - answer_text
+            - answer_sha256
+            - answer_is_platform_verified
+            - evidence
+          disclosure_summary:
+            summary: Returns a bounded answer generated by the governed OpenCode task
+              worker; the answer is not platform-verified fact.
+            released_result: Answer text plus evidence metadata.
+            released_artifacts: No artifacts are expected from this capability.
+            artifact_classes_allowed: []
+            withheld:
+            - raw task inputs
+            - internal sources and broker internals
+            - proposal diff bytes
+          negative_affordances:
+          - Does not create proposal diffs or apply changes.
+          - Answer is agent output under governance, not platform-verified truth.
+          - Must not be used as a fallback when no capability matches.
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 0.25
+          session_authority_budget:
+            max_operations: 8
+            session_taint: prod_authority
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: true
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed: []
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: false
+            broker_required: false
+        agent_workloads.opencode_orchestrate:
+          description: Imported OpenCode orchestrator that may select one server-authorized
+            delegated child capability under the parent worker claim.
+          output_schema: agent_workloads_opencode_orchestrate_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_orchestrate
+          task_contract:
+            input_schema: task_intent
+            text: Describe the governed work to route or answer in task.text.
+            required_hints: []
+            optional_hints: []
+            routing_guidance: Use for ambiguous or multi-step governed work that needs
+              model-selected routing through Mandate child dispatch. Natural-language
+              data questions should delegate to agent_workloads.readonly_query, not readonly_sql.
+          result_contract:
+            output_schema: agent_workloads_opencode_orchestrate_result_v1
+            released_result_fields:
+            - schema_version
+            - mode
+            - output_text
+            - answer_text
+            - answer_is_platform_verified
+            - capability_id
+            - child_job_id
+            - released_result
+            - evidence
+          disclosure_summary:
+            summary: Returns either a bounded no-match/local answer or the platform-released
+              result of one parent_only child job.
+            released_result: Orchestrator mode, answer text or child released result,
+              child id, delegated capability id, and evidence metadata.
+            released_artifacts: No artifacts are expected from this capability.
+            artifact_classes_allowed: []
+            withheld:
+            - parent claim token
+            - worker-service credentials
+            - child raw errors
+            - broker internals
+            - model transcripts
+          negative_affordances:
+          - Cannot create more than one child job.
+          - Cannot route to undelegated or invented capabilities.
+          - Cannot expose child jobs independently to the host channel.
+          - Must not be used as a local fallback when no governed capability matches.
+          model_lease:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 10.0
+          session_authority_budget:
+            max_operations: 8
+            session_taint: prod_authority
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: true
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed: []
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: false
+            broker_required: false
+    - id: opencode.apply_executor
+      manifest_path: registries/imports/agent-opencode.apply_executor.json
+      manifest_digest: sha256:96275e43165c5c338e1a1b0be26dc4e19293c6d5045ec8a712ce5ba2924c5169
+      image_digest: sha256:48a475ef25fb46ee05376099cf318750acdda4f8259fd0491f71611fe15a7e3b
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-apply-executor/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: broker_only
+        service_account_ref: opencode-apply-executor
+        identity_audience: mandate-api
+        executor: true
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 300
+      capabilities:
+        agent_workloads.opencode_apply:
+          description: Imported OpenCode apply executor for approved proposal diffs.
+          output_schema: agent_workloads_opencode_apply_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_apply
+          approval_mode: admin_confirm
+          result_contract:
+            output_schema: agent_workloads_opencode_apply_result_v1
+            released_result_fields:
+            - output_text
+            - operation_status
+            - action_id
+            - branch
+            - commit_sha
+            - applied_diff_sha256
+            - proposal_diff_sha256
+            - changed_files
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: false
+            citations_allowed: none
+            artifact_classes_allowed:
+            - opencode_apply_result
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+          disclosure_summary:
+            summary: OpenCode apply releases local apply metadata for the governed delivery
+              arc.
+            released_result: Local apply status, designation id, commit, patch digests,
+              changed files, and immutable base repo/ref/commit/tree metadata only.
+            released_artifacts: Apply result artifact metadata only; diff bytes and remote
+              delivery claims are withheld.
+            artifact_classes_allowed:
+            - opencode_apply_result
+            withheld:
+            - proposal and applied diff bytes
+            - remote ref and draft PR URL until deliverer confirmation
+            - raw task inputs
+            - internal sources and broker internals
+          negative_affordances:
+          - Does not push, open, merge, or claim a remote PR.
+          - Remote ref and PR URL arrive only through the deliverer callback after confirmed
+            write.
+          - Must not be used as a fallback when no capability matches.
+          session_authority_budget:
+            max_operations: 1
+            session_taint: prod_authority
+  policy.prod.yaml: |
+    defaults:
+      max_cost_usd_per_job: 10.0
+      max_runtime_seconds_per_job: 60
+      aggregate_budget:
+        platform_daily_usd: 250.0
+        per_capability_daily_usd_default: 100.0
+        per_capability_daily_usd:
+          agent_workloads.opencode_apply: 1.0
+          agent_workloads.opencode_propose: 1.0
+
+    bindings:
+      - id: private-admin-controlled-capabilities
+        description: Production-safe private admin binding for no-key probes,
+          bounded read-only SQL, and the first imported worker-service probe.
+        guild_id: "614277943706910722"
+        channel_id: "1480483954694819940"
+        users:
+          admins:
+            - "94265880216612864"
+          authorized:
+            - "94265880216612864"
+        capabilities:
+          allow:
+            - task.echo
+            - approval.probe
+            - readonly_sql
+            - audit.digest
+            - mandate.ops.inspect
+            - mandate.deploy.smoke
+            - agent_workloads.db_probe
+            - agent_workloads.readonly_query
+            - agent_workloads.opencode_apply
+            - agent_workloads.opencode_propose
+            - agent_workloads.opencode_task
+            - agent_workloads.opencode_orchestrate
+          approval_overrides:
+            approval.probe: admin_confirm
+            agent_workloads.opencode_apply: admin_confirm
+      - id: synthetic-live-verify-probe
+        description: Scheduled no-key deployment smoke probe for CES-154. This
+          binding is intentionally narrower than the private admin binding so
+          CronJob credentials can prove the live submit/worker/output/callback
+          path without gaining operator capabilities.
+        guild_id: "614277943706910722"
+        channel_id: "1480483954694819940"
+        users:
+          admins: []
+          authorized:
+            - mandate-live-probe
+        capabilities:
+          allow:
+            - mandate.deploy.smoke
+  evals.yaml: |
+    eval_suites:
+      - id: eval.task_echo_smoke
+        owner: agent-platform
+        description: End-to-end smoke suite for task submission, job state,
+          callback, audit event, and feedback capture.
+        applies_to:
+          - deterministic.echo
+        dataset: tests/evals/task_echo_smoke.jsonl
+        cadence: every_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_p95_latency_ms: 1000
+      - id: eval.model_summarize_smoke
+        owner: agent-platform
+        description: Model seam smoke suite proving leased summarization, usage
+          accounting, and output release through the broker abstraction.
+        applies_to:
+          - summarizer.fast
+        dataset: tests/evals/model_summarize_smoke.jsonl
+        cadence: every_prompt_or_model_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_budget_exceeded: 0
+      - id: eval.test_agent_probes
+        owner: agent-platform
+        description: Deterministic development-agent probe suite covering routing
+          metadata, metadata-only artifacts, approval pauses, broker-shaped
+          results, and controlled failures.
+        applies_to:
+          - deterministic.inspect
+          - deterministic.schema_inspect
+          - deterministic.artifact_probe
+          - deterministic.approval_probe
+          - deterministic.broker_probe
+          - deterministic.failure_probe
+        dataset: tests/evals/test_agent_probes.jsonl
+        cadence: every_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_unexpected_terminal_states: 0
+      - id: eval.audit_digest_smoke
+        owner: agent-platform
+        description: Read-only audit digest suite covering bounded time windows,
+          Markdown output, artifact metadata, and safe no-model execution.
+        applies_to:
+          - deterministic.audit_digest
+        dataset: tests/evals/audit_digest_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.ops_utility_smoke
+        owner: agent-platform
+        description: Deterministic ops utility suite covering Mandate operational
+          inspection and deployment smoke readiness without model keys or write
+          authority.
+        applies_to:
+          - deterministic.ops_inspect
+          - deterministic.deployment_smoke
+        dataset: tests/evals/ops_utility_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.readonly_sql_safety
+        owner: agent-platform
+        description: Read-only SQL suite requiring correct refusal of writes,
+          least-privilege query plans, and bounded result summaries.
+        applies_to:
+          - data.readonly_sql
+        dataset: tests/evals/readonly_sql_safety.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 0.95
+          max_write_attempts: 0
+          max_unbounded_queries: 0
+      - id: eval.local_data_report_smoke
+        owner: agent-platform.standard-library
+        description: Deterministic local data-report suite proving broker-backed
+          report generation and public output projection without external
+          secrets.
+        applies_to:
+          - data.local_data_report
+        dataset: tests/evals/local_data_report_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.opencode_proposer_smoke
+        owner: deployment-overlay
+        description: Deployment smoke suite for the imported OpenCode proposer
+          proposal artifact path.
+        applies_to:
+          - opencode.proposer
+        dataset: registries/imports/opencode_proposer_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.opencode_apply_smoke
+        owner: deployment-overlay
+        description: Deployment smoke suite for the imported OpenCode apply
+          executor designation path.
+        applies_to:
+          - opencode.apply_executor
+        dataset: registries/imports/opencode_apply_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+  opencode_proposer_smoke.jsonl: |
+    {"case_id":"opencode_proposal_artifact","capability":"agent_workloads.opencode_propose","input":{"text":"Draft a bounded proposal."},"expected":{"status":"succeeded","artifact_class":"opencode_proposal"}}
+  opencode_apply_smoke.jsonl: |
+    {"case_id":"opencode_apply_designation","capability":"agent_workloads.opencode_apply","input":{"text":"Apply an approved OpenCode proposal."},"expected":{"approval_mode":"admin_confirm","artifact_class":"opencode_apply_result"}}
+  agent-data.workspace_probe.json: |
+    {
+      "capabilities": [
+        "agent_workloads.db_probe",
+        "agent_workloads.readonly_query"
+      ],
+      "capability_metadata": {
+        "agent_workloads.db_probe": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.readonly_query": {
+          "consequence_class": "read_only"
+        }
+      },
+      "code_digest": "sha256:2b2e8637872c744496e769765537105fc516a031ee83af9cb02e7bad76147999",
+      "digest": "sha256:ad0fc7d1a71d263d7da00cc1adb61251ba4b79937bc1aa3b7d69f7c6ba3c9877",
+      "display_name": "Agent Workloads Data Worker",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.test_agent_probes",
+          "eval.readonly_sql_safety"
+        ]
+      },
+      "id": "data.workspace_probe",
+      "image": {
+        "digest": "sha256:cd2b2b3aa851833c8718b5d92541fb9822b1594d9b6983aebf0b6615215aed9a",
+        "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/db-workspace-probe/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }
+  agent-opencode.proposer.json: |
+    {
+      "capabilities": [
+        "agent_workloads.opencode_propose",
+        "agent_workloads.opencode_task",
+        "agent_workloads.opencode_orchestrate"
+      ],
+      "capability_metadata": {
+        "agent_workloads.opencode_orchestrate": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.opencode_propose": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.opencode_task": {
+          "consequence_class": "reversible_staging"
+        }
+      },
+      "code_digest": "sha256:da890c27c1df58eb1208188ac64ed5dec406ac7d2a1bc043d9e70495c3775c8b",
+      "digest": "sha256:dc60ee7feec97a7f407a0fc4752eac99ac3b4dc9ae99974db7a2fb9f60238f14",
+      "display_name": "OpenCode Proposer",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.opencode_proposer_smoke"
+        ]
+      },
+      "id": "opencode.proposer",
+      "image": {
+        "digest": "sha256:40fd41fa823bb5a8aea790d66c4331ea3b1436b5ba3cc55c1dc4e001ccae1808",
+        "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/opencode-proposer/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }
+  agent-opencode.apply_executor.json: |
+    {
+      "capabilities": [
+        "agent_workloads.opencode_apply"
+      ],
+      "capability_metadata": {
+        "agent_workloads.opencode_apply": {
+          "consequence_class": "consequential"
+        }
+      },
+      "code_digest": "sha256:05b77d442e4657e96fb8ba2b660d5b289a522ae5c11a5a152878fddd9cfa6204",
+      "digest": "sha256:96275e43165c5c338e1a1b0be26dc4e19293c6d5045ec8a712ce5ba2924c5169",
+      "display_name": "OpenCode Apply Executor",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.opencode_apply_smoke"
+        ]
+      },
+      "id": "opencode.apply_executor",
+      "image": {
+        "digest": "sha256:48a475ef25fb46ee05376099cf318750acdda4f8259fd0491f71611fe15a7e3b",
+        "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/opencode-apply-executor/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -112,9 +112,10 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "BeforeHookCreation",
         )
         self.assertEqual(
-            self.registry_overlay_restart_hook["metadata"]["generateName"],
-            "registry-overlay-restart-",
+            self.registry_overlay_restart_hook["metadata"]["name"],
+            "agent-control-plane-registry-overlay-restart",
         )
+        self.assertNotIn("generateName", self.registry_overlay_restart_hook["metadata"])
 
         sync_options = set(
             self.registry_overlay_application["spec"]["syncPolicy"].get(
@@ -123,6 +124,27 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertIn("CreateNamespace=true", sync_options)
         self.assertNotIn("ApplyOutOfSyncOnly=true", sync_options)
+
+    def test_ci_runs_real_registry_overlay_kustomize_render_gate(self) -> None:
+        workflow = _load_yaml(REPO_ROOT / ".github" / "workflows" / "ci.yaml")
+        job = workflow["jobs"]["agent-control-plane-registry-overlay-render"]
+        run_steps = [
+            step.get("run", "")
+            for step in job["steps"]
+            if isinstance(step, dict) and "run" in step
+        ]
+
+        self.assertTrue(
+            any("kustomize version" in step for step in run_steps),
+            "registry overlay render job must install standalone kustomize",
+        )
+        self.assertTrue(
+            any(
+                "scripts/check_agent_control_plane_registry_overlay_render.py" in step
+                for step in run_steps
+            ),
+            "registry overlay render job must run the real kustomize render gate",
+        )
 
     def test_opencode_proposer_import_is_overlay_pinned_and_proposal_only(self) -> None:
         imports = YAML_PARSER.load(self.data["workload_imports.yaml"])


### PR DESCRIPTION
## Summary
- give the registry-overlay PostSync restart Job a static `metadata.name` so `kustomize build` and Argo comparison can render the app
- add a committed pre-refactor ConfigMap golden and a real `kustomize build` render gate that extracts the generated registry ConfigMap and compares its data byte-for-byte
- wire the render gate into CI with standalone kustomize v5.4.3

## Root Cause
#272 moved the registry overlay behind kustomize, but `restart-hook.yaml` still used only `metadata.generateName`. That is valid for a loose Argo-applied hook, but kustomize resources require `metadata.name`, so Argo could not render target state and the app stayed in ComparisonError.

## Validation
- `PATH=/root/dev/local-tools:$PATH kustomize build /root/dev/.worktrees/garzaicluster-registry-overlay-kustomize-hook/apps/agent-control-plane-registry-overlay`
- `uv run python scripts/check_agent_control_plane_registry_overlay_render.py --repo-root /root/dev/.worktrees/garzaicluster-registry-overlay-kustomize-hook --kustomize /root/dev/local-tools/kustomize`
- `uv run python -m unittest discover -s tests` (`80 tests`)
- `SOPS_AGE_KEY_FILE=/root/dev/SplatTopConfig/keys/age-private.txt uv run python scripts/check_agent_workloads_identity_digests.py --check`
- `AGENT_CONTROL_PLANE_REGISTRY_BASE_REF=origin/main uv run --with pydantic --with PyYAML python scripts/check_agent_control_plane_registry_compat.py --agent-platform-repo /root/dev/.worktrees/agent-platform-garzaicluster-compat-8ae6c600`
- `git diff --check`

No merge or Argo sync performed.
