### PR TITLE
CES-356: bump agent-control-plane to sha-91079663b000 (CES-354 audit scoping)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-e57aeb5f60b9
+  tag: sha-91079663b000
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: e57aeb5f60b9ace7e5c6ec6f06858878f6ad67c9
+      targetRevision: 91079663b00071834279783290e1dcc5f1c45a48
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-b0c0476bbf4d` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-91079663b000` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-b0c0476bbf4d
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-91079663b000
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -556,18 +556,18 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             api_pins["model_gateway"]["digest"],
-            "sha256:559fb2c7f508a0c0bbcd962416db140e77f73ca8b34becfa2c0835a129b2d128",
+            "sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e",
         )
         self.assertEqual(
             api_pins["readonly-sql-broker"]["digest"],
-            "sha256:a81a9f8cb6e289492b14d4172777f2ab9228a1e13b6121ad592c9c4fcc07fa4c",
+            "sha256:6cdbd880eb2e8912359878e903b9c98ff415d7045d9a4feb159a1919640827de",
         )
         self.assertEqual(
             gateway_pins["model_gateway"],
             {
                 "digest": (
                     "sha256:"
-                    "45f52186c33477fd72749ba426110474702ceefba7350f976451617a0e126510"
+                    "dbb0d981c69e9d6f9ba7b2ce1de76f1e9eb88381f81be65314bfc9c4b5fa3a69"
                 ),
                 "protocol": "model_gateway",
             },


### PR DESCRIPTION
Deploys agent-platform `91079663b000` (ap#256, CES-354: content-digest source_event_scope for readonly-sql rejections — distinct rejections persist in run_events, replays still dedup).

- `image.tag: sha-91079663b000` + chart `targetRevision: 91079663b00071834279783290e1dcc5f1c45a48`
- **All provider pins unchanged** — validated by recompute at 9107966 (CP `a1bca832…`+`6cdbd880…`, gateway `dbb0d981…`): the changed files are app-layer, not adapter digest modules.
- No DB migrations.
- Gateway roll may hit the CES-352 RWO deadlock (scheduler-luck); recovery = scale 0→1.

Live-verify (CES-354): a multi-rejection readonly_query run shows ALL rejections in run_events, count matching CP logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i