### PR TITLE
[codex] Add Hermes governed runtime monitoring

### DIFF
--- a/helm/garz-observability/templates/monitoring-networkpolicies.yaml
+++ b/helm/garz-observability/templates/monitoring-networkpolicies.yaml
@@ -123,6 +123,18 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: {{ $nsName }}
         {{- end }}
+    {{- range .prometheus.extraEgress }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      {{- if .ports }}
+      ports:
+        {{- range .ports }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -55,6 +55,26 @@ data:
           - targets:
               - alertmanager.monitoring.svc.cluster.local:9093
 
+{{- range $scrape := .Values.monitoring.prometheus.staticScrapeConfigs }}
+      - job_name: {{ $scrape.jobName | quote }}
+        metrics_path: {{ default "/metrics" $scrape.metricsPath | quote }}
+        {{- with $scrape.scheme }}
+        scheme: {{ . | quote }}
+        {{- end }}
+        {{- with $scrape.scrapeInterval }}
+        scrape_interval: {{ . | quote }}
+        {{- end }}
+        static_configs:
+          - targets:
+            {{- range $target := $scrape.targets }}
+              - {{ $target | quote }}
+            {{- end }}
+            {{- with $scrape.labels }}
+            labels:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+{{- end }}
       - job_name: kubernetes-pods
         kubernetes_sd_configs:
           - role: pod

--- a/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-rules-configmap.yaml
@@ -155,6 +155,40 @@ data:
               summary: Mandate synthetic live verify failed
               description: The scheduled Mandate synthetic live verify CronJob has a failed Job; inspect the agent-control-plane synthetic-live-verify logs before the next deploy.
 
+          - alert: HermesGovernedRuntimeDown
+            expr: |
+              absent(up{job="hermes-governed-runtime"})
+                or up{job="hermes-governed-runtime"} == 0
+            for: 2m
+            labels:
+              severity: critical
+              service: hermes
+            annotations:
+              summary: Hermes governed runtime is unreachable
+              description: Prometheus cannot scrape the Hermes governed runtime on the nyc3 private endpoint.
+
+          - alert: HermesGovernedRuntimeNotReady
+            expr: |
+              absent(hermes_governed_runtime_ready{job="hermes-governed-runtime"})
+                or hermes_governed_runtime_ready{job="hermes-governed-runtime"} == 0
+            for: 2m
+            labels:
+              severity: critical
+              service: hermes
+            annotations:
+              summary: Hermes governed runtime readiness failed
+              description: The Hermes runtime exporter is reachable, but the governed profile, provenance, operations, or observed runtime gate is not ready.
+
+          - alert: HermesGovernedRuntimeCheckFailed
+            expr: hermes_governed_runtime_check_ok{job="hermes-governed-runtime"} == 0
+            for: 2m
+            labels:
+              severity: critical
+              service: hermes
+            annotations:
+              summary: Hermes governed runtime check failed
+              description: One of the Hermes governed-runtime checks is failing; inspect the check label and runtime evidence before continuing cutover.
+
           - alert: GrafanaDown
             expr: sum(up{job="grafana"}) == 0
             for: 5m

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -21,11 +21,22 @@ monitoring:
       - ingress-nginx
       - splattop-bot-agent-8s
       - splattop-bot-agent-8s-dev
+      extraEgress:
+      - cidr: 10.108.0.8/32
+        ports: [8080]
   cilium:
     prometheusEgressKubeAPI:
       enabled: true
   prometheus:
     enabled: true
+    staticScrapeConfigs:
+    - jobName: hermes-governed-runtime
+      metricsPath: /metrics
+      targets:
+      - 10.108.0.8:8080
+      labels:
+        service: hermes
+        deployment: hermes-mandate-edge-nyc3-01
     rules:
       enabled: true
     service:

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -34,6 +34,7 @@ monitoring:
       - monitoring
       - default
       - ingress-nginx
+      extraEgress: []
     alertmanager:
       enabled: true
       outboundCIDR: 0.0.0.0/0
@@ -61,6 +62,7 @@ monitoring:
           targetPort: http
     configMapName: prometheus-config
     retention: 15d
+    staticScrapeConfigs: []
     persistence:
       enabled: true
       accessMode: ReadWriteOnce


### PR DESCRIPTION
## Summary

Adds Prometheus monitoring and alerts for the CES-251 Hermes governed runtime on the nyc3 private endpoint.

## What changed

- Adds a reusable `monitoring.prometheus.staticScrapeConfigs` values surface.
- Adds a reusable Prometheus NetworkPolicy `extraEgress` surface.
- Configures production Prometheus to scrape `10.108.0.8:8080` as `hermes-governed-runtime`.
- Allows Prometheus egress only to `10.108.0.8/32` on TCP 8080 for the Hermes target.
- Adds alerts for Hermes scrape down, readiness failure, and individual governed-runtime check failure.

## Validation

- `helm lint /root/dev/garzaicluster-ces251/helm/garz-observability`
- `python3 /root/dev/garzaicluster-ces251/scripts/validate_prometheus_config.py --chart-dir /root/dev/garzaicluster-ces251/helm/garz-observability -f /root/dev/garzaicluster-ces251/helm/garz-observability/values-prod.yaml --label ces-251-hermes`
- `kubeconform -schema-location default -skip CiliumNetworkPolicy,Certificate -strict -summary -exit-on-error /tmp/garz-observability-default.yaml /tmp/garz-observability-prod.yaml`