### PR TITLE
CES-381: glossary hot-reload live proof (one-line skill edit)

### DIFF
--- a/apps/agent-control-plane-skills/bundle/manifest.json
+++ b/apps/agent-control-plane-skills/bundle/manifest.json
@@ -8,7 +8,7 @@
     {
       "id": "xscraper-glossary",
       "path": "xscraper-glossary.md",
-      "digest": "sha256:804f5681374b0e3ffb936133819a3a1743d424b0e2fcfb7797a1d47399e3225a"
+      "digest": "sha256:1d0221db77a4406834ec4355a15b9ec0d966c405067470e5220d4b06d9858597"
     },
     {
       "id": "xscraper-schema",

--- a/apps/agent-control-plane-skills/bundle/xscraper-glossary.md
+++ b/apps/agent-control-plane-skills/bundle/xscraper-glossary.md
@@ -1,6 +1,6 @@
 ---
 id: xscraper-glossary
-version: 2026.07.03
+version: 2026.07.04
 requires:
   - xscraper-schema
 ---
@@ -39,3 +39,5 @@ requires:
   before concluding there is no match.
 - Use regional boolean filters only when the task explicitly asks for a division
   or region, or when a leaderboard table requires the distinction.
+- Splashtag discriminators (the #NNNN suffix) are display identity, not join keys;
+  join on player_id when correlating across tables.


### PR DESCRIPTION
One glossary line + version bump + recomputed manifest digest. Merging this is the CES-355 hot-reload acceptance test: the next claimed readonly_query job must carry digest `sha256:1d0221db…` in run_events with zero restarts, zero re-mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i