### PR TITLE
[bot] Update Citrus dev image bad904ed4b042457b5ae857217a7f793975c15b6

### DIFF
--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: ba37ac601385a8af4c2e445fa1062d17955426c9 # allow-latest
+  tag: bad904ed4b042457b5ae857217a7f793975c15b6 # allow-latest
 
 application:
   configData:


### PR DESCRIPTION
Automated dev image update from Citrus deployment workflow.

Source branch: `dev`
Source commit: `bad904ed4b042457b5ae857217a7f793975c15b6`
Source commit subject: Merge pull request #35 from cesaregarza/codex/ces-466-regenerate-tailwind-css