### PR TITLE
CES-96: re-pin agent-workloads sha-5f5073ba7a7e

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -12,7 +12,7 @@
     }
   },
   "code_digest": "sha256:2acbf9b3fdc8ec129326ccdc55c13e62b6af3e66f55a3af11ba29519ec3be3d0",
-  "digest": "sha256:0b610bdafd91d61824d12c98fcc1738d5145933c91677c8b578deaa2ae481fe2",
+  "digest": "sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256",
+    "digest": "sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
@@ -8,7 +8,7 @@
     }
   },
   "code_digest": "sha256:d8607d97e16263b9d1c134b694d92e25b7ee4aac8c02852f0994ed8616b6e963",
-  "digest": "sha256:01c1be32e6ad355e991e7d372b10acce99ab005e8ae479a05eda5b538bcb5052",
+  "digest": "sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff",
   "display_name": "OpenCode Apply Executor",
   "evals": {
     "optional": [],
@@ -18,7 +18,7 @@
   },
   "id": "opencode.apply_executor",
   "image": {
-    "digest": "sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b",
+    "digest": "sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d",
     "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
@@ -16,7 +16,7 @@
     }
   },
   "code_digest": "sha256:45441ea0f3091baa08a7d3cdcf713dd833641ea0938d71338a84734984cda03d",
-  "digest": "sha256:1518a2ffae84947629254653755c04f12f6f823078e1527b98c3f110512f7b8d",
+  "digest": "sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8",
   "display_name": "OpenCode Proposer",
   "evals": {
     "optional": [],
@@ -26,7 +26,7 @@
   },
   "id": "opencode.proposer",
   "image": {
-    "digest": "sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a",
+    "digest": "sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f",
     "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:0b610bdafd91d61824d12c98fcc1738d5145933c91677c8b578deaa2ae481fe2
-  image_digest: sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256
+  manifest_digest: sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b
+  image_digest: sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -79,8 +79,8 @@ imports:
         max_concurrency: 1
 - id: opencode.proposer
   manifest_path: registries/imports/agent-opencode.proposer.json
-  manifest_digest: sha256:1518a2ffae84947629254653755c04f12f6f823078e1527b98c3f110512f7b8d
-  image_digest: sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a
+  manifest_digest: sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8
+  image_digest: sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -288,8 +288,8 @@ imports:
         broker_required: false
 - id: opencode.apply_executor
   manifest_path: registries/imports/agent-opencode.apply_executor.json
-  manifest_digest: sha256:01c1be32e6ad355e991e7d372b10acce99ab005e8ae479a05eda5b538bcb5052
-  image_digest: sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b
+  manifest_digest: sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff
+  image_digest: sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-7dfa224cbca2
-  digest: sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256
+  tag: sha-5f5073ba7a7e
+  digest: sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-7dfa224cbca2
-    digest: sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a
+    tag: sha-5f5073ba7a7e
+    digest: sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-7dfa224cbca2
-    digest: sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b
+    tag: sha-5f5073ba7a7e
+    digest: sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -222,13 +222,13 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:2acbf9b3fdc8ec129326ccdc55c13e62b6af3e66f55a3af11ba29519ec3be3d0
-    manifestDigest: sha256:0b610bdafd91d61824d12c98fcc1738d5145933c91677c8b578deaa2ae481fe2
-    imageDigest: sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256
+    manifestDigest: sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b
+    imageDigest: sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194
   opencode.apply_executor:
     codeDigest: sha256:d8607d97e16263b9d1c134b694d92e25b7ee4aac8c02852f0994ed8616b6e963
-    manifestDigest: sha256:01c1be32e6ad355e991e7d372b10acce99ab005e8ae479a05eda5b538bcb5052
-    imageDigest: sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b
+    manifestDigest: sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff
+    imageDigest: sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d
   opencode.proposer:
     codeDigest: sha256:45441ea0f3091baa08a7d3cdcf713dd833641ea0938d71338a84734984cda03d
-    manifestDigest: sha256:1518a2ffae84947629254653755c04f12f6f823078e1527b98c3f110512f7b8d
-    imageDigest: sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a
+    manifestDigest: sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8
+    imageDigest: sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -12,8 +12,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:0b610bdafd91d61824d12c98fcc1738d5145933c91677c8b578deaa2ae481fe2
-      image_digest: sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256
+      manifest_digest: sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b
+      image_digest: sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -89,8 +89,8 @@ data:
             max_concurrency: 1
     - id: opencode.proposer
       manifest_path: registries/imports/agent-opencode.proposer.json
-      manifest_digest: sha256:1518a2ffae84947629254653755c04f12f6f823078e1527b98c3f110512f7b8d
-      image_digest: sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a
+      manifest_digest: sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8
+      image_digest: sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -298,8 +298,8 @@ data:
             broker_required: false
     - id: opencode.apply_executor
       manifest_path: registries/imports/agent-opencode.apply_executor.json
-      manifest_digest: sha256:01c1be32e6ad355e991e7d372b10acce99ab005e8ae479a05eda5b538bcb5052
-      image_digest: sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b
+      manifest_digest: sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff
+      image_digest: sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -563,7 +563,7 @@ data:
         }
       },
       "code_digest": "sha256:2acbf9b3fdc8ec129326ccdc55c13e62b6af3e66f55a3af11ba29519ec3be3d0",
