### PR TITLE
CES-323: declare delegation.allowed_children for opencode_orchestrate

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -260,6 +260,10 @@ imports:
         allowed_profiles:
         - openai.gpt-5.3-codex-spark
         max_cost_usd: 10.0
+      delegation:
+        max_children: 1
+        allowed_children:
+        - agent_workloads.readonly_query
       session_authority_budget:
         max_operations: 8
         session_taint: prod_authority

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -48,6 +48,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_apply` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `session_authority_budget` | `mixed` | `control_plane_restart` |
 | `agent_workloads.opencode_orchestrate` | `artifacts` | `deployment_overlay` | `control_plane_restart` |
+| `agent_workloads.opencode_orchestrate` | `delegation` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `description` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_orchestrate` | `disclosure` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_orchestrate` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -126,6 +126,12 @@ capabilities:
         remint_required: false
         digest_moves: false
         source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
+      delegation:
+        owner: workload_release
+        deploy_consequence: digest_moves_repin_remint
+        remint_required: true
+        digest_moves: true
+        source: workload agent.yaml
       description:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -270,6 +270,10 @@ data:
             allowed_profiles:
             - openai.gpt-5.3-codex-spark
             max_cost_usd: 10.0
+          delegation:
+            max_children: 1
+            allowed_children:
+            - agent_workloads.readonly_query
           session_authority_budget:
             max_operations: 8
             session_taint: prod_authority


### PR DESCRIPTION
## Summary

Activates the CES-322 delegation envelope in prod: adds the operator-minted `delegation` declaration to `agent_workloads.opencode_orchestrate` in the registry overlay.

```yaml
delegation:
  max_children: 1
  allowed_children:
  - agent_workloads.readonly_query
```

- **Pure overlay edit** — no manifest_digest/image regeneration (overlay capability keys pass through the import loader; only `consequence_class` is cross-checked). No worker re-mint.
- The orchestrator deliberately gains **no** `broker`/`broker_lease` block: its direct execution authority stays model-only. The envelope authorizes child dispatch only; direct service grants read only direct lease fields (pinned by test in agent-platform#244).
- Shape validated against the deployed CP (`sha-bd1c1f43e4c3`) rules: `max_children` exactly 1, only `max_children`/`allowed_children` keys, child dispatchable. This exact shape is the PR-244 test fixture.
- Local contract tests: `tests/test_agent_control_plane_registry_overlay.py` + `tests/test_agent_control_plane_registry_compat.py` — 23 passed.

## Deploy (after merge)

1. Argo manual-sync `agent-control-plane-registry-overlay`.
2. **Restart the 4 CP deploys** — the overlay is boot-cached; sync alone won't activate it. A shape error would fail CP boot fail-closed (validated above, but restart one deploy first if you want a canary).
3. Live verify (CES-323 acceptance): orchestrate parent lease carries `delegation_envelope` with the readonly_query axes while direct `allowed_broker` stays null → `mandate_list_capabilities` returns `agent_workloads.readonly_query` → end-to-end natural-language data question delegates and returns the child's released result (closes CES-322 + the CES-246 live-verify gap; regression for `job_1f00ee44d8304f9b91fd1ce3e3b0a44c`).

Linear: CES-323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i