### PR TITLE
Wire Citrus media to Spaces

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: citrus-web
 spec:
   strategy:
-    type: Recreate
+    {{- toYaml .Values.strategy | nindent 4 }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -43,6 +43,11 @@ spec:
                 name: {{ .Values.application.emailSecretName }}
                 optional: true
             {{- end }}
+            {{- if .Values.application.spacesSecretName }}
+            - secretRef:
+                name: {{ .Values.application.spacesSecretName }}
+                optional: true
+            {{- end }}
             {{- if .Values.application.generatedSecretName }}
             # Generated app secrets (e.g. DJANGO_SECRET_KEY); listed last so it
             # overrides any placeholder of the same key in secretName.
@@ -62,12 +67,16 @@ spec:
             initialDelaySeconds: 20
             periodSeconds: 15
             timeoutSeconds: 3
+          {{- if and .Values.persistence.enabled .Values.persistence.mountEnabled }}
           volumeMounts:
             - name: media-volume
               mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if and .Values.persistence.enabled .Values.persistence.mountEnabled }}
       volumes:
         - name: media-volume
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.name }}
+      {{- end }}

--- a/helm/citrus/templates/migrations-job.yaml
+++ b/helm/citrus/templates/migrations-job.yaml
@@ -39,6 +39,11 @@ spec:
                 name: {{ .Values.application.emailSecretName }}
                 optional: true
             {{- end }}
+            {{- if .Values.application.spacesSecretName }}
+            - secretRef:
+                name: {{ .Values.application.spacesSecretName }}
+                optional: true
+            {{- end }}
             {{- if .Values.application.generatedSecretName }}
             # Generated app secrets (e.g. DJANGO_SECRET_KEY); listed last so it
             # overrides any placeholder of the same key in secretName.

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -21,6 +21,8 @@ application:
     EMAIL_USE_TLS: "True"
     EMAIL_USE_AUTH: "False"
     EMAIL_TIMEOUT: "10"
+    AWS_STORAGE_BUCKET_NAME: "citrus-media-dev"
+    AWS_S3_CUSTOM_DOMAIN: "citrus-media-dev.nyc3.cdn.digitaloceanspaces.com"
 
 ingress:
   hosts:

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -2,7 +2,13 @@ global:
   imagePullSecrets:
     - regcred
 
-replicaCount: 1
+replicaCount: 2
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/citrus
@@ -16,6 +22,7 @@ application:
   configMapName: django-config
   secretName: django-secrets
   emailSecretName: django-email-secrets
+  spacesSecretName: django-spaces-secrets
   command: >-
     exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout 120 --access-logfile -
   configData:
@@ -34,6 +41,13 @@ application:
     EMAIL_USE_TLS: "True"
     EMAIL_USE_AUTH: "False"
     EMAIL_TIMEOUT: "10"
+    AWS_STORAGE_BUCKET_NAME: "citrus-media"
+    AWS_S3_ENDPOINT_URL: "https://nyc3.digitaloceanspaces.com"
+    AWS_S3_REGION_NAME: "nyc3"
+    AWS_S3_CUSTOM_DOMAIN: "citrus-media.nyc3.cdn.digitaloceanspaces.com"
+    AWS_QUERYSTRING_AUTH: "False"
+    AWS_DEFAULT_ACL: "public-read"
+    AWS_S3_CACHE_CONTROL: "max-age=86400, public"
 
 
 service:
@@ -43,7 +57,8 @@ service:
   targetPort: 8000
 
 persistence:
-  enabled: true
+  enabled: false
+  mountEnabled: false
   name: django-media-pvc
   storageClassName: ""
   size: 10Gi

--- a/secrets/citrus-dev/README.md
+++ b/secrets/citrus-dev/README.md
@@ -4,5 +4,6 @@ Encrypted runtime secrets consumed by the `citrus-dev-secrets` Argo CD app.
 
 - `django-secrets.enc.yaml`: Django, Stripe, and Postgres runtime environment for the `citrus-dev` Helm release.
 - `django-email-secrets.enc.yaml`: SMTP and contact-address runtime environment for the `citrus-dev` Helm release.
+- `django-spaces-secrets.enc.yaml`: DO Spaces media upload credentials for the `citrus-media-dev` bucket.
 
 Commit only encrypted `.enc.yaml` files.

