### PR TITLE
Raise session_authority_budget.max_operations (orchestrate 8->32, readonly_query 4->16)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -41,7 +41,7 @@ imports:
         max_total_tokens: 44000
         max_cost_usd: 10.0
       session_authority_budget:
-        max_operations: 4
+        max_operations: 16
         session_taint: prod_authority
       artifacts:
         allowed: false
@@ -265,7 +265,7 @@ imports:
         allowed_children:
         - agent_workloads.readonly_query
       session_authority_budget:
-        max_operations: 8
+        max_operations: 32
         session_taint: prod_authority
       disclosure:
         raw_inputs_returnable: false

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -51,7 +51,7 @@ data:
             max_total_tokens: 44000
             max_cost_usd: 10.0
           session_authority_budget:
-            max_operations: 4
+            max_operations: 16
             session_taint: prod_authority
           artifacts:
             allowed: false
@@ -275,7 +275,7 @@ data:
             allowed_children:
             - agent_workloads.readonly_query
           session_authority_budget:
-            max_operations: 8
+            max_operations: 32
             session_taint: prod_authority
           disclosure:
             raw_inputs_returnable: false


### PR DESCRIPTION
Stopgap so opencode_orchestrate can delegate to readonly_query end-to-end. Both jobs were failing `session_authority_budget_exhausted` because the child's op budget is `min(child.max_operations, parent.remaining_operations)` and settles against the parent pool (`worker_child_dispatch.py:499`) — the orchestrator's own reasoning drains it before the child runs. Bumps orchestrate 8→32, readonly_query 4→16; regenerates the render golden (2-line change). Structural fix (session-auth ops compose across delegation) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)