### PR TITLE
Add Citrus Spaces CORS runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 
 ## Quick links
 
-- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/developer-cheat-sheet.md`
+- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/runbooks/citrus-spaces-cors.md`, `docs/developer-cheat-sheet.md`
 - KSOPS deep dive and CMP recipe: `docs/ksops-llm-response.md`
 - Argo objects: `argocd/` (AppProjects, Applications, AppSets)
 - Charts/values: `helm/` and `apps/`
@@ -16,6 +16,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 - `apps/` – per-bot values/defs consumed by AppSets (e.g., `argocd/appsets/bots-*.yaml`).
 - `helm/` – service charts and the umbrella chart; values files cover dev/default/prod overlays.
 - `k8s/` – legacy/standalone manifests (ingress, cert, repo-server patches, secrets templates).
+- `infra/spaces/` – checked-in Spaces bucket configuration payloads that must be applied by operators.
 - `secrets/` – encrypted bot secrets (`secrets/bots/**`) with `kustomization.yaml` + `ksops.yaml` per bot.
 - `docs/` – runbooks and design notes; start with `docs/README.md` for the reading order.
 - `scripts/` – helpers like `scripts/validate_prometheus_config.py` (renders Helm, then promtool).

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,10 @@ Read them in roughly this order when contributing here:
    workload capability wiring.
 8. `runbooks/postgres-restore.md` – DigitalOcean managed Postgres restore
    procedure for the live Mandate `agent-control-plane` deployment.
-9. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-10. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+9. `runbooks/citrus-spaces-cors.md` – DigitalOcean Spaces CORS procedure for
+   Citrus Grace browser media uploads.
+10. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+11. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/docs/runbooks/citrus-spaces-cors.md
+++ b/docs/runbooks/citrus-spaces-cors.md
@@ -1,0 +1,118 @@
+# Citrus Spaces CORS Runbook
+
+This runbook applies the deployment-owned CORS contract for Citrus Grace browser
+media uploads to DigitalOcean Spaces. The helm chart configures the application
+bucket names and credentials, but Spaces bucket CORS is external bucket state and
+must be applied by an operator with Spaces admin credentials.
+
+Live infrastructure mutations require explicit operator approval. Codex may
+update this source-controlled runbook, policy payload, and helper script, but
+must not apply bucket CORS unattended.
+
+## Scope
+
+Apply the same CORS policy to both Citrus media buckets:
+
+| Environment | Bucket | Helm value source |
+| --- | --- | --- |
+| Prod | `citrus-media` | `helm/citrus/values.yaml` |
+| Dev | `citrus-media-dev` | `helm/citrus/values-dev.yaml` |
+
+The checked-in CORS payload is `infra/spaces/citrus-media-cors.json`.
+
+The allowed browser origins are:
+
+- `https://citrus-grace.com`
+- `https://www.citrus-grace.com`
+- `https://dev.citrus-grace.com`
+
+The allowed methods are `GET` and `POST`. Preflight `OPTIONS` is evaluated by
+Spaces against this rule and does not need to be listed as an allowed method.
+The payload allows all request headers because presigned browser uploads can
+include `Content-Type`, `policy`, and multiple `x-amz-*` form/header fields.
+
+## References
+
+- DigitalOcean Spaces CORS docs: https://docs.digitalocean.com/products/spaces/how-to/configure-cors/
+- DigitalOcean Spaces S3 compatibility docs: https://docs.digitalocean.com/products/spaces/reference/s3-compatibility/
+- AWS CLI `put-bucket-cors` command reference: https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-cors.html
+
+## Apply
+
+Prerequisites:
+
+- `doctl` authenticated to a DigitalOcean account that can create and delete
+  Spaces keys.
+- `s3cmd`, `jq`, `python3`, and `curl`.
+- Operator approval to mutate both buckets.
+
+Run the checked-in helper:
+
+```bash
+cd /path/to/GarzAICluster
+bash scripts/apply_citrus_spaces_cors.sh
+```
+
+The helper:
+
+- Creates a temporary Spaces key with `doctl spaces keys create`.
+- Converts `infra/spaces/citrus-media-cors.json` to temporary S3 CORS XML.
+- Applies the policy to `citrus-media` and `citrus-media-dev` with
+  `s3cmd setcors`.
+- Runs POST preflight checks for all allowed origins against both buckets.
+- Deletes the temporary Spaces key in an exit trap.
+
+By default the helper uses `CITRUS_SPACES_KEY_GRANTS="bucket=;permission=fullaccess"`.
+DigitalOcean rejects bucket-scoped `fullaccess` grants and bucket-scoped
+`readwrite` grants cannot update bucket CORS (`AccessDenied`). Keep the key
+temporary and confirm deletion after the run.
+
+The operation replaces the full bucket CORS configuration, so preserve any
+future additional rules in `infra/spaces/citrus-media-cors.json` before
+applying.
+
+## Verify
+
+Confirm no temporary CES-478 key remains:
+
+```bash
+doctl spaces keys list --format Name,AccessKey,Grants,CreatedAt -o json \
+  | jq -r '.[] | select(.name | startswith("ces-478-cors-"))'
+```
+
+The helper already verifies browser preflight behavior from every allowed origin
+to each bucket. To rerun only the preflight checks:
+
+```bash
+for bucket in citrus-media citrus-media-dev; do
+  for origin in \
+    https://citrus-grace.com \
+    https://www.citrus-grace.com \
+    https://dev.citrus-grace.com; do
+    echo "== ${bucket} ${origin}"
+    curl -i -X OPTIONS "https://${bucket}.nyc3.digitaloceanspaces.com/" \
+      -H "Origin: ${origin}" \
+      -H "Access-Control-Request-Method: POST" \
+      -H "Access-Control-Request-Headers: content-type,x-amz-algorithm,x-amz-credential,x-amz-date,x-amz-signature,policy"
+  done
+done
+```
+
+Each response should be a successful preflight and include
+`Access-Control-Allow-Origin` for the tested origin plus `POST` in
+`Access-Control-Allow-Methods`.
+
+For an end-to-end browser upload, generate a real presigned POST from the Citrus
+API and upload through the frontend. A generic unsigned POST to the bucket is
+expected to fail authorization even when CORS is correct.
+
+If validating GET responses through the Spaces CDN domains
+`citrus-media.nyc3.cdn.digitaloceanspaces.com` or
+`citrus-media-dev.nyc3.cdn.digitaloceanspaces.com`, purge the CDN cache after
+changing CORS so cached responses do not hide the new CORS headers.
+
+## Rollback
+
+There is no GitOps controller reconciling this bucket state. To roll back, commit
+the previous policy payload and rerun the apply script. Do not delete bucket
+CORS unless the frontend direct-upload flow has been disabled or replaced.

