### PR TITLE
Order Citrus migrations after config sync

### DIFF
--- a/helm/citrus/templates/configmap.yaml
+++ b/helm/citrus/templates/configmap.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ .Values.application.configMapName }}
   labels:
     {{- include "citrus.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.config | quote }}
 data:
   {{- range $key, $value := .Values.application.configData }}
   {{ $key }}: {{ $value | quote }}

--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "citrus.labels" . | nindent 4 }}
     app: citrus-web
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.deployment | quote }}
 spec:
   strategy:
     {{- toYaml .Values.strategy | nindent 4 }}

--- a/helm/citrus/templates/migrations-job.yaml
+++ b/helm/citrus/templates/migrations-job.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- include "citrus.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrations
   annotations:
-    "helm.sh/hook": {{ .Values.migrations.hook | quote }}
-    "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.migrations | quote }}
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
   template:

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -18,6 +18,11 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+syncWaves:
+  config: "0"
+  migrations: "1"
+  deployment: "2"
+
 application:
   configMapName: django-config
   secretName: django-secrets
@@ -68,7 +73,6 @@ persistence:
 
 migrations:
   enabled: true
-  hook: pre-install,pre-upgrade
   backoffLimit: 3
   command:
     - python


### PR DESCRIPTION
## Summary
- Fix the first-deploy Spaces media deadlock from CES-469 by removing the Helm hook annotations that Argo translated into a PreSync migration hook.
- Make the migrate Job an explicit Argo `Sync` hook at sync wave `1`, after the Citrus ConfigMap at wave `0`.
- Put the web Deployment at sync wave `2` so migrations complete before the new web pods roll.

## Why
On the first deploy that introduces Spaces, the Spaces secret may already exist while the AWS bucket/endpoint/domain ConfigMap keys have not been applied yet. The old PreSync migration hook imported Django settings before that ConfigMap landed, tripping the partial-Spaces guard and preventing the Sync phase from applying the ConfigMap. Running migrations in Sync wave `1` lets Argo apply the ConfigMap first while keeping the app's fail-closed import guard intact.

## Validation
- `helm lint /tmp/GarzAICluster-ces469-sync-waves/helm/citrus`
- `helm template citrus /tmp/GarzAICluster-ces469-sync-waves/helm/citrus`
- `helm template citrus-dev /tmp/GarzAICluster-ces469-sync-waves/helm/citrus -f /tmp/GarzAICluster-ces469-sync-waves/helm/citrus/values.yaml -f /tmp/GarzAICluster-ces469-sync-waves/helm/citrus/values-dev.yaml`
- `helm lint /tmp/GarzAICluster-ces469-sync-waves/helm/splattop -f /tmp/GarzAICluster-ces469-sync-waves/helm/splattop/values-prod.yaml`
- `helm lint /tmp/GarzAICluster-ces469-sync-waves/helm/vanity-hosts`
- `uv run python /tmp/GarzAICluster-ces469-sync-waves/scripts/validate_prometheus_config.py`
- `git diff --check`
- Render assertion verified ConfigMap wave `0`, migrate Sync hook wave `1`, Deployment wave `2`, and no remaining Helm hook / pre-install / pre-upgrade annotations in the Citrus chart.

Linear: CES-469