### PR TITLE
CES-346: CP bump to sha-1e851e8b86aa (CES-345 Codex-auth redesign)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-b0c0476bbf4d
+  tag: sha-1e851e8b86aa
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -40,7 +40,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:559fb2c7f508a0c0bbcd962416db140e77f73ca8b34becfa2c0835a129b2d128","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -109,7 +109,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:45f52186c33477fd72749ba426110474702ceefba7350f976451617a0e126510","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:dbb0d981c69e9d6f9ba7b2ce1de76f1e9eb88381f81be65314bfc9c4b5fa3a69","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: b0c0476bbf4d357e600a8408cf2bd0d549ee4d30
+      targetRevision: 1e851e8b86aa88c2b3dc82e561a25d3181320ae7
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
## Summary

Deploys agent-platform `1e851e8b86aa` (CES-345, merged ap#253) — the Codex-auth refresh-decision + failure-handling redesign.

Four coordinates move together:
- `apps/agent-control-plane/values.yaml` `image.tag`: `sha-b0c0476bbf4d` → `sha-1e851e8b86aa`
- `argocd/applications/agent-control-plane.yaml` chart `targetRevision` → the same commit (full sha)
- **Both** `model_gateway` provider digest pins re-minted, because `codex_chatgpt.py` (the hashed broker module) changed:
  - control-plane env: `559fb2c7…` → `a1bca832…`
  - gateway pod override: `45f52186…` → `dbb0d981…`
- `readonly-sql-broker` pin untouched (module unchanged)

## Pin provenance (computed, not authored)

Method validated before minting: running `mandate-provider-fingerprints` at `b0c0476` with prod-mirrored settings (backend, timeout 90, auth JSON + store-path flags per process) reproduced **both currently-deployed digests exactly**; the new digests are the same computation at `1e851e8`.

## Deploy notes (CES-346)

No migrations in this image diff. After sync + gateway restart, expect `/readyz` on the gateway to go **not-ready** (the new latch surfacing the dead credential — that's the fix working); then do the CES-344 re-mint (fresh unused token → SOPS secret → restart, **no PVC deletion**) and run the CES-345 live-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i