--- a/infra/spaces/citrus-media-cors.json
+++ b/infra/spaces/citrus-media-cors.json
@@ -1,0 +1,23 @@
+{
+  "CORSRules": [
+    {
+      "ID": "citrus-grace-browser-media-upload",
+      "AllowedOrigins": [
+        "https://citrus-grace.com",
+        "https://www.citrus-grace.com",
+        "https://dev.citrus-grace.com"
+      ],
+      "AllowedMethods": [
+        "GET",
+        "POST"
+      ],
+      "AllowedHeaders": [
+        "*"
+      ],
+      "ExposeHeaders": [
+        "ETag"
+      ],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}

--- a/scripts/apply_citrus_spaces_cors.sh
+++ b/scripts/apply_citrus_spaces_cors.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Apply the Citrus Grace Spaces bucket CORS policy with a temporary Spaces key.
+
+This creates a short-lived DigitalOcean Spaces key, applies
+infra/spaces/citrus-media-cors.json to citrus-media and citrus-media-dev, runs
+POST preflight checks for all allowed origins, and deletes the temporary key on
+exit.
+
+Prerequisites:
+  - doctl authenticated to a DigitalOcean account that can manage Spaces keys.
+  - s3cmd, jq, python3, and curl.
+
+Environment overrides:
+  CITRUS_SPACES_CORS_CONFIG   default: infra/spaces/citrus-media-cors.json
+  CITRUS_SPACES_KEY_NAME      default: ces-478-cors-<UTC timestamp>
+  CITRUS_SPACES_KEY_GRANTS    default: bucket=;permission=fullaccess
+  SPACES_REGION               default: nyc3
+  SPACES_HOST_BASE            default: nyc3.digitaloceanspaces.com
+
+Usage:
+  bash scripts/apply_citrus_spaces_cors.sh
+  bash scripts/apply_citrus_spaces_cors.sh /path/to/cors.json
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_PATH="${CITRUS_SPACES_CORS_CONFIG:-${REPO_ROOT}/infra/spaces/citrus-media-cors.json}"
+if [[ $# -eq 1 ]]; then
+  CONFIG_PATH="$1"
+fi
+
+SPACES_REGION="${SPACES_REGION:-nyc3}"
+SPACES_HOST_BASE="${SPACES_HOST_BASE:-${SPACES_REGION}.digitaloceanspaces.com}"
+SPACES_HOST_BUCKET="${SPACES_HOST_BUCKET:-%(bucket)s.${SPACES_HOST_BASE}}"
+KEY_NAME="${CITRUS_SPACES_KEY_NAME:-ces-478-cors-$(date -u +%Y%m%d%H%M%S)}"
+KEY_GRANTS="${CITRUS_SPACES_KEY_GRANTS:-bucket=;permission=fullaccess}"
+BUCKETS=("citrus-media" "citrus-media-dev")
+ORIGINS=(
+  "https://citrus-grace.com"
+  "https://www.citrus-grace.com"
+  "https://dev.citrus-grace.com"
+)
+
+for command_name in doctl jq python3 s3cmd curl; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "$command_name is required." >&2
+    exit 127
+  fi
+done
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "CORS config not found: $CONFIG_PATH" >&2
+  exit 2
+fi
+
+ACCESS_KEY=""
+SECRET_KEY=""
+CORS_XML="$(mktemp)"
+
+cleanup() {
+  rm -f "$CORS_XML"
+  if [[ -n "$ACCESS_KEY" ]]; then
+    echo "Deleting temporary Spaces key ${KEY_NAME}"
+    doctl spaces keys delete "$ACCESS_KEY" --interactive=false >/dev/null
+  fi
+}
+trap cleanup EXIT
+
+python3 - "$CONFIG_PATH" "$CORS_XML" <<'PY'
+import json
+import sys
+import xml.etree.ElementTree as ET
+
+config_path, output_path = sys.argv[1:3]
+with open(config_path, encoding="utf-8") as config_file:
+    policy = json.load(config_file)
+
+root = ET.Element(
+    "CORSConfiguration",
+    {"xmlns": "http://s3.amazonaws.com/doc/2006-03-01/"},
+)
+for rule in policy["CORSRules"]:
+    rule_element = ET.SubElement(root, "CORSRule")
+    if rule.get("ID"):
+        ET.SubElement(rule_element, "ID").text = rule["ID"]
+    for origin in rule["AllowedOrigins"]:
+        ET.SubElement(rule_element, "AllowedOrigin").text = origin
+    for method in rule["AllowedMethods"]:
+        ET.SubElement(rule_element, "AllowedMethod").text = method
+    for header in rule.get("AllowedHeaders", []):
+        ET.SubElement(rule_element, "AllowedHeader").text = header
+    for header in rule.get("ExposeHeaders", []):
+        ET.SubElement(rule_element, "ExposeHeader").text = header
+    if "MaxAgeSeconds" in rule:
+        ET.SubElement(rule_element, "MaxAgeSeconds").text = str(rule["MaxAgeSeconds"])
+
+ET.indent(root, space="  ")
+ET.ElementTree(root).write(output_path, encoding="utf-8", xml_declaration=True)
+PY
+
+echo "Creating temporary Spaces key ${KEY_NAME}"
+create_json="$(
+  doctl spaces keys create "$KEY_NAME" \
+    --grants "$KEY_GRANTS" \
+    --interactive=false \
+    -o json
+)"
+
+ACCESS_KEY="$(jq -r 'if type == "array" then .[0] else . end | .access_key // empty' <<<"$create_json")"
+SECRET_KEY="$(jq -r 'if type == "array" then .[0] else . end | .secret_key // empty' <<<"$create_json")"
+
+if [[ -z "$ACCESS_KEY" || -z "$SECRET_KEY" ]]; then
+  echo "Unable to parse temporary Spaces key response." >&2
+  exit 1
+fi
+
+for bucket in "${BUCKETS[@]}"; do
+  echo "Applying CORS to ${bucket}"
+  s3cmd \
+    --access_key="$ACCESS_KEY" \
+    --secret_key="$SECRET_KEY" \
+    --host="$SPACES_HOST_BASE" \
+    --host-bucket="$SPACES_HOST_BUCKET" \
+    --region="$SPACES_REGION" \
+    setcors "$CORS_XML" "s3://${bucket}"
+done
+
+for bucket in "${BUCKETS[@]}"; do
+  for origin in "${ORIGINS[@]}"; do
+    echo "Verifying preflight for ${bucket} from ${origin}"
+    curl -fsS -D - -o /dev/null -X OPTIONS "https://${bucket}.${SPACES_HOST_BASE}/" \
+      -H "Origin: ${origin}" \
+      -H "Access-Control-Request-Method: POST" \
+      -H "Access-Control-Request-Headers: content-type,x-amz-algorithm,x-amz-credential,x-amz-date,x-amz-signature,policy" \
+      | awk 'BEGIN { status_ok=0; allow_origin=0; allow_methods=0 }
+          /^HTTP\// { print; if ($2 ~ /^2/) status_ok=1 }
+          tolower($0) ~ /^access-control-allow-origin:/ { print; allow_origin=1 }
+          tolower($0) ~ /^access-control-allow-methods:/ { print; if ($0 ~ /POST/) allow_methods=1 }
+          END { exit !(status_ok && allow_origin && allow_methods) }'
+  done
+done
+
+echo "CORS applied and verified for citrus-media and citrus-media-dev."

--- a/tests/test_citrus_spaces_cors_runbook.py
+++ b/tests/test_citrus_spaces_cors_runbook.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CORS_POLICY = REPO_ROOT / "infra" / "spaces" / "citrus-media-cors.json"
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "citrus-spaces-cors.md"
+SCRIPT = REPO_ROOT / "scripts" / "apply_citrus_spaces_cors.sh"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+ROOT_README = REPO_ROOT / "README.md"
+PROD_VALUES = REPO_ROOT / "helm" / "citrus" / "values.yaml"
+DEV_VALUES = REPO_ROOT / "helm" / "citrus" / "values-dev.yaml"
+
+
+class CitrusSpacesCorsRunbookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = json.loads(CORS_POLICY.read_text(encoding="utf-8"))
+        cls.runbook = RUNBOOK.read_text(encoding="utf-8")
+        cls.script = SCRIPT.read_text(encoding="utf-8")
+        cls.prod_values = PROD_VALUES.read_text(encoding="utf-8")
+        cls.dev_values = DEV_VALUES.read_text(encoding="utf-8")
+
+    def test_cors_policy_matches_direct_upload_contract(self) -> None:
+        self.assertEqual(
+            self.policy,
+            {
+                "CORSRules": [
+                    {
+                        "ID": "citrus-grace-browser-media-upload",
+                        "AllowedOrigins": [
+                            "https://citrus-grace.com",
+                            "https://www.citrus-grace.com",
+                            "https://dev.citrus-grace.com",
+                        ],
+                        "AllowedMethods": ["GET", "POST"],
+                        "AllowedHeaders": ["*"],
+                        "ExposeHeaders": ["ETag"],
+                        "MaxAgeSeconds": 3600,
+                    }
+                ]
+            },
+        )
+
+    def test_policy_tracks_citrus_helm_buckets_and_hosts(self) -> None:
+        rule = self.policy["CORSRules"][0]
+        prod_bucket = _extract_scalar(self.prod_values, "AWS_STORAGE_BUCKET_NAME")
+        dev_bucket = _extract_scalar(self.dev_values, "AWS_STORAGE_BUCKET_NAME")
+
+        self.assertEqual(prod_bucket, "citrus-media")
+        self.assertEqual(dev_bucket, "citrus-media-dev")
+        self.assertIn(prod_bucket, self.runbook)
+        self.assertIn(dev_bucket, self.runbook)
+        self.assertIn(prod_bucket, self.script)
+        self.assertIn(dev_bucket, self.script)
+
+        expected_origins = {f"https://{host}" for host in _extract_ingress_hosts(self.prod_values)}
+        expected_origins.update(f"https://{host}" for host in _extract_ingress_hosts(self.dev_values))
+        self.assertEqual(set(rule["AllowedOrigins"]), expected_origins)
+
+    def test_runbook_is_discoverable_and_records_apply_commands(self) -> None:
+        self.assertIn(
+            "docs/runbooks/citrus-spaces-cors.md",
+            ROOT_README.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "runbooks/citrus-spaces-cors.md",
+            DOCS_README.read_text(encoding="utf-8"),
+        )
+
+        required_phrases = (
+            "infra/spaces/citrus-media-cors.json",
+            "scripts/apply_citrus_spaces_cors.sh",
+            "doctl spaces keys create",
+            "s3cmd setcors",
+            "doctl spaces keys list",
+            'CITRUS_SPACES_KEY_GRANTS="bucket=;permission=fullaccess"',
+            "curl -i -X OPTIONS",
+            "Access-Control-Request-Method: POST",
+            "purge the CDN cache",
+            "must not apply bucket CORS unattended",
+        )
+        for phrase in required_phrases:
+            self.assertIn(phrase, self.runbook)
+
+    def test_apply_script_uses_checked_in_policy_for_both_buckets(self) -> None:
+        required_phrases = (
+            'CONFIG_PATH="${CITRUS_SPACES_CORS_CONFIG:-${REPO_ROOT}/infra/spaces/citrus-media-cors.json}"',
+            'SPACES_REGION="${SPACES_REGION:-nyc3}"',
+            'SPACES_HOST_BASE="${SPACES_HOST_BASE:-${SPACES_REGION}.digitaloceanspaces.com}"',
+            'KEY_GRANTS="${CITRUS_SPACES_KEY_GRANTS:-bucket=;permission=fullaccess}"',
+            'BUCKETS=("citrus-media" "citrus-media-dev")',
+            "doctl spaces keys create",
+            "doctl spaces keys delete",
+            "s3cmd",
+            "setcors",
+            "curl -fsS -D - -o /dev/null -X OPTIONS",
+        )
+        for phrase in required_phrases:
+            self.assertIn(phrase, self.script)
+
+
+def _extract_scalar(yaml_text: str, key: str) -> str:
+    prefix = f"{key}:"
+    for line in yaml_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped.removeprefix(prefix).strip().strip('"')
+    raise AssertionError(f"Missing scalar key: {key}")
+
+
+def _extract_ingress_hosts(yaml_text: str) -> list[str]:
+    lines = yaml_text.splitlines()
+    for index, line in enumerate(lines):
+        if line == "ingress:":
+            for hosts_index in range(index + 1, len(lines)):
+                if lines[hosts_index] == "  hosts:":
+                    hosts: list[str] = []
+                    for host_line in lines[hosts_index + 1 :]:
+                        if host_line.startswith("    - "):
+                            hosts.append(host_line.removeprefix("    - ").strip().strip('"'))
+                            continue
+                        if host_line and not host_line.startswith("    "):
+                            break
+                    if hosts:
+                        return hosts
+    raise AssertionError("Missing ingress hosts")


### PR DESCRIPTION
## Summary

- Add a source-controlled CORS policy for the Citrus media Spaces buckets.
- Add an operator helper that creates a temporary DigitalOcean Spaces key with `doctl`, converts the checked-in JSON policy to S3 CORS XML, applies it with `s3cmd`, verifies POST preflight behavior, and deletes the temporary key on exit.
- Document the live apply and rollback flow in a discoverable runbook, plus tests that pin bucket names, origins, methods, commands, and README links.

## Why

CES-478 blocks the browser direct-upload work because Spaces rejects cross-origin browser POSTs unless bucket CORS is configured outside the Helm chart. The bucket state is not managed by Argo or the Citrus chart, so this PR records the reproducible operator path instead of relying on a console click.

## Live apply evidence

Already applied to `citrus-media` and `citrus-media-dev` on 2026-07-09 using a temporary `doctl` Spaces key. POST preflight returned `HTTP/2 200` for all three allowed origins on both buckets:

- `https://citrus-grace.com`
- `https://www.citrus-grace.com`
- `https://dev.citrus-grace.com`

Confirmed no `ces-478-cors-*` temporary Spaces keys remained after cleanup.

Implementation note: DigitalOcean rejected bucket-scoped `fullaccess` as `Invalid Grant Combination`, and bucket-scoped `readwrite` returned `403 AccessDenied` for `s3cmd setcors`, so the helper defaults to a temporary `bucket=;permission=fullaccess` key and deletes it immediately after verification.

## Validation

- `bash -n scripts/apply_citrus_spaces_cors.sh`
- `python -m json.tool infra/spaces/citrus-media-cors.json`
- `python -m unittest tests.test_citrus_spaces_cors_runbook`
- `git diff --check --cached` before commit
- Re-ran `bash scripts/apply_citrus_spaces_cors.sh` successfully against live Spaces buckets with `CITRUS_SPACES_KEY_NAME=ces-478-cors-final`