### PR TITLE
Bump control plane to agent-platform b0c0476 (CES-338)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-c0d0e073c68a
+  tag: sha-b0c0476bbf4d
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: c0d0e073c68a6411c994365f4dcd04fa5bec89ed
+      targetRevision: b0c0476bbf4d357e600a8408cf2bd0d549ee4d30
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-c0d0e073c68a` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-b0c0476bbf4d` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-c0d0e073c68a
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-b0c0476bbf4d
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
CP → ap#252 (CES-338 orchestrate result field rename `capability_id`→`delegated_capability_id`, capability_id stays protected). No re-pin (non-provider-class files). Pairs with gaic#281 (overlay) + aw#69 (proposer re-mint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)