### PR TITLE
fix: route Citrus email through Google SMTP relay

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -28,6 +28,11 @@ application:
     HELP_EMAIL: "help@citrus-grace.com"
     ORDERS_EMAIL: "orders@citrus-grace.com"
     BUSINESS_TIME_ZONE: "America/Chicago"
+    EMAIL_HOST: "smtp-relay.gmail.com"
+    EMAIL_PORT: "587"
+    EMAIL_USE_TLS: "True"
+    EMAIL_USE_AUTH: "False"
+    EMAIL_TIMEOUT: "10"
 
 
 service:


### PR DESCRIPTION
## Summary
- configure Citrus with smtp-relay.gmail.com on port 587
- set EMAIL_USE_AUTH=False so the app uses IP-allowlisted Google Workspace SMTP relay and ignores stale Gmail credentials
- keep sender addresses unchanged for citrus-grace.com

## Validation
- helm lint helm/citrus -f helm/citrus/values.yaml
- helm template citrus helm/citrus -f helm/citrus/values.yaml
- rendered ConfigMap includes EMAIL_HOST, EMAIL_PORT, EMAIL_USE_TLS, EMAIL_USE_AUTH, and EMAIL_TIMEOUT