### PR TITLE
CES-325 bump control plane to bd1c1f43

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-8ae6c6001f56
+  tag: sha-bd1c1f43e4c3
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 8ae6c6001f567e22e4b288623c63624e5ddbc4c4
+      targetRevision: bd1c1f43e4c304158f5f283b7f9b08d9165e1761
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-8ae6c6001f56` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-bd1c1f43e4c3` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-8ae6c6001f56
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-bd1c1f43e4c3
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary

- Pin the agent-control-plane Argo chart source to `agent-platform` merge commit `bd1c1f43e4c304158f5f283b7f9b08d9165e1761`.
- Bump the control-plane image tag to the verified DOCR tag `sha-bd1c1f43e4c3`.
- This deploys CES-322 and its expand-only migration `002_add_delegation_envelope_to_leases.sql` through the chart's existing Argo `PreSync` migration job.

## Image Verification

- GitHub Actions publish run for `bd1c1f43e4c304158f5f283b7f9b08d9165e1761`: success
- DOCR tag: `registry.digitalocean.com/sendouq/agent-platform:sha-bd1c1f43e4c3`
- DOCR manifest digest: `sha256:a662d68c7997e9153a79dc030195bf9b26c94bfa2aa0c58ed9915d0b9d2231e2`

## Deploy Notes

- `AGENT_PLATFORM_POSTGRES_MIGRATE_ON_STARTUP=false` still renders for runtime pods.
- `agent-control-plane-migrate` renders as an Argo `PreSync` hook using the same `sha-bd1c1f43e4c3` image.
- No worker identity re-mint is included; CES-322 keeps the new lease fields out of the worker-facing claim projection.
- Provider pins are unchanged. The CES-322 merge does not touch provider implementation/config files; the readonly SQL fingerprint still matches local recomputation, while model-gateway local recomputation depends on the live Codex auth config shape and is not being churned in this CP-only release.

## Validation

- `doctl registry repository list-tags agent-platform --format Tag,ManifestDigest,UpdatedAt --no-header`
- `gh api 'repos/cesaregarza/agent-platform/actions/runs?head_sha=bd1c1f43e4c304158f5f283b7f9b08d9165e1761&per_page=20'`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv --directory /root/dev/.worktrees/garzai-ces325-cp-bump run python scripts/check_control_plane_release_pin.py`
- `UV_CACHE_DIR=/tmp/codex-uv-cache uv --directory /root/dev/.worktrees/agent-platform-bd1c1f43 run --with ruamel-yaml python /root/dev/.worktrees/garzai-ces325-cp-bump/scripts/check_agent_control_plane_registry_compat.py --repo-root /root/dev/.worktrees/garzai-ces325-cp-bump --agent-platform-repo /root/dev/.worktrees/agent-platform-bd1c1f43`
- `helm lint /root/dev/.worktrees/agent-platform-bd1c1f43/helm/mandate -f /root/dev/.worktrees/garzai-ces325-cp-bump/apps/agent-control-plane/values.yaml`
- `helm template agent-control-plane /root/dev/.worktrees/agent-platform-bd1c1f43/helm/mandate -f /root/dev/.worktrees/garzai-ces325-cp-bump/apps/agent-control-plane/values.yaml --namespace agent-control-plane --show-only templates/deployment.yaml --show-only templates/model-gateway-deployment.yaml --show-only templates/local-worker-deployment.yaml --show-only templates/callback-adapter-deployment.yaml --show-only templates/migration-job.yaml`
- `PYTHONPATH=/root/dev/.worktrees/garzai-ces325-cp-bump UV_CACHE_DIR=/tmp/codex-uv-cache uv --directory /root/dev/.worktrees/garzai-ces325-cp-bump run --with pytest --with ruamel-yaml python -m pytest tests/test_control_plane_release_pin.py`
- `PYTHONPATH=/root/dev/.worktrees/garzai-ces325-cp-bump UV_CACHE_DIR=/tmp/codex-uv-cache uv --directory /root/dev/.worktrees/garzai-ces325-cp-bump run --with pytest --with ruamel-yaml python -m pytest tests/test_agent_control_plane_registry_compat.py`
- `git diff --check`

CES-325