### PR TITLE
CES-403: Pin control plane denial-audit image

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-82ee6ec1c65b
+  tag: sha-f1bbc2acc7a4
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 82ee6ec1c65bdd43e06297784c613cd1f18b33e3
+      targetRevision: f1bbc2acc7a49f9fa0a4682a39c1c9fa78ed278e
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-82ee6ec1c65b` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-f1bbc2acc7a4` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-82ee6ec1c65b
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-f1bbc2acc7a4
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Summary
- Pin agent-control-plane chart source to agent-platform merge commit f1bbc2acc7a49f9fa0a4682a39c1c9fa78ed278e.
- Pin runtime image to registry.digitalocean.com/sendouq/agent-platform:sha-f1bbc2acc7a4.
- Update the Postgres restore runbook's current image reference.

## Verification
- env UV_CACHE_DIR=/root/dev/GarzAICluster-ces403-denial-audit/.uv-cache uv --directory /root/dev/GarzAICluster-ces403-denial-audit run python scripts/check_control_plane_release_pin.py
- env UV_CACHE_DIR=/root/dev/GarzAICluster-ces403-denial-audit/.uv-cache uv --directory /root/dev/GarzAICluster-ces403-denial-audit run python -m unittest tests.test_agent_control_plane_registry_overlay
- env UV_CACHE_DIR=/root/dev/GarzAICluster-ces403-denial-audit/.uv-cache uv --directory /root/dev/GarzAICluster-ces403-denial-audit run python -m unittest discover -s tests
- env UV_CACHE_DIR=/root/dev/GarzAICluster-ces403-denial-audit/.uv-cache uv --directory /root/dev/GarzAICluster-ces403-denial-audit run --with /root/dev/.worktrees/agent-platform-ces403-merge python scripts/check_agent_control_plane_registry_compat.py --agent-platform-repo /root/dev/.worktrees/agent-platform-ces403-merge
- kubectl kustomize /root/dev/GarzAICluster-ces403-denial-audit/apps/agent-control-plane-registry-overlay