### PR TITLE
Bump control plane to agent-platform c0d0e073 (CES-327/326/274 batch)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-bd1c1f43e4c3
+  tag: sha-c0d0e073c68a
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: bd1c1f43e4c304158f5f283b7f9b08d9165e1761
+      targetRevision: c0d0e073c68a6411c994365f4dcd04fa5bec89ed
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Rolls the CP to agent-platform main `c0d0e073`: **CES-327** (SQL safe window functions — unblocks opencode→sql), **CES-326** (session-budget composition), **CES-274** (narrowed readonly_query projection), + CES-333/334/230 runtime renames/seam-expiry/alias-removal.

**Gate:** CES-327/326/274 adversarially reviewed → PASS. Provider pins reproduced at c0d0e073 and MATCH deployed on both processes → **no re-pin**. No migrations. Image `sha-c0d0e073c68a` published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)