### PR TITLE
Serve Citrus media from PVC sidecar

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -55,6 +55,31 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if and .Values.media.enabled .Values.persistence.enabled }}
+        - name: media
+          image: "{{ .Values.media.image.repository }}:{{ .Values.media.image.tag }}"
+          imagePullPolicy: {{ .Values.media.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.media.containerPort }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.media.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.media.containerPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+          volumeMounts:
+            - name: media-volume
+              mountPath: {{ .Values.media.mountPath }}
+              readOnly: true
+          resources:
+            {{- toYaml .Values.media.resources | nindent 12 }}
+        {{- end }}
       volumes:
         - name: media-volume
           persistentVolumeClaim:

--- a/helm/citrus/templates/ingress.yaml
+++ b/helm/citrus/templates/ingress.yaml
@@ -26,6 +26,15 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          {{- if and $.Values.media.enabled $.Values.persistence.enabled }}
+          - path: {{ $.Values.media.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.media.servicePort }}
+          {{- end }}
           - path: /
             pathType: Prefix
             backend:

--- a/helm/citrus/templates/service.yaml
+++ b/helm/citrus/templates/service.yaml
@@ -13,3 +13,9 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
+    {{- if and .Values.media.enabled .Values.persistence.enabled }}
+    - name: media
+      port: {{ .Values.media.servicePort }}
+      targetPort: {{ .Values.media.containerPort }}
+      protocol: TCP
+    {{- end }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -44,6 +44,24 @@ service:
   port: 80
   targetPort: 8000
 
+media:
+  enabled: true
+  path: /media/
+  image:
+    repository: nginx
+    tag: 1.27-alpine
+    pullPolicy: IfNotPresent
+  servicePort: 8080
+  containerPort: 80
+  mountPath: /usr/share/nginx/html/media
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
 persistence:
   enabled: true
   name: django-media-pvc


### PR DESCRIPTION
## Summary

- add an nginx media sidecar to the Citrus Helm deployment
- mount the existing `django-media-pvc` read-only at nginx's `/usr/share/nginx/html/media`
- add a `media` Service port and route `/media/` ingress paths to it

## Why

With `DJANGO_DEBUG=False`, Django no longer serves uploaded files. The live chart only routed `/` to gunicorn, so product, banner, and gallery image URLs under `/media/` returned 404 even though the files persisted on the PVC.

## Validation

- `helm lint /tmp/SplatTopConfig-ces446/helm/citrus`
- `helm lint /tmp/SplatTopConfig-ces446/helm/citrus -f /tmp/SplatTopConfig-ces446/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces446/helm/citrus/values-dev.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces446/helm/citrus --namespace default --show-only templates/deployment.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces446/helm/citrus --namespace default --show-only templates/ingress.yaml`
- `helm template citrus-dev /tmp/SplatTopConfig-ces446/helm/citrus --namespace citrus-dev -f /tmp/SplatTopConfig-ces446/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces446/helm/citrus/values-dev.yaml --show-only templates/ingress.yaml`
- `git -C /tmp/SplatTopConfig-ces446 diff --check`

Live upload/load verification still needs to run after Argo syncs the chart.
