### PR TITLE
Harden Citrus Helm rollout

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app: citrus-web
     spec:
       {{- include "citrus.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: django
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
@@ -27,6 +30,8 @@ spec:
           command: ["sh", "-c"]
           args:
             - {{ .Values.application.command | quote }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ .Values.application.configMapName }}

--- a/helm/citrus/templates/migrations-job.yaml
+++ b/helm/citrus/templates/migrations-job.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "citrus.fullname" . }}-migrate-{{ .Release.Revision }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrations
+  annotations:
+    "helm.sh/hook": {{ .Values.migrations.hook | quote }}
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "citrus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrations
+    spec:
+      {{- include "citrus.imagePullSecrets" . | nindent 6 }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.migrations.command | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.application.configMapName }}
+            - secretRef:
+                name: {{ .Values.application.secretName }}
+                optional: true
+            {{- if .Values.application.emailSecretName }}
+            - secretRef:
+                name: {{ .Values.application.emailSecretName }}
+                optional: true
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+{{- end }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -16,10 +16,8 @@ application:
   configMapName: django-config
   secretName: django-secrets
   emailSecretName: django-email-secrets
-  command: >
-    python manage.py migrate --noinput &&
-    python manage.py collectstatic --noinput &&
-    gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000
+  command: >-
+    exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120 --access-logfile -
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace"
@@ -52,6 +50,37 @@ persistence:
   accessModes:
     - ReadWriteOnce
   mountPath: /citrus/media
+
+migrations:
+  enabled: true
+  hook: pre-install,pre-upgrade
+  backoffLimit: 3
+  command:
+    - python
+    - manage.py
+    - migrate
+    - --noinput
+
+terminationGracePeriodSeconds: 60
+
+podSecurityContext:
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+  capabilities:
+    drop:
+      - ALL
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Summary
- Replace the Citrus runtime startup chain with `exec gunicorn ...` so gunicorn becomes PID 1 and receives SIGTERM directly.
- Move Django migrations into a Helm hook Job and remove runtime `migrate`/`collectstatic` from the web pod startup path.
- Add pod/container security contexts for non-root UID/GID 10001, dropped capabilities, `allowPrivilegeEscalation: false`, `fsGroup`, and a 60s termination grace period.

## Companion PR
- Citrus image/workflow changes: https://github.com/cesaregarza/Citrus/pull/33

## Validation
- `git diff --check`
- `helm lint helm/citrus`
- `helm template citrus helm/citrus`
- `helm template citrus-dev helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- rendered manifest inspection confirmed the Deployment has `exec gunicorn` and no startup `migrate`/`collectstatic`, with migrations in the hook Job