### PR TITLE
CES-96: re-pin agent-workloads sha-31424aeaf0b2

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -11,8 +11,8 @@
       "consequence_class": "read_only"
     }
   },
-  "code_digest": "sha256:3ca2753b8f845cd52ed3fe12f3d7d09811d18c9dff5006c619c36e05697cffb8",
-  "digest": "sha256:945385558bcaeff605f4b61c3e0e1ef61facdf2d2f7db0eb2e158a3c4975104d",
+  "code_digest": "sha256:6692fbb0190d0b7e6b73cac6277c62d8fe05a54dea1c0d0467f71abb73706538",
+  "digest": "sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014",
+    "digest": "sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
@@ -7,8 +7,8 @@
       "consequence_class": "consequential"
     }
   },
-  "code_digest": "sha256:be57611ba5b46113100c53e096cb707dd2dfede68513177d5d5da5070344a109",
-  "digest": "sha256:e174b18865ba37409281cbd16c4153f9fc2a2302c017049b06a760b0638e9611",
+  "code_digest": "sha256:4bb80d27d4682075ad76387413ff7395f41adc278e38b3b596c1ab46a68692e8",
+  "digest": "sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb",
   "display_name": "OpenCode Apply Executor",
   "evals": {
     "optional": [],
@@ -18,7 +18,7 @@
   },
   "id": "opencode.apply_executor",
   "image": {
-    "digest": "sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24",
+    "digest": "sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796",
     "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
@@ -15,8 +15,8 @@
       "consequence_class": "reversible_staging"
     }
   },
-  "code_digest": "sha256:13c360858b12e5ac853abc2c98e1e4a298f96a522565cfcfa0e4787c9df88b81",
-  "digest": "sha256:b34384e3772727c50c972c9dc8cc082bf2afa9f61886c78fb5c33b7ba4b40af8",
+  "code_digest": "sha256:37562e544466984f469c96162ff28be5a3f65c65fcf46d62871cbe6194564099",
+  "digest": "sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072",
   "display_name": "OpenCode Proposer",
   "evals": {
     "optional": [],
@@ -26,7 +26,7 @@
   },
   "id": "opencode.proposer",
   "image": {
-    "digest": "sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5",
+    "digest": "sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103",
     "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:945385558bcaeff605f4b61c3e0e1ef61facdf2d2f7db0eb2e158a3c4975104d
-  image_digest: sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014
+  manifest_digest: sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a
+  image_digest: sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -71,13 +71,13 @@ imports:
         - aggregate_summary
         max_rows: 50
         max_runtime_seconds: 120
-        max_cost_usd: 10.0
+        max_cost_usd: 0.05
         statement_timeout_ms: 60000
         max_concurrency: 1
 - id: opencode.proposer
   manifest_path: registries/imports/agent-opencode.proposer.json
-  manifest_digest: sha256:b34384e3772727c50c972c9dc8cc082bf2afa9f61886c78fb5c33b7ba4b40af8
-  image_digest: sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5
+  manifest_digest: sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072
+  image_digest: sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -285,8 +285,8 @@ imports:
         broker_required: false
 - id: opencode.apply_executor
   manifest_path: registries/imports/agent-opencode.apply_executor.json
-  manifest_digest: sha256:e174b18865ba37409281cbd16c4153f9fc2a2302c017049b06a760b0638e9611
-  image_digest: sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24
+  manifest_digest: sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb
+  image_digest: sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-c9ef80f4928a
-  digest: sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014
+  tag: sha-31424aeaf0b2
+  digest: sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-c9ef80f4928a
-    digest: sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5
+    tag: sha-31424aeaf0b2
+    digest: sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-c9ef80f4928a
-    digest: sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24
+    tag: sha-31424aeaf0b2
+    digest: sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -221,14 +221,14 @@ opencodeApplyExecutor:
       memory: 512Mi
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:3ca2753b8f845cd52ed3fe12f3d7d09811d18c9dff5006c619c36e05697cffb8
-    manifestDigest: sha256:945385558bcaeff605f4b61c3e0e1ef61facdf2d2f7db0eb2e158a3c4975104d
-    imageDigest: sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014
+    codeDigest: sha256:6692fbb0190d0b7e6b73cac6277c62d8fe05a54dea1c0d0467f71abb73706538
+    manifestDigest: sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a
+    imageDigest: sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107
   opencode.apply_executor:
-    codeDigest: sha256:be57611ba5b46113100c53e096cb707dd2dfede68513177d5d5da5070344a109
-    manifestDigest: sha256:e174b18865ba37409281cbd16c4153f9fc2a2302c017049b06a760b0638e9611
-    imageDigest: sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24
+    codeDigest: sha256:4bb80d27d4682075ad76387413ff7395f41adc278e38b3b596c1ab46a68692e8
+    manifestDigest: sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb
+    imageDigest: sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796
   opencode.proposer:
-    codeDigest: sha256:13c360858b12e5ac853abc2c98e1e4a298f96a522565cfcfa0e4787c9df88b81
-    manifestDigest: sha256:b34384e3772727c50c972c9dc8cc082bf2afa9f61886c78fb5c33b7ba4b40af8
-    imageDigest: sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5
+    codeDigest: sha256:37562e544466984f469c96162ff28be5a3f65c65fcf46d62871cbe6194564099
+    manifestDigest: sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072
+    imageDigest: sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:945385558bcaeff605f4b61c3e0e1ef61facdf2d2f7db0eb2e158a3c4975104d
-      image_digest: sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014
+      manifest_digest: sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a
+      image_digest: sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -81,13 +81,13 @@ data:
             - aggregate_summary
             max_rows: 50
             max_runtime_seconds: 120
-            max_cost_usd: 10.0
+            max_cost_usd: 0.05
             statement_timeout_ms: 60000
             max_concurrency: 1
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:b34384e3772727c50c972c9dc8cc082bf2afa9f61886c78fb5c33b7ba4b40af8
-      image_digest: sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5
+      manifest_digest: sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072
+      image_digest: sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -295,8 +295,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:e174b18865ba37409281cbd16c4153f9fc2a2302c017049b06a760b0638e9611
-      image_digest: sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24
+      manifest_digest: sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb
+      image_digest: sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -559,8 +559,8 @@ data:
           "consequence_class": "read_only"
         }
       },
