### PR TITLE
[codex] Enable synthetic live verify deploy train

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -37,12 +37,15 @@ bindings:
         approval.probe: admin_confirm
         agent_workloads.opencode_apply: admin_confirm
   - id: synthetic-live-verify-probe
-    description: Scheduled no-key deployment smoke probe for CES-154. This
+    description: >-
+      Scheduled no-key deployment and readonly-query live verify probe. This
       binding is intentionally narrower than the private admin binding so
       CronJob credentials can prove the live submit/worker/output/callback
       path without gaining operator capabilities.
-    guild_id: "614277943706910722"
-    channel_id: "1480483954694819940"
+    principal:
+      issuer: synthetic
+      subject_kind: service
+      tenant_id: garzai-prod
     users:
       admins: []
       authorized:
@@ -50,3 +53,4 @@ bindings:
     capabilities:
       allow:
         - mandate.deploy.smoke
+        - agent_workloads.readonly_query

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -57,8 +57,11 @@ Required before activation:
   `agent-control-plane-model-gateway-controls` as a directory so operator edits
   project without pod restarts. See
   [model-gateway controls](../../docs/model-gateway-controls.md).
-- `syntheticLiveVerify.enabled=true` runs the CES-154 scheduled deployment
-  smoke probe every five minutes through the normal `/v1/tasks` path. The probe
-  uses the dedicated `mandate-live-probe` actor, which is policy-granted only
-  for `mandate.deploy.smoke`; failed Jobs alert through the production
-  Prometheus/Alertmanager route.
+- `syntheticLiveVerify.enabled=true` runs the scheduled deployment smoke and
+  readonly-query probes every five minutes through the trusted-edge `/v1/tasks`
+  path with signed `mctx_v2` assertions. The dedicated
+  `mandate-live-probe` service principal is policy-granted only for
+  `mandate.deploy.smoke` and `agent_workloads.readonly_query`, and the delivery
+  target is internal so successful probes do not post to the operator Discord
+  channel. Failed Jobs alert through the production Prometheus/Alertmanager
+  route.

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-184da9ef35f6
+  tag: sha-2f9c719f52d9
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -247,16 +247,74 @@ postgresSweep:
   enabled: true
 
 syntheticLiveVerify:
-  enabled: false
+  enabled: true
   schedule: "*/5 * * * *"
   baseUrl: http://agent-control-plane:80
-  actor:
-    platform: synthetic
-    guildId: "614277943706910722"
-    channelId: "1480483954694819940"
-    userId: mandate-live-probe
+  principal:
+    issuer: synthetic
+    subject_id: mandate-live-probe
+    subject_kind: service
+    tenant_id: garzai-prod
     roles:
       - synthetic_probe
-  replyTarget:
-    channelId: "1480483954694819940"
-    messageId: scheduled-synthetic-live-verify
+    provenance:
+      source: synthetic-live-verify
+      identifiers:
+        tenant_ref: garzai-prod
+        subject_ref: mandate-live-probe
+  deliveryTarget:
+    kind: internal
+    target_ref: synthetic-live-verify
+    message_ref: scheduled-synthetic-live-verify
+  surfaceContext:
+    source: synthetic-live-verify
+    surface_ref: synthetic-live-verify
+    adapter_provenance:
+      source: synthetic-live-verify
+      identifiers:
+        probe: scheduled
+  trustedContext:
+    entitlements: []
+    attachment_authorities: []
+  journeys:
+    - id: deployment-smoke
+      capability_id: mandate.deploy.smoke
+      text: Run the deployment smoke probe and return the deployment marker.
+      max_cost_usd: 0.05
+      max_runtime_seconds: 60
+      timeout_seconds: 120
+      poll_seconds: 5
+      expected_status: succeeded
+      required_result_fields:
+        - output_text
+        - probe_marker
+      required_callback_types:
+        - job.accepted
+        - job.progress
+        - job.succeeded
+      required_event_types:
+        - run.created
+        - policy.evaluated
+        - result.released
+    - id: readonly-query-skill-digests
+      capability_id: agent_workloads.readonly_query
+      text: Show 3 recent X Power schedule windows from xscraper.schedules.
+      max_cost_usd: 1.0
+      max_runtime_seconds: 120
+      timeout_seconds: 180
+      poll_seconds: 5
+      expected_status: succeeded
+      required_result_fields:
+        - output_text
+      required_callback_types:
+        - job.accepted
+        - job.progress
+        - job.succeeded
+      required_event_types:
+        - run.created
+        - policy.evaluated
+        - tool.started
+        - result.released
+      required_skill_ids:
+        - xscraper-schema
+        - xscraper-glossary

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-2f9c719f52d9
+  tag: sha-22e8e023a614
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 184da9ef35f638f498ff1c796139bfa66bf5f66d
+      targetRevision: 2f9c719f52d98cf86fd70ad9959761863b580632
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 2f9c719f52d98cf86fd70ad9959761863b580632
+      targetRevision: 22e8e023a614bbd38dec31644875cae984045556
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-2f9c719f52d9` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-22e8e023a614` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-2f9c719f52d9
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-22e8e023a614
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-184da9ef35f6` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-2f9c719f52d9` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-184da9ef35f6
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-2f9c719f52d9
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -412,12 +412,15 @@ data:
             approval.probe: admin_confirm
             agent_workloads.opencode_apply: admin_confirm
       - id: synthetic-live-verify-probe
