### PR TITLE
Enable Citrus gunicorn access logs

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -19,7 +19,7 @@ application:
   command: >
     python manage.py migrate --noinput &&
     python manage.py collectstatic --noinput &&
-    gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
+    gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --access-logfile -
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace"


### PR DESCRIPTION
## Summary
- append `--access-logfile -` to the Citrus Helm gunicorn command so production access logs reach stdout
- keep the GitOps runtime command aligned with the Citrus deployment manifest for CES-450

## Validation
- `helm lint /tmp/SplatTopConfig-ces450-8w5QYA/helm/citrus`
- `git diff --check`
- `rg -n "access-logfile" /tmp/Citrus-ces450-43j7n0/Dockerfile /tmp/Citrus-ces450-43j7n0/deployment.yaml /tmp/SplatTopConfig-ces450-8w5QYA/helm/citrus/values.yaml`
- signed commit verified with `git log --show-signature -1`