### PR TITLE
Move Citrus migrations to Argo hook

### DIFF
--- a/docs/argo-operations.md
+++ b/docs/argo-operations.md
@@ -67,6 +67,25 @@ Keep renewal dates in `developer-cheat-sheet.md` or a shared calendar.
 
 Record outcomes (date, scenario, owner) at the bottom of this file for traceability.
 
+## Citrus Rollouts
+
+Citrus uses a single web replica with the `django-media-pvc` ReadWriteOnce
+volume mounted at `/citrus/media`. Do not raise `helm/citrus/values.yaml`
+`replicaCount` above `1` unless media is moved to RWX storage or object storage;
+the launch topology deliberately keeps one writer for uploaded product, banner,
+and gallery images.
+
+Database migrations run through the `citrus-migrate` Argo CD `PreSync` Job
+rendered by `helm/citrus/templates/migrations-job.yaml`. The web Deployment
+starts only gunicorn after the hook succeeds, so migrations do not race across
+pods and app startup does not run schema changes or collectstatic. Static assets
+are expected to be present in the image before rollout; media files remain on
+the PVC.
+
+Readiness and liveness remain TCP probes on the Django service port. During a
+normal image rollout, confirm the PreSync migration Job completes, then confirm
+the single web pod is Ready and still mounts `django-media-pvc`.
+
 ## In-Cluster Secret Decryption (SOPS/ksops)
 
 - Ensure the Age private key is present as `sops-age-key` in the `argocd` namespace (`age.agekey` key).

--- a/helm/citrus/templates/migrations-job.yaml
+++ b/helm/citrus/templates/migrations-job.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "citrus.fullname" . }}-migrate
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app: citrus-migrate
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        app: citrus-migrate
+    spec:
+      restartPolicy: Never
+      {{- include "citrus.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c"]
+          args:
+            - {{ .Values.migrations.command | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.application.configMapName }}
+            - secretRef:
+                name: {{ .Values.application.secretName }}
+                optional: true
+            {{- if .Values.application.emailSecretName }}
+            - secretRef:
+                name: {{ .Values.application.emailSecretName }}
+                optional: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -17,9 +17,7 @@ application:
   secretName: django-secrets
   emailSecretName: django-email-secrets
   command: >
-    python manage.py migrate --noinput &&
-    python manage.py collectstatic --noinput &&
-    gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
+    exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace"
@@ -37,6 +35,18 @@ application:
     EMAIL_USE_AUTH: "False"
     EMAIL_TIMEOUT: "10"
 
+migrations:
+  enabled: true
+  command: python manage.py migrate --noinput
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 service:
   name: citrus-service


### PR DESCRIPTION
## Summary

- move Citrus database migrations from the web pod startup command into an Argo CD `PreSync` Job
- simplify the web pod command so it starts only gunicorn
- document the launch topology: one web replica with the ReadWriteOnce media PVC

## Why

Running `migrate` inside every web pod makes rollouts depend on schema changes during app startup and can race if the deployment is ever scaled. The safe launch topology is one web replica with the RWO media PVC, plus one migration job per GitOps sync before the web deployment rolls.

## Validation

- `helm lint /tmp/SplatTopConfig-ces440/helm/citrus`
- `helm lint /tmp/SplatTopConfig-ces440/helm/citrus -f /tmp/SplatTopConfig-ces440/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces440/helm/citrus/values-dev.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces440/helm/citrus --namespace default --show-only templates/deployment.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces440/helm/citrus --namespace default --show-only templates/migrations-job.yaml`
- `helm template citrus-dev /tmp/SplatTopConfig-ces440/helm/citrus --namespace citrus-dev -f /tmp/SplatTopConfig-ces440/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces440/helm/citrus/values-dev.yaml --show-only templates/deployment.yaml`
- `helm template citrus-dev /tmp/SplatTopConfig-ces440/helm/citrus --namespace citrus-dev -f /tmp/SplatTopConfig-ces440/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces440/helm/citrus/values-dev.yaml --show-only templates/migrations-job.yaml`
- `git -C /tmp/SplatTopConfig-ces440 diff --check`
