### PR TITLE
CES-351: bump agent-control-plane to sha-e57aeb5f60b9 (CES-350 broker errors)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-83eb3d6c0fc5
+  tag: sha-e57aeb5f60b9
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -40,7 +40,7 @@ secretKeys:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:6cdbd880eb2e8912359878e903b9c98ff415d7045d9a4feb159a1919640827de","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 83eb3d6c0fc53a7057d274f4604303cb2ca773c8
+      targetRevision: e57aeb5f60b9ace7e5c6ec6f06858878f6ad67c9
       path: helm/mandate
       helm:
         releaseName: agent-control-plane


### PR DESCRIPTION
Deploys agent-platform `e57aeb5f60b9` (ap#255, CES-350: actionable readonly_sql broker errors + recorded refused SQL).

**Coordinates changed (3 of 3 — pin moves this time):**
- `apps/agent-control-plane/values.yaml` → `image.tag: sha-e57aeb5f60b9`
- `apps/agent-control-plane/values.yaml` → CP env `readonly-sql-broker` pin `sha256:a81a9f8c…` → `sha256:6cdbd880…` (`postgres_broker.py` is in its digest module set)
- `argocd/applications/agent-control-plane.yaml` → chart `targetRevision: e57aeb5f60b9ace7e5c6ec6f06858878f6ad67c9`

**Pin method validated first**: reproduced all three currently-deployed digests exactly at the old commit (CP `a1bca832…` + `a81a9f8c…`, gateway `dbb0d981…`) with prod-mirrored env, then recomputed at `e57aeb5f`. Both model_gateway pins unchanged (codex adapter untouched) — the modelGateway.env override is NOT edited.

**No DB migrations.** Deploy lock: DOCR image `sha-e57aeb5f60b9` (push CI/publish fired normally this time; verify green before sync).

**Live-verify plan (CES-350 acceptance):** seeded bad-identifier readonly_query self-corrects within the pass budget; rejection run_events carry `sqlstate` + `attempted_sql`; the original Tentatek top-5 ask succeeds end-to-end through orchestrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i