### PR TITLE
CES-349: bump agent-control-plane to sha-83eb3d6c0fc5 (CES-348 sweep)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-1e851e8b86aa
+  tag: sha-83eb3d6c0fc5
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 1e851e8b86aa88c2b3dc82e561a25d3181320ae7
+      targetRevision: 83eb3d6c0fc53a7057d274f4604303cb2ca773c8
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Deploys agent-platform `83eb3d6c0fc5` (#254, CES-348 queued-lease expiry sweep) to the control plane.

**Coordinates changed (2 of 3):**
- `apps/agent-control-plane/values.yaml` → `image.tag: sha-83eb3d6c0fc5`
- `argocd/applications/agent-control-plane.yaml` → chart `targetRevision: 83eb3d6c0fc53a7057d274f4604303cb2ca773c8`
- Provider digest pins: **unchanged** — the #254 diff touches no broker adapter modules (verified against the file list; `mandate/adapters/model/*` untouched).

**No DB migrations** in the diff → no migrate-job crash-loop window.

**Deploy lock:** requires the DOCR image `sha-83eb3d6c0fc5` (publish was workflow_dispatch'd manually — GitHub dropped the push event for the merge; verify the run is green before sync).

**Live-verify plan:** after sync + restart, `job_04ff87287da944f3b55cf1a304ad64be` (the stranded queued row from 08:02Z) must be swept to `failed` / `lease_expired_unclaimed` by the maintenance cron within one cycle, with a `platform_sweeper` audit event and no new active reservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i