-        description: Scheduled no-key deployment smoke probe for CES-154. This
+        description: >-
+          Scheduled no-key deployment and readonly-query live verify probe. This
           binding is intentionally narrower than the private admin binding so
           CronJob credentials can prove the live submit/worker/output/callback
           path without gaining operator capabilities.
-        guild_id: "614277943706910722"
-        channel_id: "1480483954694819940"
+        principal:
+          issuer: synthetic
+          subject_kind: service
+          tenant_id: garzai-prod
         users:
           admins: []
           authorized:
@@ -425,6 +428,7 @@ data:
         capabilities:
           allow:
             - mandate.deploy.smoke
+            - agent_workloads.readonly_query
   evals.yaml: |
     eval_suites:
       - id: eval.task_echo_smoke

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -486,8 +486,16 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             ["mandate-live-probe"],
         )
         self.assertEqual(
+            synthetic_binding["principal"],
+            {
+                "issuer": "synthetic",
+                "subject_kind": "service",
+                "tenant_id": "garzai-prod",
+            },
+        )
+        self.assertEqual(
             synthetic_binding["capabilities"]["allow"],
-            ["mandate.deploy.smoke"],
+            ["mandate.deploy.smoke", "agent_workloads.readonly_query"],
         )
         self.assertEqual(synthetic_binding["users"].get("admins"), [])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])
@@ -547,29 +555,74 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "evals.yaml",
         )
 
-    def test_synthetic_live_verify_keeps_dedicated_probe_actor_disabled(self) -> None:
+    def test_synthetic_live_verify_runs_internal_deployment_and_readonly_probes(
+        self,
+    ) -> None:
         synthetic = self.control_plane_values["syntheticLiveVerify"]
 
-        self.assertFalse(synthetic["enabled"])
+        self.assertTrue(synthetic["enabled"])
         self.assertEqual(synthetic["schedule"], "*/5 * * * *")
         self.assertEqual(synthetic["baseUrl"], "http://agent-control-plane:80")
         self.assertEqual(
-            synthetic["actor"],
+            synthetic["principal"],
             {
-                "platform": "synthetic",
-                "guildId": "614277943706910722",
-                "channelId": "1480483954694819940",
-                "userId": "mandate-live-probe",
+                "issuer": "synthetic",
+                "subject_id": "mandate-live-probe",
+                "subject_kind": "service",
+                "tenant_id": "garzai-prod",
                 "roles": ["synthetic_probe"],
+                "provenance": {
+                    "source": "synthetic-live-verify",
+                    "identifiers": {
+                        "tenant_ref": "garzai-prod",
+                        "subject_ref": "mandate-live-probe",
+                    },
+                },
             },
         )
         self.assertEqual(
-            synthetic["replyTarget"],
+            synthetic["deliveryTarget"],
             {
-                "channelId": "1480483954694819940",
-                "messageId": "scheduled-synthetic-live-verify",
+                "kind": "internal",
+                "target_ref": "synthetic-live-verify",
+                "message_ref": "scheduled-synthetic-live-verify",
             },
         )
+        self.assertEqual(
+            synthetic["surfaceContext"],
+            {
+                "source": "synthetic-live-verify",
+                "surface_ref": "synthetic-live-verify",
+                "adapter_provenance": {
+                    "source": "synthetic-live-verify",
+                    "identifiers": {"probe": "scheduled"},
+                },
+            },
+        )
+        self.assertEqual(
+            synthetic["trustedContext"],
+            {"entitlements": [], "attachment_authorities": []},
+        )
+        journeys = {journey["id"]: journey for journey in synthetic["journeys"]}
+        self.assertEqual(
+            set(journeys),
+            {"deployment-smoke", "readonly-query-skill-digests"},
+        )
+        self.assertEqual(
+            journeys["deployment-smoke"]["required_result_fields"],
+            ["output_text", "probe_marker"],
+        )
+        readonly_query = journeys["readonly-query-skill-digests"]
+        self.assertEqual(
+            readonly_query["capability_id"],
+            "agent_workloads.readonly_query",
+        )
+        self.assertEqual(readonly_query["required_result_fields"], ["output_text"])
+        self.assertEqual(
+            readonly_query["required_skill_ids"],
+            ["xscraper-schema", "xscraper-glossary"],
+        )
+        self.assertIn("tool.started", readonly_query["required_event_types"])
 
     def test_prometheus_alerts_on_failed_synthetic_live_verify_job(self) -> None:
         rules_template = (


### PR DESCRIPTION
## Summary
- pin agent-control-plane to `agent-platform@2f9c719f52d98cf86fd70ad9959761863b580632` / `sha-2f9c719f52d9`
- enable the synthetic live-verify CronJob with internal delivery and neutral trusted-edge principal context
- grant the probe only `mandate.deploy.smoke` and `agent_workloads.readonly_query`, and assert readonly_query skill digests for `xscraper-schema` and `xscraper-glossary`
- update the registry overlay golden and restore runbook image refs

## Dependency
- Requires https://github.com/cesaregarza/agent-platform/pull/260 and the matching AP image publish run for `sha-2f9c719f52d9`.

## Validation
- `python -m unittest discover -s tests`
- `python scripts/check_agent_control_plane_registry_overlay_render.py` via local `kubectl kustomize` wrapper
- `helm template agent-control-plane /root/dev/agent-platform-ces382/helm/mandate -f apps/agent-control-plane/values.yaml --namespace agent-control-plane --debug`