### PR TITLE
CES-96: re-pin agent-workloads sha-6865661d4dcd

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -12,7 +12,7 @@
     }
   },
   "code_digest": "sha256:aed42a1269247a0292e2e3cfeaf1752aa9be6a6451562b0c601fdbf1ad7059e0",
-  "digest": "sha256:df6ddf514c9d9ff43eb69d0295859831452eab10b96e1bf374afda0e209f38a7",
+  "digest": "sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26",
+    "digest": "sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
@@ -8,7 +8,7 @@
     }
   },
   "code_digest": "sha256:81d0df6458c578554e1699f22e00b3b7d9d140979dd57bdcd3dd9856ffd6ae77",
-  "digest": "sha256:f654c6c47d39d88088793f1b5680a7740d72794976978b4098eab05106340fb2",
+  "digest": "sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96",
   "display_name": "OpenCode Apply Executor",
   "evals": {
     "optional": [],
@@ -18,7 +18,7 @@
   },
   "id": "opencode.apply_executor",
   "image": {
-    "digest": "sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a",
+    "digest": "sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c",
     "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
@@ -16,7 +16,7 @@
     }
   },
   "code_digest": "sha256:7c09ad09b6350da5fa71c3e5e67d7a02e84f761feea011322af197bfb0825ec2",
-  "digest": "sha256:d80909a90d82200b2f1254e5bb9769fadadf0a46ea8d964e7213435e9bbf97d9",
+  "digest": "sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7",
   "display_name": "OpenCode Proposer",
   "evals": {
     "optional": [],
@@ -26,7 +26,7 @@
   },
   "id": "opencode.proposer",
   "image": {
-    "digest": "sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263",
+    "digest": "sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1",
     "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:df6ddf514c9d9ff43eb69d0295859831452eab10b96e1bf374afda0e209f38a7
-  image_digest: sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26
+  manifest_digest: sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6
+  image_digest: sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -76,8 +76,8 @@ imports:
         max_concurrency: 1
 - id: opencode.proposer
   manifest_path: registries/imports/agent-opencode.proposer.json
-  manifest_digest: sha256:d80909a90d82200b2f1254e5bb9769fadadf0a46ea8d964e7213435e9bbf97d9
-  image_digest: sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263
+  manifest_digest: sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7
+  image_digest: sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -285,8 +285,8 @@ imports:
         broker_required: false
 - id: opencode.apply_executor
   manifest_path: registries/imports/agent-opencode.apply_executor.json
-  manifest_digest: sha256:f654c6c47d39d88088793f1b5680a7740d72794976978b4098eab05106340fb2
-  image_digest: sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a
+  manifest_digest: sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96
+  image_digest: sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-31ad05e8f981
-  digest: sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26
+  tag: sha-6865661d4dcd
+  digest: sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-31ad05e8f981
-    digest: sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263
+    tag: sha-6865661d4dcd
+    digest: sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-31ad05e8f981
-    digest: sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a
+    tag: sha-6865661d4dcd
+    digest: sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -222,13 +222,13 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:aed42a1269247a0292e2e3cfeaf1752aa9be6a6451562b0c601fdbf1ad7059e0
-    manifestDigest: sha256:df6ddf514c9d9ff43eb69d0295859831452eab10b96e1bf374afda0e209f38a7
-    imageDigest: sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26
+    manifestDigest: sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6
+    imageDigest: sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478
   opencode.apply_executor:
     codeDigest: sha256:81d0df6458c578554e1699f22e00b3b7d9d140979dd57bdcd3dd9856ffd6ae77
-    manifestDigest: sha256:f654c6c47d39d88088793f1b5680a7740d72794976978b4098eab05106340fb2
-    imageDigest: sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a
+    manifestDigest: sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96
+    imageDigest: sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c
   opencode.proposer:
     codeDigest: sha256:7c09ad09b6350da5fa71c3e5e67d7a02e84f761feea011322af197bfb0825ec2
-    manifestDigest: sha256:d80909a90d82200b2f1254e5bb9769fadadf0a46ea8d964e7213435e9bbf97d9
-    imageDigest: sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263
+    manifestDigest: sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7
+    imageDigest: sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:df6ddf514c9d9ff43eb69d0295859831452eab10b96e1bf374afda0e209f38a7
-      image_digest: sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26
+      manifest_digest: sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6
+      image_digest: sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -86,8 +86,8 @@ data:
             max_concurrency: 1
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:d80909a90d82200b2f1254e5bb9769fadadf0a46ea8d964e7213435e9bbf97d9
-      image_digest: sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263
+      manifest_digest: sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7
+      image_digest: sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -295,8 +295,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:f654c6c47d39d88088793f1b5680a7740d72794976978b4098eab05106340fb2
-      image_digest: sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a
+      manifest_digest: sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96
+      image_digest: sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -560,7 +560,7 @@ data:
         }
       },
       "code_digest": "sha256:aed42a1269247a0292e2e3cfeaf1752aa9be6a6451562b0c601fdbf1ad7059e0",
