### PR TITLE
Add registry overlay golden update mode

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,6 +91,19 @@ Utilities that were previously bundled with the app repo move here when they are
   in `argocd/applications/agent-control-plane.yaml`. Use
   `--print-target-revision` to retrieve that SHA for automation.
 
+- `check_agent_control_plane_registry_overlay_render.py` – renders
+  `apps/agent-control-plane-registry-overlay` with real kustomize and compares
+  the generated `agent-control-plane-registry-overlay` ConfigMap to the
+  committed golden. After editing registry overlay source files, regenerate the
+  golden and derived ownership docs before running the gate:
+
+  ```bash
+  uv run python scripts/check_agent_control_plane_registry_overlay_render.py --update-golden
+  uv run python scripts/generate_grant_ownership.py
+  uv run python scripts/check_agent_control_plane_registry_overlay_render.py
+  uv run python scripts/generate_grant_ownership.py --check
+  ```
+
 - `mandate_apply.py` – plans or writes a local CES-123
   `MandateWorkloadEnablement` document into deployment-owned files only. Dry-run
   is the default; `--write` edits files for a normal PR. It never reads or

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -42,6 +42,14 @@ def main() -> int:
         default=None,
         help="Optional path to the pre-refactor registry overlay ConfigMap golden.",
     )
