### PR TITLE
fix: wire Citrus to Postgres

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -23,6 +23,7 @@ application:
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace"
+    DB_SCHEMA: "citrus"
     ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
     DEFAULT_FROM_EMAIL: "orders@citrus-grace.com"
     MEDIA_EMAIL: "media@citrus-grace.com"

--- a/secrets/citrus/README.md
+++ b/secrets/citrus/README.md
@@ -2,6 +2,7 @@
 
 Encrypted runtime secrets consumed by the `citrus-secrets` Argo CD app.
 
-- `django-secrets.enc.yaml`: Django and Stripe runtime environment for the Citrus Helm release.
+- `django-secrets.enc.yaml`: Django, Stripe, and Postgres runtime environment for the Citrus Helm release.
+- `django-email-secrets.enc.yaml`: SMTP and contact-address runtime environment for the Citrus Helm release.
 
 Regenerate from `/root/dev/Citrus/.env` with the repo SOPS age key. Commit only encrypted `.enc.yaml` files.

--- a/secrets/citrus/django-secrets.enc.yaml
+++ b/secrets/citrus/django-secrets.enc.yaml
@@ -5,12 +5,17 @@ metadata:
     namespace: default
 type: Opaque
 stringData:
-    STRIPE_PUBLIC_KEY: ENC[AES256_GCM,data:9nkkf+RBca9eY+4gmijgJDgE2Uz69VCe8HLY4CH0DCLBuS7XaypgNSJfidHkKACLictl771Cp7EC8biTwI9EtoKth9cz5dlj0VK8YTQxqZ+WrYHuJyvgzcEvBxNl+Ghd5GMaIZJLiRH4hMw=,iv:cM5GUqeETtH6fB6f5/LO5SjHn3kdJbCgUw0sTLDwFCo=,tag:9nIym7wGU/MFmSxy69kFww==,type:str]
-    STRIPE_PUBLISHABLE_KEY: ENC[AES256_GCM,data:/3ebZWNbYVKF64ztFLq2J7vl/qjaENkq8Yx4O+wwaFc4PA4Zt37mcqL3YSSTYI9lmbOiYBR6WgWS7v0EKdfncHVXyTk506XBhz+WGdkvLtRgQDOWPq8dkgoncQKpiMyp2uW9l0jIOFbKswQ=,iv:er4XBZIGY4aW62zvl8GOUSzIwaYGg+p1FW1kTucul4s=,tag:p+TKjZ7l69QvwWQt6RKtiQ==,type:str]
-    STRIPE_SECRET_KEY: ENC[AES256_GCM,data:xHtIYVy5oV7JnQZ6NayOK41QWUrEX8uO0upqC2C+fOtIaAtRm8wLpIAAlqg6HGvR8iNVOQJ0f3UdO9zLaBTbHyvPRY4wRZKiq3pw992sFevUBht+npdlxSrLOiJC0FvOEi4Ex8TYo8VdHMI=,iv:jWqSVDiB7Euyuu8VldUF6tbkjaQa/XrHAGTqoC8ZA+M=,tag:ETIukBQX6nVKH7FOriSK6g==,type:str]
-    STRIPE_WEBHOOK_SECRET: ENC[AES256_GCM,data:MlGEXYy7s/csiYhNWjFqNP6UXCqNCKxEXGO2mQcOxQkjQfIflUw=,iv:i2PUk7MiaD4pI0I+D3ZHsuYIesnOgVYOj/pLy8llBxo=,tag:WmMRbqfzWXWmvi0382IPQg==,type:str]
-    STRIPE_WEBHOOK_SECRET_DEV: ENC[AES256_GCM,data:X1tiXKQEXw7kmZD5L+mfJ6OYbQeLS79WCEDWqM/QE+iYOeezhw4=,iv:P7Fs5hGEI0D9xCIMgmxMc/rbh7PUEFyVeFGtojKvZ28=,tag:Qt9XePTEKGk7hmpUo0n82Q==,type:str]
-    STRIPE_WEBHOOK_SECRET_PROD: ENC[AES256_GCM,data:GkirzmsJFo6Hy0hzkIGcSzD70TTLH3oHYvJuOrZkCYb8Q8ZK570=,iv:uPpDsPZrq8fv0JrpP3ZF6/bf8B3DIlDoYo6oNbGD890=,tag:TI/fJsuY8oXj0FDonE9RYA==,type:str]
+    STRIPE_PUBLIC_KEY: ENC[AES256_GCM,data:v8xURlM/jQ1ZgnnV/WHAv/ncw7RFgA9mbuD1yRlPU0YXqDNRKWOd6pG2Ybgi/fK9DKGpKNArOf4XFxxdRLDNUrSwFS8EkbFS5Kanja9J7VXk0GDSTMgAwFtUgSut+XfHrSLqv2Fj8Pm7QwM=,iv:tiU2sPJAGmyHY6m12ggrP29sUWPaJr+ArllAC/bdwJk=,tag:1VrdR7AhTu3kVFvRyq1CFA==,type:str]
+    STRIPE_PUBLISHABLE_KEY: ENC[AES256_GCM,data:6Lz9As5Ox/t/ggfmSICtgZz4pZ20IrMH+G0I65DwXNpzwDhkKzb4dhpnDU3sy3yngXFxUGYj6oqI4mtoQny0aF4iw3dKaEErDKelv/IDkr2Lf2mlALeRzWXnWuBk3UuhiCqCobDxYthLwaw=,iv:OPt5V3qMoBCNP1ne8dnx6euzHqq8MUCBue65jOfSMBQ=,tag:8DLRoJFAm+IB9EDj//lHHg==,type:str]
+    STRIPE_SECRET_KEY: ENC[AES256_GCM,data:RA8imAuvX4n2Z2aE43Xy2supNvNAx635cFwqjFwFAwtYxZxSGa1qB9Hy7CGdtYehV+5dGyoclykSawMT81GP74qBsScZmT4Wrxo8QQDhsO3qeReuYlYC3tkLHvPogclUn23/+WMNLmg0A7Q=,iv:gDV6BS+1F0EcyyX9G6mDB3aoekQz89FmTg158I6BfTg=,tag:g60U5dglK92LeKM5oX/Yqw==,type:str]
+    STRIPE_WEBHOOK_SECRET: ENC[AES256_GCM,data:wvHSoRYoa5meNl7gFE9A6gVh2zO3h+I8wZEC31AOldB5SPQ86RI=,iv:ahi0jEad4vBHLC20T/8eOfr+gswt9bGhi7u9mLfPRo0=,tag:1nN78Wb/E/JCQ6+xcgtrGQ==,type:str]
+    STRIPE_WEBHOOK_SECRET_DEV: ENC[AES256_GCM,data:AiW2GSML3gR0d2l6+JjI4HLsewI+Pg4KmwJsUwl8YdBAAVp07VI=,iv:sJSRkazXv4sfY6VVczwLmoWX2RTOZhk+wAaZsNghRWA=,tag:eKQf13wmeJlMVbGpxkOvBQ==,type:str]
+    STRIPE_WEBHOOK_SECRET_PROD: ENC[AES256_GCM,data:PnaJZDSOr6uEYC8i4EBcIrcO+gRx764/4k0FMf/W2kxd0FKIVyo=,iv:4HyYv/hXA+GnzFLLiLI664QFQbHFURJkjz5vlck/hHM=,tag:Pduu1OJ7W1A1psZ4O55h+A==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:G67KquYlJ9F8Wtoc+AbnTijvbt4YA2s+ereE70AXFChdenTJtxlyw0Bam1HnuWxWJh2/4PVJ69CsFBE4qlc71Xmdktuh7P5S1YaNQovu,iv:RXVHrkqSh1XHc0jQufaGn3BQ1E79D26k+AjpxZZ8qWg=,tag:7gbgTN6wbFRzZYFESPwWFw==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:yjryngk=,iv:7ZiaOsXF7JT+r/mDPntLh3gM1y0aRsta2FnbLTR5oWQ=,tag:X9yWsOdx4KepTmMgzBOR1w==,type:str]
+    DB_NAME: ENC[AES256_GCM,data:Z4bf6Jdc,iv:25HXBctZnojWBPkfx571SZ3cO4GvjfS0+6Xm4IDF5aQ=,tag:kaP0Rr3XoIbgb7ssBwO7Zg==,type:str]
+    DB_USER: ENC[AES256_GCM,data:eB0yLQFb3eQjcoU=,iv:Jtkn0b8E+7NqcXje0ilo6HfnmernTGqZ531rZhHi7mw=,tag:rvISWymKIoCzHioHWNDASA==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:bijEsopBiV628lziJICF8dCiKdeon+dmG7KQaZw57UmIMiqQPAz7kQ==,iv:YnPb40hBd6HPT6MEAgmwzLVFQua4HIxjU9GQcmRr5g4=,tag:4H+w67SxGKYpQNjxMMjvHQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,14 +25,14 @@ sops:
         - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaWkZrNncxLzRMT2ErTnRJ
-            T3VHSGt1aktSTTZCeW5QbEJuVjMzNnFFZno4Cm5uejBNVUxYMW4xUGJtb1Z4Ymo0
-            c29rckxYaitiemlFcHFESXZSRXhDZE0KLS0tIDBmRzJjQXo3Mks3UUhlZk11NExq
-            K3RoZU45blpDaWQ5RFZiSzMyTHI5Qk0KDnbJZlDx+CsRNWp/tIAG7HvbKiKYjRlo
-            Bf6cHTb07Vr3NveKFUoGL9eF9amRH070A3PQZwvpn5dmTSj0npy2cg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXQWMya2NMaUdSWDc0WERy
+            aEZOQVhHbGFBcXh3VjFIZkJ3WTR4SU9hNFRFCi82dHZvVWtjcXpPWmxMbVNmdzZW
+            clJoZ1NnaTUxOVZlTmRYbkM2RnhOZVkKLS0tIHdpYXFxMnh3WlZpWi9lOUJWMSs5
+            UkRFV2VTZVM1NGZsenMzdnVwQStqOW8K4TxcBhJZCZ/gEHII0a/OEYSPeRLtKtLb
+            7vPSWcvKOwcksiJ/fQd4OAVImYWxmkgwA2IRXKc2RRUc/Y2FMmUt8w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-17T03:39:53Z"
-    mac: ENC[AES256_GCM,data:SXBh/zcp85mG5r3LEdOdfoUYDkPkhoy8D/fS4gZG3boILN38C9NfLpBwVqHOY4LjWKYwKZ/ZbtEmpB8VVO0hcKT3tyAIX3exo+Z0esDNDk+KJEE7BMcXiV8c5lh+Is/tW6duSFJTrbqVfi4/sSaaq9dqNHuXXzaWun7wrpg151Q=,iv:MP331nvxUFx0BHw/N8KgyMhrAxl7xI0SRAbkfzY/4ew=,tag:KdWRgt4W8K2HQHRFRcF6jA==,type:str]
+    lastmodified: "2026-07-06T22:37:21Z"
+    mac: ENC[AES256_GCM,data:7Y0Mw6dA1MNDYcL4LtCh5YJ8ExXhRfh/TCjsGwEyzQPdJof0qnPUK5KWsFeavpcfaWLot0uMA16nl451DicpIcIPtZ+zdhlzXXnfp69cSopVfKC4cKDaKfgICZ7r+H/cGoM9kE+t3HrK/m6uvAAPgyv32wqPSjHahcLGweYuUrU=,iv:XzQtZZmV/cu/oo/LmjcjgIS/r+r97meWiMKzdV/2PfQ=,tag:/c9cv46lpNcE0wfBtfH8eQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
## Summary
- Add DB_SCHEMA=citrus to the Citrus Helm config.
- Add Postgres DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD to the encrypted Citrus django-secrets manifest.
- Document the Citrus Postgres secret fields.

## Provisioning
- Created/refreshed database: citrus
- Created/refreshed schema: citrus
- Created/refreshed role: citrus_user
- Verified an in-cluster psql smoke test uses current_schema() = citrus.

## Verification
- SOPS decrypt key-list check for django-secrets.enc.yaml
- helm template citrus /tmp/garzaicluster-citrus-postgres/helm/citrus
- git diff --check
- in-cluster psql smoke test as citrus_user