### PR TITLE
[codex] CES-338 update orchestrator result contract overlay

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -232,7 +232,7 @@ imports:
         - output_text
         - answer_text
         - answer_is_platform_verified
-        - capability_id
+        - delegated_capability_id
         - child_job_id
         - released_result
         - evidence

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-bd1c1f43e4c3` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-c0d0e073c68a` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-bd1c1f43e4c3
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-c0d0e073c68a
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -242,7 +242,7 @@ data:
             - output_text
             - answer_text
             - answer_is_platform_verified
-            - capability_id
+            - delegated_capability_id
             - child_job_id
             - released_result
             - evidence

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -181,6 +181,15 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {"allowed": True, "broker_required": False},
         )
 
+        orchestrate = opencode["capabilities"]["agent_workloads.opencode_orchestrate"]
+        self.assertEqual(
+            orchestrate["result_contract"]["output_schema"],
+            "agent_workloads_opencode_orchestrate_result_v1",
+        )
+        released_fields = set(orchestrate["result_contract"]["released_result_fields"])
+        self.assertIn("delegated_capability_id", released_fields)
+        self.assertNotIn("capability_id", released_fields)
+
         manifest = json.loads(self.data["agent-opencode.proposer.json"])
         self.assertEqual(manifest["id"], "opencode.proposer")
         self.assertEqual(manifest["digest"], release_pin["manifestDigest"])


### PR DESCRIPTION
## Summary
- update the registry overlay `opencode_orchestrate` result contract to release `delegated_capability_id` instead of protected `capability_id`
- update the rendered configmap golden fixture
- add a regression assertion that the overlay includes `delegated_capability_id` and does not release `capability_id`

## Validation
- `pytest -q tests/test_agent_control_plane_registry_overlay.py`
- `pytest -q tests/test_agent_control_plane_registry_compat.py tests/test_agent_workloads_identity_digests.py`
- `ruff check tests/test_agent_control_plane_registry_overlay.py`
- `git diff --check`

Part of the CES-338 cross-repo fix with companion changes in `agent-platform` and `agent-workloads`. This overlay should be merged/deployed only after the compatible platform/workload changes are ready.