### PR TITLE
Add Citrus shared rate limit cache

### DIFF
--- a/helm/citrus/templates/redis-deployment.yaml
+++ b/helm/citrus/templates/redis-deployment.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.redis.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      {{- include "citrus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "citrus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 999
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}

--- a/helm/citrus/templates/redis-service.yaml
+++ b/helm/citrus/templates/redis-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redis.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: {{ .Values.redis.service.type }}
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "citrus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -31,6 +31,10 @@ application:
     HELP_EMAIL: "help@citrus-grace.com"
     ORDERS_EMAIL: "orders@citrus-grace.com"
     BUSINESS_TIME_ZONE: "America/Chicago"
+    CACHE_URL: "redis://citrus-redis:6379/0"
+    TRUST_X_FORWARDED_FOR: "True"
+    TRUSTED_PROXY_IPS: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+    RECAPTCHA_MIN_SCORE: "0.5"
     EMAIL_HOST: "smtp-relay.gmail.com"
     EMAIL_PORT: "587"
     EMAIL_USE_TLS: "True"
@@ -52,6 +56,25 @@ persistence:
   accessModes:
     - ReadWriteOnce
   mountPath: /citrus/media
+
+redis:
+  enabled: true
+  name: citrus-redis
+  replicas: 1
+  image:
+    repository: redis
+    tag: "7.2.4-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 6379
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
 
 ingress:
   enabled: true

--- a/helm/splattop/files/ingress-nginx/controller-v1.0.0.yaml
+++ b/helm/splattop/files/ingress-nginx/controller-v1.0.0.yaml
@@ -37,6 +37,9 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 data:
+  use-forwarded-headers: "true"
+  compute-full-forwarded-for: "true"
+  proxy-real-ip-cidr: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 ---
 # Source: ingress-nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- Add chart-managed Redis deployment/service for Citrus rate limiting and cache-backed sessions.
- Set `CACHE_URL`, trusted XFF settings, and `RECAPTCHA_MIN_SCORE` in the Citrus app ConfigMap values.
- Enable forwarded header handling in the vendored legacy ingress-nginx controller ConfigMap source.

## Companion PR
- Citrus auth/app changes: https://github.com/cesaregarza/Citrus/pull/34

## Validation
- `git diff --check`
- `helm lint helm/citrus`
- `helm template citrus helm/citrus`
- `helm template citrus-dev helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- `helm lint helm/splattop -f helm/splattop/values-prod.yaml`
- `helm template splattop helm/splattop -f helm/splattop/values-prod.yaml`
- rendered Citrus prod/dev manifests include Redis and cache/trusted-XFF env settings