### PR TITLE
CES-382: readonly journey max_runtime 120 → 60 (prod policy cap)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -300,7 +300,7 @@ syntheticLiveVerify:
       capability_id: agent_workloads.readonly_query
       text: Show 3 recent X Power schedule windows from xscraper.schedules.
       max_cost_usd: 1.0
-      max_runtime_seconds: 120
+      max_runtime_seconds: 60
       timeout_seconds: 180
       poll_seconds: 5
       expected_status: succeeded


### PR DESCRIPTION
Probe firing #2 (job 29719915): deployment-smoke **passed end-to-end**; readonly journey advanced 403 → 422 at submit. Cause verified in ap: `registries/policy.prod.yaml` sets `max_runtime_seconds_per_job: 60` and admission rejects with 'max_runtime_seconds exceeds policy limit'. Journey asked 120. Live readonly_query runs complete well under 60s (CES-381 verify ran at exactly this cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5qVgJbu3v8CmxLGYW77i