### PR TITLE
[codex] Add Citrus dev environment

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -22,6 +22,9 @@ creation_rules:
   - path_regex: ^secrets/citrus/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+  - path_regex: ^secrets/citrus-dev/.*\.enc\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
   - path_regex: ^secrets/spotify-hot-100/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt

--- a/argocd/applications/citrus-dev-secrets.yaml
+++ b/argocd/applications/citrus-dev-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citrus-dev-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/GarzAICluster
+    targetRevision: main
+    path: secrets/citrus-dev
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: citrus-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/argocd/applications/citrus-dev.yaml
+++ b/argocd/applications/citrus-dev.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: citrus-dev
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/GarzAICluster
+    targetRevision: main
+    path: helm/citrus
+    helm:
+      releaseName: citrus-dev
+      valueFiles:
+        - values.yaml
+        - values-dev.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: citrus-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/argocd/projects/splattop-project.yaml
+++ b/argocd/projects/splattop-project.yaml
@@ -18,6 +18,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: citrus
       server: https://kubernetes.default.svc
+    - namespace: citrus-dev
+      server: https://kubernetes.default.svc
     - namespace: splatvote-prod
       server: https://kubernetes.default.svc
     - namespace: monitoring

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,0 +1,27 @@
+image:
+  tag: ba37ac601385a8af4c2e445fa1062d17955426c9 # allow-latest
+
+application:
+  configData:
+    DJANGO_DEBUG: "False"
+    SITE_NAME: "Citrus Grace Dev"
+    DB_SCHEMA: "citrus"
+    ALLOWED_HOSTS: "dev.citrus-grace.com"
+    CSRF_TRUSTED_ORIGINS: "https://dev.citrus-grace.com"
+    DEFAULT_FROM_EMAIL: "orders@citrus-grace.com"
+    MEDIA_EMAIL: "media@citrus-grace.com"
+    HELP_EMAIL: "help@citrus-grace.com"
+    ORDERS_EMAIL: "orders@citrus-grace.com"
+    BUSINESS_TIME_ZONE: "America/Chicago"
+    EMAIL_HOST: "smtp-relay.gmail.com"
+    EMAIL_PORT: "587"
+    EMAIL_USE_TLS: "True"
+    EMAIL_USE_AUTH: "False"
+    EMAIL_TIMEOUT: "10"
+
+ingress:
+  hosts:
+    - dev.citrus-grace.com
+  tls:
+    enabled: true
+    secretName: citrus-dev-grace-tls

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -24,7 +24,8 @@ application:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace"
     DB_SCHEMA: "citrus"
-    ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com,dev.citrus-grace.com"
+    ALLOWED_HOSTS: "citrus-grace.com,www.citrus-grace.com"
+    CSRF_TRUSTED_ORIGINS: "https://citrus-grace.com,https://www.citrus-grace.com"
     DEFAULT_FROM_EMAIL: "orders@citrus-grace.com"
     MEDIA_EMAIL: "media@citrus-grace.com"
     HELP_EMAIL: "help@citrus-grace.com"
@@ -65,7 +66,6 @@ ingress:
   hosts:
     - citrus-grace.com
     - www.citrus-grace.com
-    - dev.citrus-grace.com
   tls:
     enabled: true
     secretName: citrus-grace-tls

--- a/secrets/citrus-dev/README.md
+++ b/secrets/citrus-dev/README.md
@@ -1,0 +1,8 @@
+# Citrus Dev Secrets
+
+Encrypted runtime secrets consumed by the `citrus-dev-secrets` Argo CD app.
+
+- `django-secrets.enc.yaml`: Django, Stripe, and Postgres runtime environment for the `citrus-dev` Helm release.
+- `django-email-secrets.enc.yaml`: SMTP and contact-address runtime environment for the `citrus-dev` Helm release.
+
+Commit only encrypted `.enc.yaml` files.

