### PR TITLE
CES-382: fix smoke journey marker assertion (probe_marker → schema_version)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -287,7 +287,7 @@ syntheticLiveVerify:
       expected_status: succeeded
       required_result_fields:
         - output_text
-        - probe_marker
+        - schema_version
       required_callback_types:
         - job.accepted
         - job.progress

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -610,7 +610,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             journeys["deployment-smoke"]["required_result_fields"],
-            ["output_text", "probe_marker"],
+            ["output_text", "schema_version"],
         )
         readonly_query = journeys["readonly-query-skill-digests"]
         self.assertEqual(


### PR DESCRIPTION
First live probe (job 29719895) failed stage-named at `output_gate`: `released result missing non-empty fields: probe_marker`. Verified against ap main: `probe_marker` exists nowhere; the deployment_smoke worker emits `schema_version: mandate_deployment_smoke_v1` — the natural marker. One-line journey assertion fix.

The readonly-query journey's 403 was a separate cause — the registry-overlay app was OutOfSync (manual-sync + boot-cache); overlay synced + CP restarted at ~19:45Z, so that journey should pass on the next probe without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i