### PR TITLE
[codex] CES-392 deploy kube-state-metrics

### DIFF
--- a/helm/garz-observability/README.md
+++ b/helm/garz-observability/README.md
@@ -17,6 +17,9 @@ The `garz-observability` Argo application renders this chart with
 `values-prod.yaml` into the `monitoring` namespace. It keeps the existing
 annotation-based `kubernetes-pods` Prometheus scrape config, alert rules,
 Grafana dashboards, Grafana ingress, Alertmanager, network policies, and PDBs.
+Production also enables kube-state-metrics scoped to `agent-control-plane` Jobs
+so the Mandate synthetic live-verify failed-Job alert has real `kube_job_*`
+series to evaluate.
 
 Required pre-existing secrets:
 

--- a/helm/garz-observability/templates/kube-state-metrics-deployment.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.monitoring.kube_state_metrics.enabled }}
+{{- $ksm := .Values.monitoring.kube_state_metrics -}}
+{{- $fullName := include "garzObservability.fullname" . -}}
+{{- $monitoringNamespace := include "garzObservability.monitoringNamespace" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  namespace: {{ $monitoringNamespace }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 4 }}
+spec:
+  replicas: {{ $ksm.replicas }}
+  selector:
+    matchLabels:
+      {{- include "garzObservability.componentSelectorLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "garzObservability.componentSelectorLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 8 }}
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: {{ $fullName }}-kube-state-metrics
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kube-state-metrics
+          image: "{{ $ksm.image.repository }}:{{ $ksm.image.tag }}"
+          imagePullPolicy: {{ $ksm.image.pull_policy }}
+          args:
+            - "--port=8080"
+            - "--telemetry-port=8081"
+            - "--resources={{ join "," $ksm.resources_to_collect }}"
+            - "--namespaces={{ join "," $ksm.watched_namespaces }}"
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: telemetry
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: telemetry
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml $ksm.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop:
+                - ALL
+{{- end }}

--- a/helm/garz-observability/templates/kube-state-metrics-networkpolicy.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.monitoring.kube_state_metrics.enabled .Values.monitoring.networkPolicies.kube_state_metrics.enabled }}
+{{- $root := . -}}
+{{- $ns := include "garzObservability.monitoringNamespace" . -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-state-metrics-allow-prometheus
+  namespace: {{ $ns }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "monitoring-netpol-kube-state-metrics" "root" $root) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "garzObservability.componentSelectorLabels" (dict "component" "kube-state-metrics" "root" $root) | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $ns }}
+          podSelector:
+            matchLabels:
+              {{- include "garzObservability.componentSelectorLabels" (dict "component" "prometheus" "root" $root) | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.monitoring.kube_state_metrics.service.port }}
+{{- end }}