-      "digest": "sha256:df6ddf514c9d9ff43eb69d0295859831452eab10b96e1bf374afda0e209f38a7",
+      "digest": "sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -571,7 +571,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:7b8d74ac2409d1662b5f51f101fcafd981237ef9b58ce31d1758f36f3f73cd26",
+        "digest": "sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -606,7 +606,7 @@ data:
         }
       },
       "code_digest": "sha256:7c09ad09b6350da5fa71c3e5e67d7a02e84f761feea011322af197bfb0825ec2",
-      "digest": "sha256:d80909a90d82200b2f1254e5bb9769fadadf0a46ea8d964e7213435e9bbf97d9",
+      "digest": "sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -616,7 +616,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:c1882eaa429d52d807ac668ece6be2909e0af02962cb55faaf8e578cd7f53263",
+        "digest": "sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -643,7 +643,7 @@ data:
         }
       },
       "code_digest": "sha256:81d0df6458c578554e1699f22e00b3b7d9d140979dd57bdcd3dd9856ffd6ae77",
-      "digest": "sha256:f654c6c47d39d88088793f1b5680a7740d72794976978b4098eab05106340fb2",
+      "digest": "sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -653,7 +653,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:b8e0a5fd74c985764c5e5edcf2d4eafd113bc6e3b23ebcadae2865bddbb9da5a",
+        "digest": "sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {


### PR DESCRIPTION
## Summary
- Re-pin GarzAICluster to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `6865661d4dcdc1619cf2f7511def0e537016de69`
- Publish run id: `28672797044`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:db84b9f0616abd0bb16d57645f2ec6926666203c0713cb0714e966a60b031478` | `sha256:454fd795e20844d6cf6e366634ca6e4bd93d1fda68fbfeadc7f6706f59123fc6` | `sha256:aed42a1269247a0292e2e3cfeaf1752aa9be6a6451562b0c601fdbf1ad7059e0` |
| `opencode.apply_executor` | `sha256:6355467d5a2052512129a2e97466e84278a82e7b53cfdf0f5b4fb5985ea8010c` | `sha256:d117bb5f74466b0fbd7caefa10348ae3b74af5b02ce3d363a0d78150bb6e9a96` | `sha256:81d0df6458c578554e1699f22e00b3b7d9d140979dd57bdcd3dd9856ffd6ae77` |
| `opencode.proposer` | `sha256:93513de2069d84faae31c2b7045559570fb3a51b3d9b957c42a2609896b29cd1` | `sha256:6b4f71c272d0f778b92ec75e26034a031ae31b48cf77bd0c3c2951ef03dd60b7` | `sha256:7c09ad09b6350da5fa71c3e5e67d7a02e84f761feea011322af197bfb0825ec2` |

## Safety
- This PR does not mint workload identity tokens.
- The GarzAICluster drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.