### PR TITLE
citrus (prod): real DJANGO_SECRET_KEY via standalone KSOPS secret

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -16,6 +16,10 @@ application:
   configMapName: django-config
   secretName: django-secrets
   emailSecretName: django-email-secrets
+  # Standalone generated-secret file (KSOPS: secrets/citrus/citrus-app-key.enc.yaml)
+  # holding a real DJANGO_SECRET_KEY, encrypted with the public age recipient only.
+  # dev overrides this with citrus-dev-app-key in values-dev.yaml.
+  generatedSecretName: citrus-app-key
   command: >-
     exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120 --access-logfile -
   configData:

--- a/secrets/citrus/citrus-app-key.enc.yaml
+++ b/secrets/citrus/citrus-app-key.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: citrus-app-key
+    namespace: default
+type: Opaque
+stringData:
+    DJANGO_SECRET_KEY: ENC[AES256_GCM,data:yV7pVlOH2TtvptvgJUqQon8XK+VGup9AOdPYCQRM6kIGNLkC3kRBKyTFWM8G0+xQmp13lsBejZXMeGk4yR7EdHO81DTvhFw6KCMJNHd4/d5Rzd/OTAKvfQ+Wc7LLZHjv6tk5cA==,iv:pVEMfKAww/eTImPiTbQ29nUuggRpdfNy6uH5bqA0Dv8=,tag:+vGaN6HkKIcWBrA4Spl7Gg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1RkVqMjZVNng1Y3FDa3ZF
+            eVZkNy9DTnpuOHVadXBkYWdtWVhJYnRSL25FCkEwcDlmVGpoK1VMbE9CdkN4Z2Y5
+            Tk5HWWlrLzBCNnAwZzZDNFZJZmh3Q3MKLS0tIDJiMDltS3JyTWJZT3ZMbU9BcC8x
+            djRDQ1VYZzhwTlhjRUowditYMGdsVDgKbcrjAwzE9KUegsJQtRo5C7rXjhgM6kX+
+            Dst3Y5jWQjUAhQ2+9Mz/hhXOGulHCxkUudsvTYE6tHO36dxLx3MXhQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-08T06:25:16Z"
+    mac: ENC[AES256_GCM,data:7ZWe6HbTUtXBzT30gK6zEBzBOqTiQ5+PLBiI9KgXekZar1ssHeiAs6p30zDzWVzo4X0OtakehvWScjWTbJwXczWbhxsZjRMt+oOWyq8eurENoL7uQz48I74B6VxkcCYEwCtxMJgCXHYKV546SvV4UfGQBflxsbq+CvUtLJbeSLM=,iv:KRTQH0j0uAdO8XPTQ9y95xWLHbHhu3/AX0RyN2EpYtU=,tag:r6+1FU9B6oVeys7sgSdtlg==,type:str]
+    version: 3.13.2

--- a/secrets/citrus/ksops.yaml
+++ b/secrets/citrus/ksops.yaml
@@ -5,3 +5,4 @@ metadata:
 files:
   - django-secrets.enc.yaml
   - django-email-secrets.enc.yaml
+  - citrus-app-key.enc.yaml


### PR DESCRIPTION
## Why
Prod audit found **`default/django-secrets` has an empty `DJANGO_SECRET_KEY`**. The release image's CES-439 fail-closed `production_checks` will crash-loop prod exactly as they did dev (migrate hook + app pod raise `ImproperlyConfigured`). Real secrets (DB, Stripe, webhooks) are all present; `EMAIL_USE_AUTH=False` so the empty email creds are fine.

## What
Mirror of the dev fix (#354): a standalone **`citrus-app-key`** Secret (ns `default`) with a real `DJANGO_SECRET_KEY`, encrypted to the **public** age recipient only (`secrets/citrus/` `.sops.yaml` rule — no private key used). Wired as the **last** `envFrom` via `application.generatedSecretName: citrus-app-key` on base `values.yaml`, so it overrides the empty key. Dev keeps overriding with `citrus-dev-app-key` (values-dev.yaml).

## Validated
- `sops --encrypt` → `DJANGO_SECRET_KEY: ENC[…]`, no plaintext remnants.
- `helm template` (base) → `citrus-app-key` last in prod deployment + migrate job.
- `helm template -f values-dev.yaml` → still `citrus-dev-app-key` last (dev unaffected).

## ⚠️ Merge timing
Merging makes the prod `citrus` Argo app OutOfSync → a real `DJANGO_SECRET_KEY` lands on the running (pre-CES-439) prod pods = **one-time session invalidation + restart**. Harmless on the current image, but best merged **as part of the prod cutover** (alongside the release image) rather than standalone. Part of getting Citrus#37 prod-ready (CES-439 prerequisite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)