-      "code_digest": "sha256:3ca2753b8f845cd52ed3fe12f3d7d09811d18c9dff5006c619c36e05697cffb8",
-      "digest": "sha256:945385558bcaeff605f4b61c3e0e1ef61facdf2d2f7db0eb2e158a3c4975104d",
+      "code_digest": "sha256:6692fbb0190d0b7e6b73cac6277c62d8fe05a54dea1c0d0467f71abb73706538",
+      "digest": "sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -571,7 +571,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:f24aa9535af4a3c3174569562812d7c7131b87aae36e1d3039ca684e14762014",
+        "digest": "sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -605,8 +605,8 @@ data:
           "consequence_class": "reversible_staging"
         }
       },
-      "code_digest": "sha256:13c360858b12e5ac853abc2c98e1e4a298f96a522565cfcfa0e4787c9df88b81",
-      "digest": "sha256:b34384e3772727c50c972c9dc8cc082bf2afa9f61886c78fb5c33b7ba4b40af8",
+      "code_digest": "sha256:37562e544466984f469c96162ff28be5a3f65c65fcf46d62871cbe6194564099",
+      "digest": "sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -616,7 +616,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:a3bb07d2677c77b1563da61618e0aaba11e03f6051f7d1bfcd3c1d0ae16860b5",
+        "digest": "sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -642,8 +642,8 @@ data:
           "consequence_class": "consequential"
         }
       },
-      "code_digest": "sha256:be57611ba5b46113100c53e096cb707dd2dfede68513177d5d5da5070344a109",
-      "digest": "sha256:e174b18865ba37409281cbd16c4153f9fc2a2302c017049b06a760b0638e9611",
+      "code_digest": "sha256:4bb80d27d4682075ad76387413ff7395f41adc278e38b3b596c1ab46a68692e8",
+      "digest": "sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -653,7 +653,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:57859f8d25fb9d23f54c521ed5cc4c28c838440cbab733824d8cd83b69147f24",
+        "digest": "sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {


### PR DESCRIPTION
## Summary
- Re-pin GarzAICluster to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `31424aeaf0b2fd016b61ebcd77ee76c1fad12032`
- Publish run id: `28636498215`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:0aa4d9d833981b5faf3f048a6af6e4f96d3e59d37e4d4b5e15cd5d270e3e1107` | `sha256:0fc2801a383f625c955499c0e0a4af89dd5a98be308acbeecccdae22f457c66a` | `sha256:6692fbb0190d0b7e6b73cac6277c62d8fe05a54dea1c0d0467f71abb73706538` |
| `opencode.apply_executor` | `sha256:0a9a38686652a18284e8c16cef5e45f541c1fd26b61cd065984e21076d677796` | `sha256:4a2b9886107a0dafcf739918336746787fcb1a31723c476e9a4001ad1b3865cb` | `sha256:4bb80d27d4682075ad76387413ff7395f41adc278e38b3b596c1ab46a68692e8` |
| `opencode.proposer` | `sha256:9a8e54ee7b7ef3493415c50523f7b2d064333324cce73ed2b249e4167e3ba103` | `sha256:d307d1d9937b2d2386d9b97f36cd9b0aa5b78f6993b2e9696b51cb722818f072` | `sha256:37562e544466984f469c96162ff28be5a3f65c65fcf46d62871cbe6194564099` |

## Safety
- This PR does not mint workload identity tokens.
- The GarzAICluster drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.