--- a/helm/garz-observability/templates/kube-state-metrics-rbac.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-rbac.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.monitoring.kube_state_metrics.enabled }}
+{{- $root := . -}}
+{{- $fullName := include "garzObservability.fullname" . -}}
+{{- $monitoringNamespace := include "garzObservability.monitoringNamespace" . -}}
+{{- $watchedNamespaces := .Values.monitoring.kube_state_metrics.watched_namespaces | default list -}}
+{{- if not $watchedNamespaces -}}
+{{- fail "monitoring.kube_state_metrics.watched_namespaces must include at least one namespace" -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  namespace: {{ $monitoringNamespace }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 4 }}
+{{- range $namespace := $watchedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics-rbac" "root" $root) | nindent 4 }}
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics-rbac" "root" $root) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-kube-state-metrics
+    namespace: {{ $monitoringNamespace }}
+{{- end }}
+{{- end }}

--- a/helm/garz-observability/templates/kube-state-metrics-service.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.monitoring.kube_state_metrics.enabled }}
+{{- $ksm := .Values.monitoring.kube_state_metrics -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "garzObservability.fullname" . }}-kube-state-metrics
+  namespace: {{ include "garzObservability.monitoringNamespace" . }}
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 4 }}
+spec:
+  type: {{ $ksm.service.type }}
+  ports:
+    - name: http-metrics
+      port: {{ $ksm.service.port }}
+      targetPort: http-metrics
+      protocol: TCP
+  selector:
+    {{- include "garzObservability.componentSelectorLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 4 }}
+{{- end }}

--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -55,6 +55,14 @@ data:
           - targets:
               - alertmanager.monitoring.svc.cluster.local:9093
 
+{{- if .Values.monitoring.kube_state_metrics.enabled }}
+      - job_name: kube-state-metrics
+        metrics_path: /metrics
+        static_configs:
+          - targets:
+              - {{ printf "%s-kube-state-metrics.%s.svc.cluster.local:%v" $fullName (include "garzObservability.monitoringNamespace" .) (.Values.monitoring.kube_state_metrics.service.port | int) | quote }}
+
+{{- end }}
 {{- range $scrape := .Values.monitoring.prometheus.staticScrapeConfigs }}
       - job_name: {{ $scrape.jobName | quote }}
         metrics_path: {{ default "/metrics" $scrape.metricsPath | quote }}

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -50,6 +50,8 @@ monitoring:
           app.kubernetes.io/component: prometheus
           app.kubernetes.io/instance: splattop-prod
           app.kubernetes.io/name: splattop
+  kube_state_metrics:
+    enabled: true
   grafana:
     enabled: true
     serverDomain: grafana.splat.top

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -35,6 +35,8 @@ monitoring:
       - default
       - ingress-nginx
       extraEgress: []
+    kube_state_metrics:
+      enabled: true
     alertmanager:
       enabled: true
       outboundCIDR: 0.0.0.0/0
@@ -78,6 +80,30 @@ monitoring:
     rules:
       enabled: false
       configMapName: prometheus-rules
+
+  # kube-state-metrics exposes Kubernetes Job status for alert rules that need
+  # to reason about completed or failed batch work.
+  kube_state_metrics:
+    enabled: false
+    replicas: 1
+    image:
+      repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+      tag: v2.19.1
+      pull_policy: IfNotPresent
+    watched_namespaces:
+      - agent-control-plane
+    resources_to_collect:
+      - jobs
+    service:
+      type: ClusterIP
+      port: 8080
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
 
   # Grafana configuration
   grafana:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -649,6 +649,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             'kube_job_status_failed{namespace="agent-control-plane"}',
             rules_template,
         )
+        self.assertIn("kube_job_owner", rules_template)
 
     def test_hosted_harness_safe_floor_and_token_handoff_are_configured(self) -> None:
         values = self.control_plane_values

--- a/tests/test_garz_observability_kube_state_metrics.py
+++ b/tests/test_garz_observability_kube_state_metrics.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+
+def _render_garz_observability_prod() -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "garz-observability",
+            "helm/garz-observability",
+            "--namespace",
+            "monitoring",
+            "-f",
+            "helm/garz-observability/values-prod.yaml",
+        ],
+        check=True,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    docs = [
+        doc
+        for doc in YAML_PARSER.load_all(result.stdout)
+        if isinstance(doc, dict) and doc
+    ]
+    if not docs:
+        raise AssertionError("helm rendered no Kubernetes documents")
+    return docs
+
+
+def _find_doc(
+    docs: list[dict[str, Any]],
+    *,
+    kind: str,
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    for doc in docs:
+        metadata = doc.get("metadata", {})
+        if (
+            doc.get("kind") == kind
+            and metadata.get("name") == name
+            and (namespace is None or metadata.get("namespace") == namespace)
+        ):
+            return doc
+    namespace_label = f" in {namespace}" if namespace else ""
+    raise AssertionError(f"{kind}/{name}{namespace_label} not rendered")
+
+
+class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.docs = _render_garz_observability_prod()
+
+    def test_synthetic_live_verify_alert_uses_kube_job_state_metrics(self) -> None:
+        rules = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-rules",
+            namespace="monitoring",
+        )["data"]["critical-alerts.yaml"]
+
+        self.assertIn("MandateSyntheticLiveVerifyFailed", rules)
+        self.assertIn(
+            'kube_job_status_failed{namespace="agent-control-plane"}',
+            rules,
+        )
+        self.assertIn("kube_job_owner", rules)
+        self.assertIn('owner_kind="CronJob"', rules)
+        self.assertIn(
+            'owner_name="agent-control-plane-synthetic-live-verify"',
+            rules,
+        )
+
+    def test_kube_state_metrics_renders_job_source_for_alert(self) -> None:
+        deployment = _find_doc(
+            self.docs,
+            kind="Deployment",
+            name="splattop-prod-kube-state-metrics",
+            namespace="monitoring",
+        )
+        container = deployment["spec"]["template"]["spec"]["containers"][0]
+        self.assertEqual(
+            container["image"],
+            "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1",
+        )
+        self.assertIn("--resources=jobs", container["args"])
+        self.assertIn("--namespaces=agent-control-plane", container["args"])
+        self.assertEqual(
+            deployment["spec"]["template"]["spec"]["serviceAccountName"],
+            "splattop-prod-kube-state-metrics",
+        )
+
+        service = _find_doc(
+            self.docs,
+            kind="Service",
+            name="splattop-prod-kube-state-metrics",
+            namespace="monitoring",
+        )
+        self.assertEqual(service["spec"]["ports"][0]["port"], 8080)
+
+        role = _find_doc(
+            self.docs,
+            kind="Role",
+            name="splattop-prod-kube-state-metrics",
+            namespace="agent-control-plane",
+        )
+        self.assertEqual(
+            role["rules"],
+            [
+                {
+                    "apiGroups": ["batch"],
+                    "resources": ["jobs"],
+                    "verbs": ["list", "watch"],
+                }
+            ],
+        )
+
+        role_binding = _find_doc(
+            self.docs,
+            kind="RoleBinding",
+            name="splattop-prod-kube-state-metrics",
+            namespace="agent-control-plane",
+        )
+        self.assertEqual(
+            role_binding["subjects"],
+            [
+                {
+                    "kind": "ServiceAccount",
+                    "name": "splattop-prod-kube-state-metrics",
+                    "namespace": "monitoring",
+                }
+            ],
+        )
+
+    def test_prometheus_scrapes_kube_state_metrics(self) -> None:
+        prometheus_config = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-config",
+            namespace="monitoring",
+        )["data"]["prometheus.yml"]
+
+        self.assertIn("job_name: kube-state-metrics", prometheus_config)
+        self.assertIn(
+            "splattop-prod-kube-state-metrics.monitoring.svc.cluster.local:8080",
+            prometheus_config,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add kube-state-metrics to the garz-observability Helm chart, enabled in production.
- Scope kube-state-metrics to `agent-control-plane` Jobs and bind only `list/watch` on `batch/jobs` in that namespace.
- Add an explicit Prometheus `kube-state-metrics` scrape job so `MandateSyntheticLiveVerifyFailed` can evaluate `kube_job_status_failed` joined to `kube_job_owner`.
- Add render tests proving both the alert rule inputs and the kube-state-metrics source are present.

## Root Cause
`MandateSyntheticLiveVerifyFailed` depended on kube-state-metrics Job owner/status series, but the monitoring stack did not deploy or scrape kube-state-metrics. Live read-only checks showed no kube-state-metrics resources, no scrape job, and empty Prometheus results for `count(kube_job_status_failed)`, `count(kube_job_owner)`, and `count(kube_pod_info)`.

## Validation
- `helm lint helm/garz-observability`
- `helm lint helm/garz-observability -f helm/garz-observability/values-prod.yaml`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest tests.test_garz_observability_kube_state_metrics tests.test_agent_control_plane_registry_overlay`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/validate_prometheus_config.py --chart-dir helm/garz-observability --release-name garz-observability --namespace monitoring --values helm/garz-observability/values-prod.yaml --label prod`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest discover -s tests`
- `git diff --check`
- `kubeconform -schema-location default -skip CiliumNetworkPolicy,Certificate -strict -summary -exit-on-error /tmp/garz-observability-prod.yaml`

No deploy, Argo sync, or cluster mutation was performed.