--- a/secrets/citrus-dev/django-spaces-secrets.enc.yaml
+++ b/secrets/citrus-dev/django-spaces-secrets.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-spaces-secrets
+    namespace: citrus-dev
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:bD1J8U7JsAcOTld/3K4OKuruluM=,iv:bHhO0rcsIf278o/idFBkDcINWpQHxuDQeVWVgMXVspE=,tag:cxlOjTUcqwJ0Fysvnc73KQ==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:y4YMIeMoQAfqaiqW1X6e+3yB2pZnuS7pahAp6vuMgAArJLAwY1L78A0iQw==,iv:F6S2qnoUtVZRaFYNGIFCqoE9iazD1Upd+5a6Lu3WutI=,tag:HQIMRD9rWaGeC4bNR3CbFQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VmZqVWdYb0VOc1V5cjVM
+            R1l1dzV3alYwNlpBMUZ4ak9aQW5Ub2M4bjNzCmdFM2QwbjdMaE1kQ2trVjQzMS8z
+            dFlNMFEyZWRnV1JBWHp2ZXZEcHlhbWsKLS0tIEFrcTZYU1Vld0NzakEwZ3RhRE1L
+            WURaZnJJeVRFQlg5VWxDbEJ5ZUE2bFkKEqhuDmfhVNhK2RnlMV3PoN/qMwr+TCJ+
+            YrfG8MfS7WKT1i22iXBnpIGHDgFN1vXEfmiFBGprTme4oscwtUxiyg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-08T06:54:40Z"
+    mac: ENC[AES256_GCM,data:FQrLpe5W4TrzYvTRIrw4oY6rnNa9Uzo487Mp9Pf8UKb5cq545nFAKFyiNI0vocuwnX/HSaOWcnFkBBa/pQRfSLbPupp9L8Uo1h/0//AaBgdRx9fOLn4/gXqhHlzqKV2R5fVFqswsUbkX8zOKSCaNyAo0xPk45WBTAoWUVYA+07M=,iv:pmyf96Pn92v7KI8XDbNzkk9WxxNXE3njRrAV5IeFvwQ=,tag:VODkIVnjr/doyrmt7Dqzww==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus-dev/ksops.yaml
+++ b/secrets/citrus-dev/ksops.yaml
@@ -6,3 +6,4 @@ files:
   - django-secrets.enc.yaml
   - django-email-secrets.enc.yaml
   - django-app-key.enc.yaml
+  - django-spaces-secrets.enc.yaml

--- a/secrets/citrus/README.md
+++ b/secrets/citrus/README.md
@@ -4,5 +4,6 @@ Encrypted runtime secrets consumed by the `citrus-secrets` Argo CD app.
 
 - `django-secrets.enc.yaml`: Django, Stripe, and Postgres runtime environment for the Citrus Helm release.
 - `django-email-secrets.enc.yaml`: SMTP and contact-address runtime environment for the Citrus Helm release.
+- `django-spaces-secrets.enc.yaml`: DO Spaces media upload credentials for the Citrus media bucket.
 
-Regenerate from `/root/dev/Citrus/.env` with the repo SOPS age key. Commit only encrypted `.enc.yaml` files.
+Regenerate environment secret files from `/root/dev/Citrus/.env` with the repo SOPS age key. Commit only encrypted `.enc.yaml` files.

--- a/secrets/citrus/django-spaces-secrets.enc.yaml
+++ b/secrets/citrus/django-spaces-secrets.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: django-spaces-secrets
+    namespace: default
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:Tk5NTXSTbIvaD0kO//V9WwJYY1I=,iv:vKX2uRpkUhfs0mgOge/rJatK7I2zvs4tV67mvtHp8rA=,tag:eSd1jQrYY8GvbRKmBJ0Zjg==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:A58OGnK8ozURNDshPWEunT9ZanrwIsqY/+23BTverDtA5NWI7hhb5u9JAQ==,iv:7lxHzw0wFKDQN4Lrbb/UZdk2rsXhdKpG2L3xOKnKVYo=,tag:l8KtYxhuaX/vmojF8LsIbA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFdUxHeU03WEw4bzIxc09p
+            eG16SnlBU3VvNjdOYVVzVGlKWlM3OTZreTFZCnlOMVZlOWhZdHVSdlNxdXdqaEFS
+            K0xMWjI4WkpXUlBFbi83QVR6Sml5OEEKLS0tIGt0WVNvRldGdjk1a2lrOUR4ZENX
+            MTh3RFdUb1lPSkRUUmNiSlNlS1FaWEEKqi8aJyu2F/lgOxJhcYI+fXuyiV3QUwkg
+            sXtAJO9TNg70hvLECQ/KCTLRrbd++s/4QVkFUiaqVEfi/PUISUapJQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-08T06:54:40Z"
+    mac: ENC[AES256_GCM,data:JW8J7PmPQ0BgAdXDwilRJQZ+/e0y/iVofeMGGkriqvLQyXX/gxmwJfPZhYTlfKK4CgpoaLUov4au5UnVMgI3L52J7aP7uPF0kL408PqUJ00qhKmPtNUyHw34SGHpSvtoyEYdOog1ncQQneyTNgkE/egM9o2vArK2t2okFH/AJD0=,iv:Vw8o0pcCuLDDnAIsy5RdW5dFJJW/cYj8Qa1pDJBIV1Q=,tag:2+cD4ApuE9RROdKJXV1HJA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/citrus/ksops.yaml
+++ b/secrets/citrus/ksops.yaml
@@ -5,3 +5,4 @@ metadata:
 files:
   - django-secrets.enc.yaml
   - django-email-secrets.enc.yaml
+  - django-spaces-secrets.enc.yaml


### PR DESCRIPTION
## Summary
- Add the encrypted `django-spaces-secrets` runtime secret for prod and dev Citrus releases, sourced from the local Citrus `.env` Spaces keys.
- Wire the secret into the web deployment and migration job env, configure prod/dev Spaces buckets and CDN domains, and leave static app secrets ordering intact.
- Disable the old media PVC mount and use rolling updates with two replicas now that uploaded media is externalized.

## Migration notes
- Created and verified DigitalOcean Spaces buckets `citrus-media` and `citrus-media-dev` in `nyc3`, each with CDN enabled.
- Live PVC inventory found zero uploaded files in both `default/django-media-pvc` and `citrus-dev/django-media-pvc`, so there was nothing to copy before decommissioning the PVC-rendered workload path.

## Validation
- `helm lint /tmp/GarzAICluster-ces446-spaces-work/helm/citrus`
- `helm template` prod/dev Citrus renders verified for Spaces env, `django-spaces-secrets`, rolling deployment, and no rendered PVC/volume mount
- `helm lint /tmp/GarzAICluster-ces446-spaces-work/helm/splattop -f /tmp/GarzAICluster-ces446-spaces-work/helm/splattop/values-prod.yaml`
- `helm lint /tmp/GarzAICluster-ces446-spaces-work/helm/vanity-hosts`
- `uv run python /tmp/GarzAICluster-ces446-spaces-work/scripts/validate_prometheus_config.py`
- SOPS manifests checked for encrypted-only secret values

Linear: CES-446