### PR TITLE
CES-476 Add Citrus media worker Deployment

### DIFF
--- a/helm/citrus/templates/worker-deployment.yaml
+++ b/helm/citrus/templates/worker-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "citrus.fullname" . }}-media-worker
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app: citrus-media-worker
+    app.kubernetes.io/component: media-worker
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.worker | quote }}
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: citrus-media-worker
+  template:
+    metadata:
+      labels:
+        app: citrus-media-worker
+        app.kubernetes.io/component: media-worker
+    spec:
+      {{- include "citrus.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: media-worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c"]
+          args:
+            - {{ .Values.worker.command | quote }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.application.configMapName }}
+            - secretRef:
+                name: {{ .Values.application.secretName }}
+                optional: true
+            {{- if .Values.application.emailSecretName }}
+            - secretRef:
+                name: {{ .Values.application.emailSecretName }}
+                optional: true
+            {{- end }}
+            {{- if .Values.application.spacesSecretName }}
+            - secretRef:
+                name: {{ .Values.application.spacesSecretName }}
+                optional: true
+            {{- end }}
+            {{- if .Values.application.generatedSecretName }}
+            # Generated app secrets (e.g. DJANGO_SECRET_KEY); listed last so it
+            # overrides any placeholder of the same key in secretName.
+            - secretRef:
+                name: {{ .Values.application.generatedSecretName }}
+                optional: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+{{- end }}

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -24,6 +24,9 @@ application:
     AWS_STORAGE_BUCKET_NAME: "citrus-media-dev"
     AWS_S3_CUSTOM_DOMAIN: "citrus-media-dev.nyc3.cdn.digitaloceanspaces.com"
 
+worker:
+  enabled: true
+
 ingress:
   hosts:
     - dev.citrus-grace.com

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -99,7 +99,7 @@ migrations:
     - --noinput
 
 worker:
-  enabled: true
+  enabled: false
   replicas: 1
   command: >-
     exec celery -A Mycore worker --loglevel=INFO --queues=media --concurrency=1

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -22,6 +22,7 @@ syncWaves:
   config: "0"
   migrations: "1"
   deployment: "2"
+  worker: "2"
 
 application:
   configMapName: django-config
@@ -47,6 +48,16 @@ application:
     ORDERS_EMAIL: "orders@citrus-grace.com"
     BUSINESS_TIME_ZONE: "America/Chicago"
     CACHE_URL: "redis://citrus-redis:6379/0"
+    CELERY_BROKER_URL: "redis://citrus-redis:6379/1"
+    CELERY_TASK_ALWAYS_EAGER: "False"
+    CELERY_TASK_DEFAULT_QUEUE: "media"
+    CELERY_BROKER_VISIBILITY_TIMEOUT: "3600"
+    CELERY_TASK_SOFT_TIME_LIMIT: "240"
+    CELERY_TASK_TIME_LIMIT: "300"
+    MEDIA_UPLOAD_MAX_BYTES: "10485760"
+    MEDIA_COMPRESSION_MAX_IMAGE_PIXELS: "50000000"
+    MEDIA_COMPRESSION_ENABLED: "True"
+    MEDIA_GALLERY_MAX_BATCH: "25"
     RATELIMIT_USE_CACHE: "default"
     EMAIL_HOST: "smtp-relay.gmail.com"
     EMAIL_PORT: "587"
@@ -86,6 +97,22 @@ migrations:
     - manage.py
     - migrate
     - --noinput
+
+worker:
+  enabled: true
+  replicas: 1
+  command: >-
+    exec celery -A Mycore worker --loglevel=INFO --queues=media --concurrency=1
+    --prefetch-multiplier=1 --max-tasks-per-child=20 --soft-time-limit=240
+    --time-limit=300
+  terminationGracePeriodSeconds: 300
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 750m
+      memory: 1Gi
 
 terminationGracePeriodSeconds: 60
 


### PR DESCRIPTION
## Summary
- Add the Citrus media-worker Deployment using the same image/tag, config, and secrets as the web pod.
- Run Celery on the `media` queue with concurrency 1, prefetch 1, max-tasks-per-child, and 240/300s task limits.
- Add worker resources, sync wave 2, Redis DB 1 broker config, and media compression env flags to the Citrus chart.
- Keep the worker disabled in base/prod values until prod is running a Celery-capable image; enable it only in `values-dev.yaml` for the first rollout.

## Paired Change
- Citrus app PR: https://github.com/cesaregarza/Citrus/pull/42

## Validation
- `helm lint ./helm/citrus`
- `helm template citrus ./helm/citrus --namespace citrus`
- `helm template citrus-dev ./helm/citrus --namespace citrus-dev -f helm/citrus/values-dev.yaml`
- Render assertions confirmed prod keeps `CELERY_BROKER_URL` / `MEDIA_*` config but renders no media worker, while dev renders the worker command, Redis DB 1 broker config, sync wave 2, dev bucket override, and no Service selecting `citrus-media-worker`.

Linear: CES-476