-      "digest": "sha256:0b610bdafd91d61824d12c98fcc1738d5145933c91677c8b578deaa2ae481fe2",
+      "digest": "sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -574,7 +574,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:dee0a25a7bf906693804a01ac81b38b8be8051c490b7677754e769591e8f3256",
+        "digest": "sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -609,7 +609,7 @@ data:
         }
       },
       "code_digest": "sha256:45441ea0f3091baa08a7d3cdcf713dd833641ea0938d71338a84734984cda03d",
-      "digest": "sha256:1518a2ffae84947629254653755c04f12f6f823078e1527b98c3f110512f7b8d",
+      "digest": "sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8",
       "display_name": "OpenCode Proposer",
       "evals": {
         "optional": [],
@@ -619,7 +619,7 @@ data:
       },
       "id": "opencode.proposer",
       "image": {
-        "digest": "sha256:9c7b957e20edd32024cf7823a0fca29477f9d635626b48fbd38ffb5e22f8984a",
+        "digest": "sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f",
         "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
       },
       "loop": {
@@ -646,7 +646,7 @@ data:
         }
       },
       "code_digest": "sha256:d8607d97e16263b9d1c134b694d92e25b7ee4aac8c02852f0994ed8616b6e963",
-      "digest": "sha256:01c1be32e6ad355e991e7d372b10acce99ab005e8ae479a05eda5b538bcb5052",
+      "digest": "sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff",
       "display_name": "OpenCode Apply Executor",
       "evals": {
         "optional": [],
@@ -656,7 +656,7 @@ data:
       },
       "id": "opencode.apply_executor",
       "image": {
-        "digest": "sha256:f2b19e75cbf43c5fc8742a55ce7941e1a1333ef71f7a1f1b85f424ae8a9acb5b",
+        "digest": "sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d",
         "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
       },
       "loop": {


### PR DESCRIPTION
## Summary
- Re-pin GarzAICluster to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `5f5073ba7a7ebec8352aac80c509de752223939f`
- Publish run id: `28701605565`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:ed85aaf0279afaf5ac3e593142f16db85d423bb0b2f47cdf34b771fde9ec3194` | `sha256:12b19342ecfa4650cce9c497b6e2c53794d26919ab589a15b3e119384b7d693b` | `sha256:2acbf9b3fdc8ec129326ccdc55c13e62b6af3e66f55a3af11ba29519ec3be3d0` |
| `opencode.apply_executor` | `sha256:158875ac3e9dedd95291be02a1afc0fc3fd8517453534178a8643754f1c8f26d` | `sha256:6d8b8d6c9938cabef9710275a7facf08c747df646b00e6820b6c0597aeea98ff` | `sha256:d8607d97e16263b9d1c134b694d92e25b7ee4aac8c02852f0994ed8616b6e963` |
| `opencode.proposer` | `sha256:ed8c86e724ec1eb5489abf584f2f3d5427704b6b9e6ed9c3735bba14de40b39f` | `sha256:89c796164edacb4bd047338c5e8131ea17c8e851ba9737e52e8a0895430472d8` | `sha256:45441ea0f3091baa08a7d3cdcf713dd833641ea0938d71338a84734984cda03d` |

## Safety
- This PR does not mint workload identity tokens.
- The GarzAICluster drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.