### PR TITLE
[codex] Point control plane at neutral surface policy

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -12,8 +12,9 @@ bindings:
   - id: private-admin-controlled-capabilities
     description: Production-safe private admin binding for no-key probes,
       bounded read-only SQL, and the first imported worker-service probe.
-    guild_id: "1523242748822425750"
-    channel_id: "1523242750043226234"
+    surface_identifiers:
+      guild_id: "1523242748822425750"
+      channel_id: "1523242750043226234"
     users:
       admins:
         - "94265880216612864"

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-4ab0be09c386
+  tag: sha-82ee6ec1c65b
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 4ab0be09c386ce1ffca0835290aa80d03c1b1f89
+      targetRevision: 82ee6ec1c65bdd43e06297784c613cd1f18b33e3
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-4ab0be09c386` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-82ee6ec1c65b` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-4ab0be09c386
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-82ee6ec1c65b
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -387,8 +387,9 @@ data:
       - id: private-admin-controlled-capabilities
         description: Production-safe private admin binding for no-key probes,
           bounded read-only SQL, and the first imported worker-service probe.
-        guild_id: "1523242748822425750"
-        channel_id: "1523242750043226234"
+        surface_identifiers:
+          guild_id: "1523242748822425750"
+          channel_id: "1523242750043226234"
         users:
           admins:
             - "94265880216612864"

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -482,6 +482,13 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         synthetic_binding = bindings_by_id["synthetic-live-verify-probe"]
 
         self.assertEqual(
+            binding["surface_identifiers"],
+            {
+                "guild_id": "1523242748822425750",
+                "channel_id": "1523242750043226234",
+            },
+        )
+        self.assertEqual(
             synthetic_binding["users"]["authorized"],
             ["mandate-live-probe"],
         )


### PR DESCRIPTION
## Summary
- Pin agent-control-plane to merged agent-platform CES-402 revision `82ee6ec1c65bdd43e06297784c613cd1f18b33e3` and image `sha-82ee6ec1c65b`.
- Migrate the production registry overlay binding to generic `surface_identifiers` while preserving the Hermes canary guild/channel as policy data.
- Update the rendered ConfigMap golden, overlay assertion, and restore runbook image references.

## Authority Invariants Preserved
- The private admin binding still scopes to Hermes canary guild `1523242748822425750` and channel `1523242750043226234`.
- The control-plane image and Argo target revision are pinned to the same agent-platform merge commit.

## Tests
- `uv run python scripts/check_control_plane_release_pin.py` -> passed.
- `uv run python -m unittest tests.test_agent_control_plane_registry_overlay` -> 15 passed.
- `uv run python -m unittest discover -s tests` -> 89 passed.
- `kubectl kustomize apps/agent-control-plane-registry-overlay` renders `surface_identifiers` with the canary guild/channel.
- `uv run --with /root/dev/.worktrees/agent-platform-ces402-merge python scripts/check_agent_control_plane_registry_compat.py --agent-platform-repo /root/dev/.worktrees/agent-platform-ces402-merge` -> compatible with agent-platform `82ee6ec1c65bdd43e06297784c613cd1f18b33e3` for prod.
- `git diff --check` -> passed.

## Docs
- Updated `docs/runbooks/postgres-restore.md` to the new image tag.

## Deferred
- Live Argo sync and CES-401/CES-402 acceptance rerun after this PR is green and merged.

## Security Review Notes
- This is the deployment half of CES-402: adapter-specific identifier names remain data in the deployment-owned policy overlay, not neutral-core code.

## Adversarial Self-Review
- The overlay is not backward-compatible with the old control-plane image, which is intentional. This PR pins the new agent-platform revision and overlay schema together.