### PR TITLE
[codex] Suspend control-plane postgres sweep

### DIFF
--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -61,6 +61,10 @@ Required before activation:
   `agent-control-plane-model-gateway-controls` as a directory so operator edits
   project without pod restarts. See
   [model-gateway controls](../../docs/model-gateway-controls.md).
+- `postgresSweep.enabled=false` while the current
+  `db-postgresql-nyc3-xscraper` `db-amd-1vcpu-2gb` plan is connection-slot
+  saturated by the live control-plane services. Re-enable it only after the
+  database connection budget is raised or the service pool footprint is reduced.
 - `syntheticLiveVerify.enabled=true` runs the scheduled deployment smoke and
   readonly-query probes every five minutes through the trusted-edge `/v1/tasks`
   path with signed `mctx_v2` assertions. The dedicated

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -249,7 +249,7 @@ extraVolumeMounts:
     readOnly: true
 
 postgresSweep:
-  enabled: true
+  enabled: false
 
 syntheticLiveVerify:
   enabled: true


### PR DESCRIPTION
## Summary
- Disable the `agent-control-plane-postgres-sweep` CronJob while the current `db-postgresql-nyc3-xscraper` `db-amd-1vcpu-2gb` plan is connection-slot saturated.
- Document that the sweep should be re-enabled after the database connection budget is raised or service pool footprint is reduced.
- Leave `syntheticLiveVerify` enabled; the latest scheduled synthetic verify succeeded after the Hermes/control-plane rollout.

## Validation
- `env UV_CACHE_DIR=/root/dev/.uv-cache uv run --with pytest python -m pytest` (89 passed)
- `helm template agent-control-plane /root/dev/agent-platform-ces251-mctx-secondary/helm/mandate -f apps/agent-control-plane/values.yaml` with parsed check: `postgres_sweep_rendered=false`