--- a/secrets/citrus-dev/django-email-secrets.enc.yaml
+++ b/secrets/citrus-dev/django-email-secrets.enc.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-email-secrets
+    namespace: citrus-dev
+type: Opaque
+stringData:
+    ADMIN_EMAIL: ENC[AES256_GCM,data:VB+mhny5wQSE2v7VbBeYzMfa6pVd,iv:Jz/lcqsZxvBtp0ywOIlsdsI0Tp99R++5vn2kxv77VnM=,tag:dTNmZg3rj2ZU/xVj5+26sA==,type:str]
+    BUSINESS_TIME_ZONE: ENC[AES256_GCM,data:WtnzBiFpP+ML3SPlWEUA,iv:mdlfoGs2T1olzowIcDpryGktZAMcBofZCDEJfyEHiNg=,tag:+87xJvK1Y7+FUVLhL2pZhA==,type:str]
+    DEFAULT_FROM_EMAIL: ENC[AES256_GCM,data:AJ03VU7Wbvg7RVOYt7lge7o5FzuQF2E=,iv:3Via1tnFfNoZfO09aEpa/yQc1b3VcbNpKeImkylVDLU=,tag:FfUfvdykC7UU3Yf9/8UU5g==,type:str]
+    EMAIL_HOST_PASSWORD: ENC[AES256_GCM,data:NA41FB9vtoyxncOUDP0JBw==,iv:gpJNuvfcGc5Sjzc57AoedigZ95E+cHyvDlRTf9lngvA=,tag:jBPVF8AXXPmVms1cLk2DJQ==,type:str]
+    EMAIL_HOST_USER: ENC[AES256_GCM,data:+AV8IMBflhm2wPEdatldRCa6HDi+eiw=,iv:JEVPM4F1OKp+o35mR0LiLYIiQTE9hIuIIirQJRkML6c=,tag:fkgVzZYrjYL5fAeCHqfQEA==,type:str]
+    HELP_EMAIL: ENC[AES256_GCM,data:qzkAMkj+yEv3UcW7MTEdVF5PeI4W,iv:JdS4ao+lefux5gD3SIkEYSJLcGlTFFM0F0ttKQ1yt5I=,tag:TjEZyhAwrjSv5tr9z///Pg==,type:str]
+    MEDIA_EMAIL: ENC[AES256_GCM,data:+NQugVGj0cQDZb4lldTJ1pNoh3OH+A==,iv:Fnc/S+qXYzzRilOwN/POld1X3gBG8iVvVW0HVNwdXdU=,tag:EA69qrWs7OJ2Sc/VIclN4w==,type:str]
+    ORDERS_EMAIL: ENC[AES256_GCM,data:91kdfrvFE+XEPt1VEbaD+K8SNiFRB7w=,iv:pbSB2zrQckCy4m7oEx9SIzXYnMUAArjPiPR6U8nKovo=,tag:y1CwB/3GP+2n+poqK92Obw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1TUFVVEZ2UjVnOFVBRTRo
+            NTlKL0xlblhNTlcxUlhYTmdrSWRudkwvTGlZCnhKOUFrWmNXem9ac3NNOGxJWURm
+            YWl3Und2M0ViZ0ErSGtpeHQrNkRCeHcKLS0tIE9lbWxGSEJXWlREem9aUzJqVExX
+            OHgrUEhaaTBScmdIRTkycmt0UktKa0EKRNedgG5i3vIw2iPZ4i5WHa4SYpH5cjz/
+            AMevmK5mrSP27yRgfp2NGcs222PYmopDrpyix2uUxMfbzpdvs3Elhw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-06T23:50:59Z"
+    mac: ENC[AES256_GCM,data:imXvhjDfKT37XNpU6CVH3UcXBwFph/OfJIu3DjBsVIMgg+oxnJtbBH9LboGZA4sJHcPu/XX6afnHJwBkDEiL5IK0zglWPZxPr7q/eQc8EDLh/ex5noslrwUrBgePvEhXyLlc3+FDCAKfFBPuk352eWZhtuY78ud53RyiEW5t+rk=,iv:Wdpq4oV8r/oXgwtK2K6rzJw00PReeSxFuNwWqewF7Hk=,tag:1CVgB/B/K9eUqADnkHCrwA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus-dev/django-secrets.enc.yaml
+++ b/secrets/citrus-dev/django-secrets.enc.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-secrets
+    namespace: citrus-dev
+type: Opaque
+stringData:
+    DJANGO_SECRET_KEY: ENC[AES256_GCM,data:pmUCJ10hwzX7+tX6E4lrZv3G5DAn1NIcT6MJw0L0L3aMIiXTwdQRiV0JoF/L3/n0OptQ4MA2EUUC27ZmUZweWowTA7o0SAZ1t5EIh2ZQfZXlgIQ=,iv:+lJStK0nbjq/BYX65yCpK8TLxgt854883Wca77fZ2hk=,tag:Tw+unNKgNanAYsR+VYZOlg==,type:str]
+    STRIPE_PUBLIC_KEY: ENC[AES256_GCM,data:6Zrfw4jkwl4cLrziCrCSZ83C8vXXM7QYZFDRSpKaSWPcl2XoXHiIo9GCXFLFFKWWXFmfG7iOe350eDhmR+lVyAag842cTTbnONQrjU2fwwuIqpgqDOCRqIZxUzk9FjtQPZjCx9FZaCLy224=,iv:QZ32uIDP5Rlz1IFOeHL84ZaioLOEqNtLpdwMh9+J8aw=,tag:F9n0Z6IzdVYQVpAO9fkkFg==,type:str]
+    STRIPE_PUBLISHABLE_KEY: ENC[AES256_GCM,data:b3O/PI9qKyngZYsJwLaaFQd3wOmedy8KlM/n//4M1A2l0sscVIqRI0wTi98F2JWWuE3at+zxUHSj0E0ucTOeJCeH8GZ/X8kEY2yj5nmnvAIV2sPFW08LyXxsqtARElsuFdLozEXFE5+5J08=,iv:HHoFuR5tVcjsQxfMMNyH5JenScQJCWdzpfsRlvfAwBA=,tag:HyhmWOxiCTK4eoo2ZltM1w==,type:str]
+    STRIPE_SECRET_KEY: ENC[AES256_GCM,data:/jzY89JvriTpb8ry3qut035vIO/nv64cmVypulX0xLkxiJSsQgarWaoIawVSJq0SkBpLB4LT85FWdjzh9m5bM5d+eBN89uqjI4HeWPLOYLBhahsmYC9/PPS9rFDQb+8DnXAKGIxj/MVwycg=,iv:NIThSdimwoXT05V82chV53XFlTaMQ+zGU3eErM/QYKw=,tag:GD7nE+7Hy61ow7aAAQcgnw==,type:str]
+    STRIPE_WEBHOOK_SECRET: ENC[AES256_GCM,data:FRAGI1VwJ3aqZBzkHutE268AO6x98wuhKZT8Sq7GPrqKW/OlMSU=,iv:nyfGOU4m5o/uxejlkjTcO16CTvG4gO3DFuCCWRVRXow=,tag:0BV0iKwXzIk7f0HKxNxlRQ==,type:str]
+    STRIPE_WEBHOOK_SECRET_DEV: ENC[AES256_GCM,data:Ad3eIopcMzUUROvaPPKl5M5YZeTaEpe3CfRgfO+HnGtSVpM3pbI=,iv:QzpbHIPHJxufLZ8/U7DmFMQwpVazLD4ErcclTWRuGG8=,tag:e5QSsxJ9SXURcMeAjELT7w==,type:str]
+    STRIPE_WEBHOOK_SECRET_PROD: ENC[AES256_GCM,data:y2XcAEA8y+zNLJ3AiWZGGtY0owwGt5rGY5rABLAMTGJWNye/i6I=,iv:VuWB8bzqtBkpnw4Jwbb57i8hgLd1tSup21x3xH7qA20=,tag:AaExnuqPCGoAimL4JwWOxA==,type:str]
+    DB_HOST: ENC[AES256_GCM,data:Tfy9flErjkxy+2jthtRNaMcXiiSjXCJgrP/+6KEu3sXMC3FdLvQ4kYBVZ6bKBUftR9ifQjrYUHKYRmPtrSsaJV+Y/dw4yRSbnygMy37e,iv:9hDnStp8ZE3/J0WFxJmm/SiQlO6ogQGX3lf7TIku5WM=,tag:z3bMRHr49YSI+Ea51DH48Q==,type:str]
+    DB_PORT: ENC[AES256_GCM,data:QcFZm0w=,iv:cPJs+qPRFDev4CmpC266lpJVuo8LvHd+LBO9EjEHTqg=,tag:xOYZoBPBJ/svuYRQpQY9Hw==,type:str]
+    DB_NAME: ENC[AES256_GCM,data:QICvuRZNDv1s6Q==,iv:eCxzF+MUU26mUYTpEt3rhcV4zvjJmzRKAvRJcli3Spw=,tag:qoD53MsFdSDdfLiFvKnOhQ==,type:str]
+    DB_USER: ENC[AES256_GCM,data:yiEr0y0NjAJKhNgVU/LM,iv:74m9HNYmKcfmGH7/RUcDwgszUB5Y2ojzMBAaFLyxVmY=,tag:KDXR85l7pJTT10SROPVHuA==,type:str]
+    DB_PASSWORD: ENC[AES256_GCM,data:WcJzgev2qv5qsGLEn1tPAHNnPKdTgW3a,iv:gbPt0+g89qxp30IKQRwve4NNhNnNGnbGwBpaMH7yy54=,tag:3uTPJw6BPdVQ0/4s+dz2Ww==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPdmFNUExSZ0x3eXlobng2
+            MDJvWHV5bm5HVnNUUjZ4b3dLTXlIL3lUWGd3CkduNWVSOU5SbHh4RVB3YVBpdW1n
+            Q2dPZlB3NHdkVjRjNndCZldoUktlSEEKLS0tIHptWUdUZzF5bTNJaVQ0aFloQUNa
+            VzRDTm5PVlRMVlkwdGtjNGJYUmZzdk0KPKmCCWXwz72ItTSn/BWTR1G3FjnXD+b9
+            nJAkakQLLU3yzLFF3KYRb0s+jmsTOuav3OTji9374M7loDZ/GD2mVQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-06T23:50:59Z"
+    mac: ENC[AES256_GCM,data:+1XmXueg3jFQ+w7XNb7XDVwuB77xcccbJR+0saIJ3Bm3ICnsu++DtVzhDutE/QjRH4K5yjUZmJZIPWt9ArC6mI9rmBOawRnd5rwuPV/lpdK6sb92lP448WGTazVM6S/29VBwH9wz2ibextSZblczKUtfcI8DgZkZktLFPD4kiZA=,iv:deXEPXObtOjIlVDYlRZeRsltCAMZWcjosfh5SK9mhQA=,tag:q25tMo8JPwDR38zD28dLZg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus-dev/ksops.yaml
+++ b/secrets/citrus-dev/ksops.yaml
@@ -1,0 +1,7 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: citrus-dev-secrets
+files:
+  - django-secrets.enc.yaml
+  - django-email-secrets.enc.yaml

--- a/secrets/citrus-dev/kustomization.yaml
+++ b/secrets/citrus-dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: citrus-dev
+generators:
+  - ksops.yaml


### PR DESCRIPTION
## Summary

- Add a separate `citrus-dev` Argo CD Application in namespace `citrus-dev`.
- Add a separate `citrus-dev-secrets` Argo CD Application with SOPS-encrypted runtime secrets.
- Add `helm/citrus/values-dev.yaml` for `dev.citrus-grace.com`.
- Remove `dev.citrus-grace.com` from the prod Citrus ingress and `ALLOWED_HOSTS`.
- Add explicit prod/dev `CSRF_TRUSTED_ORIGINS`.
- Allow the `splattop` AppProject to deploy into namespace `citrus-dev`.

## Runtime split

- Prod: `default` namespace, `citrus` database, `citrus` schema, `citrus-grace.com` and `www.citrus-grace.com`.
- Dev: `citrus-dev` namespace, `citrus_dev` database, `citrus` schema, `dev.citrus-grace.com`.

## Validation

- Provisioned managed Postgres database `citrus_dev`.
- Provisioned managed Postgres user `citrus_dev_user`.
- Bootstrapped and smoke-tested the dev DB schema from an in-cluster job.
- `helm template citrus helm/citrus --namespace default`
- `helm template citrus-dev helm/citrus --namespace citrus-dev -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- `helm lint helm/citrus`
- `helm lint helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- `git diff --check`
