### PR TITLE
Add Citrus Redis cache

### DIFF
--- a/helm/citrus/templates/redis-deployment.yaml
+++ b/helm/citrus/templates/redis-deployment.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.redis.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      {{- include "citrus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "citrus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 999
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}

--- a/helm/citrus/templates/redis-service.yaml
+++ b/helm/citrus/templates/redis-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redis.name }}
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: {{ .Values.redis.service.type }}
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "citrus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -36,6 +36,8 @@ application:
     HELP_EMAIL: "help@citrus-grace.com"
     ORDERS_EMAIL: "orders@citrus-grace.com"
     BUSINESS_TIME_ZONE: "America/Chicago"
+    CACHE_URL: "redis://citrus-redis:6379/0"
+    RATELIMIT_USE_CACHE: "default"
     EMAIL_HOST: "smtp-relay.gmail.com"
     EMAIL_PORT: "587"
     EMAIL_USE_TLS: "True"
@@ -96,6 +98,25 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
+
+redis:
+  enabled: true
+  name: citrus-redis
+  replicas: 1
+  image:
+    repository: redis
+    tag: "7.2.4-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 6379
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Summary
- Split the safe Redis/cache half out of GarzAICluster #350 for CES-470.
- Add chart-managed `citrus-redis` Deployment and Service for Citrus.
- Wire `CACHE_URL=redis://citrus-redis:6379/0` and `RATELIMIT_USE_CACHE=default` through the Citrus ConfigMap so the `8036fe63` dev image can pass production checks.

## Deliberately excluded
- No changes to `helm/splattop/files/ingress-nginx/controller-v1.0.0.yaml`.
- No shared ingress `use-forwarded-headers` / `compute-full-forwarded-for` changes.
- No `TRUST_X_FORWARDED_FOR`, `TRUSTED_PROXY_IPS`, or recaptcha score changes from #350.

## Validation
- `helm lint /tmp/GarzAICluster-ces470-redis/helm/citrus`
- `helm template citrus /tmp/GarzAICluster-ces470-redis/helm/citrus`
- `helm template citrus-dev /tmp/GarzAICluster-ces470-redis/helm/citrus -f /tmp/GarzAICluster-ces470-redis/helm/citrus/values.yaml -f /tmp/GarzAICluster-ces470-redis/helm/citrus/values-dev.yaml`
- `helm lint /tmp/GarzAICluster-ces470-redis/helm/splattop -f /tmp/GarzAICluster-ces470-redis/helm/splattop/values-prod.yaml`
- `helm lint /tmp/GarzAICluster-ces470-redis/helm/vanity-hosts`
- `uv run python /tmp/GarzAICluster-ces470-redis/scripts/validate_prometheus_config.py`
- `git diff --check`
- Rendered prod/dev Citrus manifests include `citrus-redis`, `CACHE_URL`, and `RATELIMIT_USE_CACHE`; search confirmed no XFF/ingress keys in this diff.

Linear: CES-470