### PR TITLE
[codex] Wire Hermes mctx secret into control plane

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -45,6 +45,10 @@ Required before activation:
   with the public control API URL, the matching trusted-edge/OpenClaw service
   token, and the shared `AGENT_PLATFORM_MCP_TRUSTED_CONTEXT_HMAC_SECRET` used
   to sign per-turn `mctx_v2` assertions.
+- Hermes uses a separate `agent-control-plane-hermes-mctx` Secret mounted only
+  into the API pod through `apiExtraSecretRefs`, so Discord ingress does not
+  share OpenClaw's trusted-context HMAC key or expose the Hermes key to worker,
+  callback, or model-gateway pods.
 - The callback adapter deployment uses the same Postgres state as the API and
   worker, claims delivery by event id, and posts safe terminal output to the
   OpenClaw droplet's `/mandate-edge/openclaw-callback` plugin route. The

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-22e8e023a614
+  tag: sha-33546e5db1b0
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -37,6 +37,11 @@ secretKeys:
   - AGENT_PLATFORM_MODEL_GATEWAY_CODEX_AUTH_JSON
   - AGENT_PLATFORM_WORKLOAD_IDENTITY_HMAC_SECRET
   - AGENT_PLATFORM_MCP_TRUSTED_CONTEXT_HMAC_SECRET
+
+apiExtraSecretRefs:
+  - secretName: agent-control-plane-hermes-mctx
+    keys:
+      - AGENT_PLATFORM_MCP_TRUSTED_CONTEXT_HMAC_SECONDARY_SECRET
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 22e8e023a614bbd38dec31644875cae984045556
+      targetRevision: 33546e5db1b02b00115663546f828b47c498f70b
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-22e8e023a614` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-33546e5db1b0` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-22e8e023a614
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-33546e5db1b0
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/secrets/agent-control-plane/hermes-mctx-secret.enc.yaml
+++ b/secrets/agent-control-plane/hermes-mctx-secret.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: agent-control-plane-hermes-mctx
+    namespace: agent-control-plane
+type: Opaque
+stringData:
+    AGENT_PLATFORM_MCP_TRUSTED_CONTEXT_HMAC_SECONDARY_SECRET: ENC[AES256_GCM,data:qoeuP8EfxEmHcd380A2TW//c6tpAhaLymQdGOh0iNACvIILbQE1abLk94GJjzDjWKpzJsqvzbgn/lIq89JjkAQ==,iv:57ggkWryEiS6AuJ7SC+iplcNz3KMmpGnWp0flIJHCyI=,tag:yrVbW+e8x1atnVzdZdum2A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdzhMbUxTMDNZSDJ1NVFj
+            dDNkTG5pMVFGV041K0wraCtzTnc3UUk2cXlBCnNFdElwaFFNVzdOTXhtWDNmSVBQ
+            UWtxZGRCZERkOFJMZHNDTUdjT05salUKLS0tIHJoY1VkY3NZeXRnVDdLNDJFOCsy
+            d2FvUTJWOGc2ZHJQQTZDcFBYRS9URnMKMP5i5JpNcaHuXthWSoQneDXlzLrXakOS
+            XJu30JD1gljLXpUVIP/9vHApOau6C2edAlbapDBNNQNKXR61ZOI9sw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-05T08:25:42Z"
+    mac: ENC[AES256_GCM,data:BPK+HzWsuiClbK1iERgW4PAPZUIJfbZBgG5IJLciZf8hc2VyHxeQUl+mJLfLthBe3aVO0npHeFqQbXq8iUGwIfen9uEuS/7JP8z3/4lyepH2be1EC7VLnL863opzl66VsFb4T5aY2AcIfOGP0qmCBKCVwjuxwPQWAE0a+9ExBCo=,iv:izcXrpCHCYTKrhpgz+B60Z18RwkOl5gF+N9KyTQNMw4=,tag:vE/epYSSu00AGCDlBJYPKg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/agent-control-plane/ksops.yaml
+++ b/secrets/agent-control-plane/ksops.yaml
@@ -4,4 +4,5 @@ metadata:
   name: agent-control-plane-secrets
 files:
   - runtime-secret.enc.yaml
+  - hermes-mctx-secret.enc.yaml
   - regcred.enc.yaml


### PR DESCRIPTION
## Summary
- Pin `agent-control-plane` to merged `agent-platform` commit `33546e5db1b02b00115663546f828b47c498f70b` and image tag `sha-33546e5db1b0`.
- Add a separate SOPS-managed `agent-control-plane-hermes-mctx` Secret for Hermes trusted-context HMAC verification.
- Mount the Hermes mctx key only into the API pod through `apiExtraSecretRefs`.
- Document that Hermes does not share OpenClaw's mctx HMAC key and update the Postgres restore runbook image reference.

## Image
- `registry.digitalocean.com/sendouq/agent-platform:sha-33546e5db1b0`
- Manifest digest: `sha256:c5015e3337a909c42decba62e29d099afd7ec82bffe2401e3a2c9c64e76ae12e`

## Validation
- `helm template agent-control-plane /root/dev/agent-platform-ces251-mctx-secondary/helm/mandate -f apps/agent-control-plane/values.yaml`
- Parsed Helm render check: `AGENT_PLATFORM_MCP_TRUSTED_CONTEXT_HMAC_SECONDARY_SECRET` appears only on `Deployment/agent-control-plane`
- `env UV_CACHE_DIR=/root/dev/.uv-cache uv run --with pytest python -m pytest` (89 passed)
- `doctl registry repository list-tags agent-platform --format Tag,UpdatedAt,ManifestDigest` verified the published tag and digest