### PR TITLE
Protect Citrus media and add backups

### DIFF
--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -71,6 +71,33 @@ tooling is added outside this slice.
 
 ## Restore Procedure
 
+## Citrus Restore Notes
+
+Citrus stores its PostgreSQL data in the shared
+`db-postgresql-nyc3-xscraper` DigitalOcean managed database cluster. The live
+chart sets `DB_SCHEMA=citrus`; the database name, host, port, user, and password
+come from the `django-secrets` Secret in the `default` namespace. The
+`citrus-dev` environment uses its own `django-secrets` Secret in the
+`citrus-dev` namespace and should not be restored into production without an
+explicit operator decision.
+
+The `helm/citrus` chart renders a nightly `citrus-backup` CronJob for
+production. It writes two objects per run to DO Spaces under the configured
+`backup.prefix`: a custom-format `pg_dump` of the Citrus schema and a gzip tar
+archive of `/citrus/media` from `django-media-pvc`. The job deletes backup
+objects older than `backup.retentionDays` (30 days by default). The
+`citrus-backup-secrets` Secret must provide DO Spaces credentials as
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+For a managed-database PITR incident, fork the source cluster first, as
+described below, then extract only the Citrus data into the live cluster after
+the owner approves the target restore point. For logical-backup restore, fetch
+the matching `citrus-*.dump` object from Spaces, freeze Citrus writes by scaling
+the `citrus` deployment to zero or pausing the Argo application, and restore the
+dump into the `citrus` schema with `pg_restore --clean --if-exists --schema=citrus`.
+Restore the corresponding `citrus-media-*.tar.gz` archive into the retained
+`django-media-pvc` before resuming the web deployment.
+
 ### 1. Freeze Writers
 
 Stop all Mandate writers before pointing anything at a restored database. Do not

--- a/helm/citrus/templates/backup-cronjob.yaml
+++ b/helm/citrus/templates/backup-cronjob.yaml
@@ -1,0 +1,125 @@
+{{- if and .Values.backup.enabled .Values.persistence.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "citrus.fullname" . }}-backup
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app: citrus-backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            app: citrus-backup
+        spec:
+          restartPolicy: Never
+          {{- include "citrus.imagePullSecrets" . | nindent 10 }}
+          containers:
+            - name: backup
+              image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  apk add --no-cache aws-cli postgresql16-client tar gzip python3
+
+                  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+                  workdir="/backup/${timestamp}"
+                  mkdir -p "${workdir}"
+
+                  db_dump="${workdir}/citrus-${timestamp}.dump"
+                  media_archive="${workdir}/citrus-media-${timestamp}.tar.gz"
+
+                  export PGPASSWORD="${DB_PASSWORD}"
+                  pg_dump_args="-h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} --format=custom --no-owner --no-privileges --file=${db_dump}"
+                  if [ -n "${DB_SCHEMA:-}" ]; then
+                    pg_dump_args="${pg_dump_args} --schema=${DB_SCHEMA}"
+                  fi
+                  pg_dump ${pg_dump_args} "${DB_NAME}"
+
+                  tar -czf "${media_archive}" -C "$(dirname "${MEDIA_ROOT}")" "$(basename "${MEDIA_ROOT}")"
+
+                  destination="s3://${BACKUP_BUCKET}/${BACKUP_PREFIX}/${timestamp}"
+                  aws_args=""
+                  if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+                    aws_args="--endpoint-url ${AWS_ENDPOINT_URL}"
+                  fi
+                  aws ${aws_args} s3 cp "${db_dump}" "${destination}/$(basename "${db_dump}")"
+                  aws ${aws_args} s3 cp "${media_archive}" "${destination}/$(basename "${media_archive}")"
+
+                  cutoff_epoch="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
+                  aws ${aws_args} s3api list-objects-v2 \
+                    --bucket "${BACKUP_BUCKET}" \
+                    --prefix "${BACKUP_PREFIX}/" \
+                    --query 'Contents[].{Key:Key,LastModified:LastModified}' \
+                    --output json > "${workdir}/objects.json"
+
+                  python3 - "${workdir}/objects.json" "${cutoff_epoch}" > "${workdir}/expired-keys.txt" <<'PY'
+                  import datetime
+                  import json
+                  import sys
+
+                  path = sys.argv[1]
+                  cutoff = int(sys.argv[2])
+                  with open(path, "r", encoding="utf-8") as handle:
+                      objects = json.load(handle) or []
+                  for obj in objects:
+                      last_modified = obj.get("LastModified", "")
+                      if not last_modified:
+                          continue
+                      parsed = datetime.datetime.fromisoformat(
+                          last_modified.replace("Z", "+00:00")
+                      )
+                      if int(parsed.timestamp()) < cutoff:
+                          print(obj["Key"])
+                  PY
+
+                  while IFS= read -r key; do
+                    [ -n "${key}" ] || continue
+                    aws ${aws_args} s3api delete-object --bucket "${BACKUP_BUCKET}" --key "${key}"
+                  done < "${workdir}/expired-keys.txt"
+              env:
+                - name: MEDIA_ROOT
+                  value: {{ .Values.persistence.mountPath | quote }}
+                - name: AWS_ENDPOINT_URL
+                  value: {{ .Values.backup.endpointUrl | quote }}
+                - name: AWS_DEFAULT_REGION
+                  value: {{ .Values.backup.region | quote }}
+                - name: BACKUP_BUCKET
+                  value: {{ .Values.backup.bucket | quote }}
+                - name: BACKUP_PREFIX
+                  value: {{ .Values.backup.prefix | quote }}
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
+              envFrom:
+                - configMapRef:
+                    name: {{ .Values.application.configMapName }}
+                - secretRef:
+                    name: {{ .Values.application.secretName }}
+                - secretRef:
+                    name: {{ .Values.backup.secretName }}
+              volumeMounts:
+                - name: media-volume
+                  mountPath: {{ .Values.persistence.mountPath }}
+                  readOnly: true
+                - name: backup-work
+                  mountPath: /backup
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+          volumes:
+            - name: media-volume
+              persistentVolumeClaim:
+                claimName: {{ .Values.persistence.name }}
+                readOnly: true
+            - name: backup-work
+              emptyDir: {}
+{{- end }}

