### PR TITLE
fix: set Citrus site name

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -22,6 +22,7 @@ application:
     gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
   configData:
     DJANGO_DEBUG: "False"
+    SITE_NAME: "Citrus Grace"
     ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
     DEFAULT_FROM_EMAIL: "orders@citrus-grace.com"
     MEDIA_EMAIL: "media@citrus-grace.com"


### PR DESCRIPTION
## Summary
- Set the Citrus Helm ConfigMap SITE_NAME to "Citrus Grace" so account emails render the correct brand in dev/prod.

## Verification
- helm template citrus /tmp/garzaicluster-citrus-site-name/helm/citrus
- git diff --check