+    parser.add_argument(
+        "--update-golden",
+        action="store_true",
+        help=(
+            "Rewrite the committed ConfigMap golden from the real kustomize render "
+            "instead of only checking for drift."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = args.repo_root.resolve()
@@ -55,10 +63,14 @@ def main() -> int:
             repo_root=repo_root,
             kustomize=args.kustomize,
             golden_configmap_path=golden_path,
+            update_golden=args.update_golden,
         )
     except RegistryOverlayRenderError as exc:
         print(f"registry overlay render gate failed: {exc}", file=sys.stderr)
         return 1
+    if args.update_golden:
+        print(f"updated registry overlay ConfigMap golden: {golden_path}")
+        return 0
     print("registry overlay kustomize render matches the committed ConfigMap golden.")
     return 0
 
@@ -68,6 +80,7 @@ def check_registry_overlay_render(
     repo_root: Path,
     kustomize: str,
     golden_configmap_path: Path,
+    update_golden: bool = False,
 ) -> None:
     rendered = _kustomize_build(
         repo_root=repo_root,
@@ -75,6 +88,8 @@ def check_registry_overlay_render(
         kustomize=kustomize,
     )
     rendered_configmap = _extract_registry_configmap(rendered)
+    if update_golden:
+        _write_golden_configmap(rendered_configmap, golden_configmap_path)
     golden_configmap = _load_yaml(golden_configmap_path)
     _assert_configmap_identity_matches(rendered_configmap, golden_configmap)
     _assert_configmap_data_matches(rendered_configmap, golden_configmap)
@@ -187,6 +202,102 @@ def _configmap_data(configmap: dict[str, Any], *, label: str) -> dict[str, str]:
             )
         strings[key] = value
     return strings
+
+
+def _write_golden_configmap(
+    rendered_configmap: dict[str, Any],
+    golden_configmap_path: Path,
+) -> None:
+    """Write a stable golden from the rendered ConfigMap.
+
+    Kustomize emits valid YAML but may order top-level fields differently than the
+    committed fixture. Preserve the existing fixture's data-key and label order
+    where possible so regeneration diffs stay focused on actual registry data.
+    """
+    rendered_identity = _configmap_identity(rendered_configmap)
+    rendered_data = _configmap_data(rendered_configmap, label="rendered")
+
+    existing_identity: dict[str, Any] | None = None
+    existing_data: dict[str, str] = {}
+    if golden_configmap_path.exists():
+        existing = _load_yaml(golden_configmap_path)
+        existing_identity = _configmap_identity(existing)
+        existing_data = _configmap_data(existing, label="golden")
+
+    data_keys = _stable_order(
+        existing_order=existing_data.keys(),
+        rendered_keys=rendered_data.keys(),
+    )
+    label_keys = _stable_order(
+        existing_order=(
+            (existing_identity or {}).get("metadata", {}).get("labels", {}) or {}
+        ).keys(),
+        rendered_keys=rendered_identity["metadata"]["labels"].keys(),
+    )
+
+    golden_configmap_path.parent.mkdir(parents=True, exist_ok=True)
+    golden_configmap_path.write_text(
+        _format_golden_configmap(
+            identity=rendered_identity,
+            data=rendered_data,
+            data_keys=data_keys,
+            label_keys=label_keys,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _stable_order(*, existing_order: Any, rendered_keys: Any) -> list[str]:
+    rendered = set(rendered_keys)
+    ordered = [key for key in existing_order if key in rendered]
+    ordered.extend(sorted(key for key in rendered if key not in ordered))
+    return ordered
+
+
+def _format_golden_configmap(
+    *,
+    identity: dict[str, Any],
+    data: dict[str, str],
+    data_keys: list[str],
+    label_keys: list[str],
+) -> str:
+    metadata = identity["metadata"]
+    labels = metadata["labels"]
+    lines = [
+        f"apiVersion: {_yaml_scalar(identity['apiVersion'])}",
+        f"kind: {_yaml_scalar(identity['kind'])}",
+        "metadata:",
+        f"  name: {_yaml_scalar(metadata['name'])}",
+        f"  namespace: {_yaml_scalar(metadata['namespace'])}",
+        "  labels:",
+    ]
+    for key in label_keys:
+        lines.append(f"    {_yaml_key(key)}: {_yaml_scalar(labels[key])}")
+    lines.append("data:")
+    for key in data_keys:
+        value = data[key]
+        chomping = "|" if value.endswith("\n") else "|-"
+        lines.append(f"  {_yaml_key(key)}: {chomping}")
+        value_lines = value.splitlines()
+        if value_lines:
+            lines.extend(f"    {line}" if line else "" for line in value_lines)
+        else:
+            lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _yaml_key(value: str) -> str:
+    if not value or any(char in value for char in " \t\n\r:#{}[],&*?|<>=!%@\\\"'"):
+        return json.dumps(value)
+    return value
+
+
+def _yaml_scalar(value: Any) -> str:
+    if not isinstance(value, str):
+        return json.dumps(value)
+    if not value or any(char in value for char in " \t\n\r:#{}[],&*?|<>=!%@\\\"'"):
+        return json.dumps(value)
+    return value
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from ruamel.yaml import YAML
@@ -145,6 +147,72 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ),
             "registry overlay render job must run the real kustomize render gate",
         )
+
+    def test_registry_overlay_render_gate_can_update_golden(self) -> None:
+        script_path = (
+            REPO_ROOT / "scripts" / "check_agent_control_plane_registry_overlay_render.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "check_agent_control_plane_registry_overlay_render",
+            script_path,
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        rendered_configmap = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": REGISTRY_OVERLAY_CONFIGMAP_NAME,
+                "namespace": "agent-control-plane",
+                "labels": {
+                    "app.kubernetes.io/component": "registry-overlay",
+                    "app.kubernetes.io/name": "agent-control-plane",
+                },
+            },
+            "data": {
+                "agent-opencode.proposer.json": "{}\n",
+                "workload_imports.yaml": "schema_version: workload-imports.v1\n",
+            },
+        }
+        with TemporaryDirectory() as tmp:
+            golden_path = Path(tmp) / "configmap.golden.yaml"
+            golden_path.write_text(
+                "\n".join(
+                    (
+                        "apiVersion: v1",
+                        "kind: ConfigMap",
+                        "metadata:",
+                        f"  name: {REGISTRY_OVERLAY_CONFIGMAP_NAME}",
+                        "  namespace: agent-control-plane",
+                        "  labels:",
+                        "    app.kubernetes.io/name: agent-control-plane",
+                        "    app.kubernetes.io/component: registry-overlay",
+                        "data:",
+                        "  workload_imports.yaml: |",
+                        "    old: value",
+                        "",
+                    )
+                )
+            )
+
+            module._write_golden_configmap(rendered_configmap, golden_path)
+            updated = _load_yaml(golden_path)
+            self.assertEqual(updated["data"], rendered_configmap["data"])
+
+            text = golden_path.read_text()
+            self.assertIn("  workload_imports.yaml: |", text)
+            self.assertIn("  agent-opencode.proposer.json: |", text)
+            self.assertLess(
+                text.index("workload_imports.yaml"),
+                text.index("agent-opencode.proposer.json"),
+            )
+            self.assertLess(
+                text.index("app.kubernetes.io/name"),
+                text.index("app.kubernetes.io/component"),
+            )
 
     def test_opencode_proposer_import_is_overlay_pinned_and_proposal_only(self) -> None:
         imports = YAML_PARSER.load(self.data["workload_imports.yaml"])


### PR DESCRIPTION
## Summary
- add `--update-golden` to `scripts/check_agent_control_plane_registry_overlay_render.py` so registry overlay source changes can regenerate the committed ConfigMap golden from real kustomize output
- keep regenerated golden formatting stable by preserving existing data-key and label order where possible
- document the faster regeneration flow, including `generate_grant_ownership.py`
- add a focused regression test for the golden update writer

## Validation
- `uv run --with ruamel-yaml python scripts/check_agent_control_plane_registry_overlay_render.py --kustomize /tmp/kustomize-pr276 --update-golden`
- `uv run --with ruamel-yaml python scripts/check_agent_control_plane_registry_overlay_render.py --kustomize /tmp/kustomize-pr276`
- `uv run python scripts/generate_grant_ownership.py --check`
- `uv run --with pytest --with ruamel-yaml python -m pytest tests/test_agent_control_plane_registry_overlay.py`
- `uv run python -m unittest discover -s tests`
- `git diff --check`