--- a/helm/citrus/templates/pvc.yaml
+++ b/helm/citrus/templates/pvc.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.persistence.name }}
   labels:
     {{- include "citrus.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     {{- toYaml .Values.persistence.accessModes | nindent 4 }}

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -19,6 +19,9 @@ application:
     EMAIL_USE_AUTH: "False"
     EMAIL_TIMEOUT: "10"
 
+backup:
+  enabled: false
+
 ingress:
   hosts:
     - dev.citrus-grace.com

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -53,6 +53,32 @@ persistence:
     - ReadWriteOnce
   mountPath: /citrus/media
 
+backup:
+  enabled: true
+  schedule: "17 8 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  backoffLimit: 1
+  activeDeadlineSeconds: 3600
+  image:
+    repository: alpine
+    tag: "3.20"
+    pullPolicy: IfNotPresent
+  secretName: citrus-backup-secrets
+  bucket: citrus-grace-backups
+  prefix: citrus
+  endpointUrl: https://nyc3.digitaloceanspaces.com
+  region: nyc3
+  retentionDays: 30
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 ingress:
   enabled: true
   name: citrus-ingress

--- a/secrets/citrus/README.md
+++ b/secrets/citrus/README.md
@@ -4,5 +4,7 @@ Encrypted runtime secrets consumed by the `citrus-secrets` Argo CD app.
 
 - `django-secrets.enc.yaml`: Django, Stripe, and Postgres runtime environment for the Citrus Helm release.
 - `django-email-secrets.enc.yaml`: SMTP and contact-address runtime environment for the Citrus Helm release.
+- `citrus-backup-secrets` must exist in the live namespace for the backup CronJob. It is expected to provide
+  `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` with write/delete access to the configured DO Spaces backup prefix.
 
 Regenerate from `/root/dev/Citrus/.env` with the repo SOPS age key. Commit only encrypted `.enc.yaml` files.


### PR DESCRIPTION
## Summary

- add Argo/Helm keep annotations to the Citrus media PVC
- add a nightly production backup CronJob for `/citrus/media` and a Citrus schema `pg_dump`
- document the Citrus restore path and required backup secret

## Why

The live Citrus media PVC is the only copy of uploaded product, banner, and gallery images. Before this change, Argo prune or a PVC rename could delete the backing DigitalOcean volume, and there was no logical backup path covering both media and the Citrus database schema.

## Live action taken

Patched the current Citrus media PVs to `Retain`:

- `default/django-media-pvc` -> `pvc-1a3c804c-4795-4d21-ba20-924a7e07de53`
- `citrus-dev/django-media-pvc` -> `pvc-93064713-35d6-4efd-8c99-ae50d3cde320`

Verified both now report `RECLAIM=Retain`.

## Validation

- `helm lint /tmp/SplatTopConfig-ces452/helm/citrus`
- `helm lint /tmp/SplatTopConfig-ces452/helm/citrus -f /tmp/SplatTopConfig-ces452/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces452/helm/citrus/values-dev.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces452/helm/citrus --namespace default --show-only templates/pvc.yaml`
- `helm template citrus /tmp/SplatTopConfig-ces452/helm/citrus --namespace default --show-only templates/backup-cronjob.yaml`
- `helm template citrus-dev /tmp/SplatTopConfig-ces452/helm/citrus --namespace citrus-dev -f /tmp/SplatTopConfig-ces452/helm/citrus/values.yaml -f /tmp/SplatTopConfig-ces452/helm/citrus/values-dev.yaml`
- `git -C /tmp/SplatTopConfig-ces452 diff --check`

## Follow-up

Create the live `citrus-backup-secrets` Secret with DO Spaces credentials before relying on the CronJob for recoverability.
