### PR TITLE
CES-343: restore readonly_query broker cost cap 0.05->10.0 (unblock opencode->sql)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -71,7 +71,7 @@ imports:
         - aggregate_summary
         max_rows: 50
         max_runtime_seconds: 120
-        max_cost_usd: 0.05
+        max_cost_usd: 10.0
         statement_timeout_ms: 60000
         max_concurrency: 1
 - id: opencode.proposer

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -81,7 +81,7 @@ data:
             - aggregate_summary
             max_rows: 50
             max_runtime_seconds: 120
-            max_cost_usd: 0.05
+            max_cost_usd: 10.0
             statement_timeout_ms: 60000
             max_concurrency: 1
     - id: opencode.proposer


### PR DESCRIPTION
Re-pin #283 reverted `readonly_query` `broker_lease.max_cost_usd` to the 0.05 source default; below the child model-call worst case (~0.071), so the budget MIN starved the model call. Restores 10.0 + regenerates golden. Render gate verified locally. Stopgap for CES-343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)