### PR TITLE
citrus-dev: real DJANGO_SECRET_KEY via standalone KSOPS secret

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
                 name: {{ .Values.application.emailSecretName }}
                 optional: true
             {{- end }}
+            {{- if .Values.application.generatedSecretName }}
+            # Generated app secrets (e.g. DJANGO_SECRET_KEY); listed last so it
+            # overrides any placeholder of the same key in secretName.
+            - secretRef:
+                name: {{ .Values.application.generatedSecretName }}
+                optional: true
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.targetPort }}

--- a/helm/citrus/templates/migrations-job.yaml
+++ b/helm/citrus/templates/migrations-job.yaml
@@ -39,6 +39,13 @@ spec:
                 name: {{ .Values.application.emailSecretName }}
                 optional: true
             {{- end }}
+            {{- if .Values.application.generatedSecretName }}
+            # Generated app secrets (e.g. DJANGO_SECRET_KEY); listed last so it
+            # overrides any placeholder of the same key in secretName.
+            - secretRef:
+                name: {{ .Values.application.generatedSecretName }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
 {{- end }}

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -2,6 +2,9 @@ image:
   tag: bad904ed4b042457b5ae857217a7f793975c15b6 # allow-latest
 
 application:
+  # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)
+  # holding a real DJANGO_SECRET_KEY, encrypted with the public age recipient only.
+  generatedSecretName: citrus-dev-app-key
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace Dev"

--- a/secrets/citrus-dev/django-app-key.enc.yaml
+++ b/secrets/citrus-dev/django-app-key.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: citrus-dev-app-key
+    namespace: citrus-dev
+type: Opaque
+stringData:
+    DJANGO_SECRET_KEY: ENC[AES256_GCM,data:8llXKhjxwrVg2raKBwGcf9wN2JwFKAypEjti5bDz4t6NPmhzHX8H4Ye6uSY69q27DtzVMj53UIASHHt+zRTRNppsb/ydGKJ8lQpGyz3exZe7OpOlF9n7Qc2f4cjewfZfWm/lEw==,iv:elncaZCxZlaUqjvdFmzhn7jaeZG2wsfxZsTdTaunhow=,tag:LwU21cSFjxjIlkHnwqQEug==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1T2hrMGNpKzVFMk5UMnlp
+            OThscC9FK0E0QjNZSW5KNWJ0ZVNYU0FNUVFFCkJ6ZXdTaHFwM1o4bWRCY3U5Q09x
+            SHRpTlI0azZ3Zkgrc0pMZGtHQUNJU2cKLS0tIFdSMnNkdVU5QXh1Q1UrVkptN2ln
+            dFFtSVhLSzVFelJDZ2dDT2dBOGtkSVEKfATPXft6eqymczBmU1w43wGZk6PqFenz
+            JRSY0SMWRKBAG5nv1UZuLIKdTJl2Py4UiGvLSN07WehJbAEeculRpg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-08T05:17:56Z"
+    mac: ENC[AES256_GCM,data:1hFMMehoCnKVdxwBtL3jV5HPhxIIdF1avG+4EhE7QYktJt5VSlSo3DADxc05KmLHQ8ugt/USe+rqehW480Mx7l/zzQj7B/Kwgq+kpNp0kb5t6zR6K6bWAQZIC8x4L/MJbS2c1zdRlKyWCjq++LQen8l5dGpk+e/yKivp0SOuDFE=,iv:hTi2iHfC18dV+ITfl8Tx9/sqYIm1L8iP8WfJRn8gCEo=,tag:Wq9b54vFClUUazAHvEcznQ==,type:str]
+    version: 3.13.2

--- a/secrets/citrus-dev/ksops.yaml
+++ b/secrets/citrus-dev/ksops.yaml
@@ -5,3 +5,4 @@ metadata:
 files:
   - django-secrets.enc.yaml
   - django-email-secrets.enc.yaml
+  - django-app-key.enc.yaml


### PR DESCRIPTION
## Why
The `bad904ed4` dev rollout is blocked: CES-439's fail-closed `production_checks` in the new image reject the placeholder `DJANGO_SECRET_KEY` (`django-insecure-…`) in `citrus-dev`, so both the migrate hook and the app pod raise `ImproperlyConfigured` and the Argo sync fails. (The old image never validated, which masked it.)

## Approach — standalone file, public-key-only (no in-place edit)
`DJANGO_SECRET_KEY` is a *generated* value, so rather than in-place editing the shared `django-secrets.enc.yaml` (which would couple rotating it to decrypting all 11 real secrets, and needs the private key), it goes in its own file:

- **`secrets/citrus-dev/django-app-key.enc.yaml`** — a `citrus-dev-app-key` Secret with a fresh real `DJANGO_SECRET_KEY`, encrypted to the public age recipient only (via the existing `.sops.yaml` `secrets/citrus-dev/` rule — **no private key was used or needed**).
- **`ksops.yaml`** — include the new file.
- **`deployment.yaml` + `migrations-job.yaml`** — append it as the **last** `envFrom` secretRef, so its `DJANGO_SECRET_KEY` overrides the placeholder still present in `django-secrets` (which we intentionally don't touch).
- **`values-dev.yaml`** — `application.generatedSecretName: citrus-dev-app-key`.

Rotating/regenerating this key later never touches the other secrets and never needs the private key.

## Validation
- `sops --encrypt` produced `DJANGO_SECRET_KEY: ENC[…]` with the correct recipient; no plaintext remains.
- `helm template … -f values-dev.yaml` renders `citrus-dev-app-key` as the **last** envFrom entry in both the deployment and the migrate job.
- `helm template …` with **base** values (prod) shows **0** occurrences — `generatedSecretName` is unset there, so prod is unaffected.

## After merge
`citrus-dev-secrets` syncs the new Secret → then re-sync `citrus-dev`; the migrate Job applies migration 0004 and the pod comes up on `bad904ed4`.

Related: CES-468 (make `regcred` declarative — separate gap surfaced by the same rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)