### PR TITLE
Point control-plane policy binding at Hermes canary

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -12,8 +12,8 @@ bindings:
   - id: private-admin-controlled-capabilities
     description: Production-safe private admin binding for no-key probes,
       bounded read-only SQL, and the first imported worker-service probe.
-    guild_id: "614277943706910722"
-    channel_id: "1480483954694819940"
+    guild_id: "1523242748822425750"
+    channel_id: "1523242750043226234"
     users:
       admins:
         - "94265880216612864"

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-33546e5db1b0
+  tag: sha-4ab0be09c386
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 33546e5db1b02b00115663546f828b47c498f70b
+      targetRevision: 4ab0be09c386ce1ffca0835290aa80d03c1b1f89
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-33546e5db1b0` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-4ab0be09c386` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-33546e5db1b0
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-4ab0be09c386
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -387,8 +387,8 @@ data:
       - id: private-admin-controlled-capabilities
         description: Production-safe private admin binding for no-key probes,
           bounded read-only SQL, and the first imported worker-service probe.
-        guild_id: "614277943706910722"
-        channel_id: "1480483954694819940"
+        guild_id: "1523242748822425750"
+        channel_id: "1523242750043226234"
         users:
           admins:
             - "94265880216612864"


### PR DESCRIPTION
## Summary

- Updates the agent-control-plane registry overlay production binding from the old OpenClaw guild/channel to the Hermes nyc3 canary guild/channel verified during CES-400.
- Pins the agent-control-plane Argo source to agent-platform `4ab0be09c386ce1ffca0835290aa80d03c1b1f89` and image tag `sha-4ab0be09c386` published from PR #264.
- Updates the rendered configmap golden fixture and the Postgres restore runbook image reference.

## Validation

- `uv run python scripts/check_control_plane_release_pin.py`
- `uv run python -m unittest tests.test_agent_control_plane_registry_overlay`
- `uv run python -m unittest discover -s tests` (`89 tests`)
- `git diff --check`
- GitHub CI is green on head `7201703`, including `agent-control-plane-registry-overlay-render`, `python-contracts`, `agent-control-plane-deployed-registry-compat`, `agent-control-plane-provider-digest-pins`, identity drift, no-latest, helm/kubeconform, and prometheus-rules checks.

## Rollout note

This PR is the GitOps rollout half for CES-401. Once merged, Argo will roll the control plane to the CES-401 runtime and apply the Hermes canary policy surface binding. Live acceptance should verify wrong-surface denial and intended canary admission.

Related: CES-401. Depends on merged agent-platform PR: https://github.com/cesaregarza/agent-platform/pull/264.
