### PR TITLE
Record right-sizing metrics in Prometheus

### DIFF
--- a/helm/garz-observability/README.md
+++ b/helm/garz-observability/README.md
@@ -17,9 +17,11 @@ The `garz-observability` Argo application renders this chart with
 `values-prod.yaml` into the `monitoring` namespace. It keeps the existing
 annotation-based `kubernetes-pods` Prometheus scrape config, alert rules,
 Grafana dashboards, Grafana ingress, Alertmanager, network policies, and PDBs.
-Production also enables kube-state-metrics scoped to `agent-control-plane` Jobs
-so the Mandate synthetic live-verify failed-Job alert has real `kube_job_*`
-series to evaluate.
+Production also enables kube-state-metrics cluster-wide and Prometheus kubelet
+scrapes through the Kubernetes API server. That gives Prometheus the historical
+container CPU/memory usage series plus Kubernetes request/limit metadata needed
+for reservation right-sizing. Metrics Server remains useful for live
+`kubectl top` and autoscalers, but it is not the historical store.
 
 Required pre-existing secrets:
 

--- a/helm/garz-observability/templates/kube-state-metrics-deployment.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-deployment.yaml
@@ -35,7 +35,9 @@ spec:
             - "--port=8080"
             - "--telemetry-port=8081"
             - "--resources={{ join "," $ksm.resources_to_collect }}"
+            {{- if $ksm.watched_namespaces }}
             - "--namespaces={{ join "," $ksm.watched_namespaces }}"
+            {{- end }}
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/helm/garz-observability/templates/kube-state-metrics-rbac.yaml
+++ b/helm/garz-observability/templates/kube-state-metrics-rbac.yaml
@@ -3,9 +3,6 @@
 {{- $fullName := include "garzObservability.fullname" . -}}
 {{- $monitoringNamespace := include "garzObservability.monitoringNamespace" . -}}
 {{- $watchedNamespaces := .Values.monitoring.kube_state_metrics.watched_namespaces | default list -}}
-{{- if not $watchedNamespaces -}}
-{{- fail "monitoring.kube_state_metrics.watched_namespaces must include at least one namespace" -}}
-{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,6 +10,57 @@ metadata:
   namespace: {{ $monitoringNamespace }}
   labels:
     {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics" "root" .) | nindent 4 }}
+{{- if not $watchedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics-rbac" "root" $root) | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $fullName }}-kube-state-metrics
+  labels:
+    {{- include "garzObservability.componentLabels" (dict "component" "kube-state-metrics-rbac" "root" $root) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $fullName }}-kube-state-metrics
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-kube-state-metrics
+    namespace: {{ $monitoringNamespace }}
+{{- else }}
 {{- range $namespace := $watchedNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,5 +94,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ $fullName }}-kube-state-metrics
     namespace: {{ $monitoringNamespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -55,6 +55,38 @@ data:
           - targets:
               - alertmanager.monitoring.svc.cluster.local:9093
 
+{{- if .Values.monitoring.prometheus.kubeletScrape.enabled }}
+      - job_name: kubernetes-cadvisor
+        scheme: https
+        kubernetes_sd_configs:
+          - role: node
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        relabel_configs:
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels:
+              - __meta_kubernetes_node_name
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+      - job_name: kubernetes-kubelet
+        scheme: https
+        kubernetes_sd_configs:
+          - role: node
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        relabel_configs:
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels:
+              - __meta_kubernetes_node_name
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics
+
+{{- end }}
 {{- if .Values.monitoring.kube_state_metrics.enabled }}
       - job_name: kube-state-metrics
         metrics_path: /metrics

--- a/helm/garz-observability/values-prod.yaml
+++ b/helm/garz-observability/values-prod.yaml
@@ -29,6 +29,8 @@ monitoring:
       enabled: true
   prometheus:
     enabled: true
+    kubeletScrape:
+      enabled: true
     staticScrapeConfigs:
     - jobName: hermes-governed-runtime
       metricsPath: /metrics

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -64,6 +64,8 @@ monitoring:
           targetPort: http
     configMapName: prometheus-config
     retention: 15d
+    kubeletScrape:
+      enabled: false
     staticScrapeConfigs: []
     persistence:
       enabled: true
@@ -81,8 +83,9 @@ monitoring:
       enabled: false
       configMapName: prometheus-rules
 
-  # kube-state-metrics exposes Kubernetes Job status for alert rules that need
-  # to reason about completed or failed batch work.
+  # kube-state-metrics exposes Kubernetes object state for alerting and
+  # reservation right-sizing. Leave watched_namespaces empty to watch all
+  # namespaces with a ClusterRole.
   kube_state_metrics:
     enabled: false
     replicas: 1
@@ -90,9 +93,14 @@ monitoring:
       repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
       tag: v2.19.1
       pull_policy: IfNotPresent
-    watched_namespaces:
-      - agent-control-plane
+    watched_namespaces: []
     resources_to_collect:
+      - pods
+      - nodes
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
       - jobs
     service:
       type: ClusterIP

--- a/scripts/validate_prometheus_config.py
+++ b/scripts/validate_prometheus_config.py
@@ -186,6 +186,24 @@ def run_promtool_config(config_text: str) -> None:
         cfg_dir = Path(tempdir)
         config_path = cfg_dir / "prometheus.yml"
         config_path.write_text(config_text)
+        # promtool checks referenced bearer_token_file/ca_file paths even though
+        # CI is not running inside a Kubernetes pod.
+        service_account_dir = cfg_dir / "serviceaccount"
+        service_account_dir.mkdir()
+        (service_account_dir / "token").write_text("promtool-ci-token\n")
+        (service_account_dir / "ca.crt").write_text(
+            "-----BEGIN CERTIFICATE-----\n"
+            "MIIBhTCCASugAwIBAgIJAO7gPromtoolCiMAoGCCqGSM49BAMCMBQxEjAQBgNV\n"
+            "BAMMCXByb210b29sMB4XDTI2MDEwMTAwMDAwMFoXDTM2MDEwMTAwMDAwMFow\n"
+            "FDESMBAGA1UEAwwJcHJvbXRvb2wwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n"
+            "AAS8LL2hHmgKTu0eYi5iqHe4UjsJ61rVjuzh0f4fPTTW5s12rEc3D9GYm0NG\n"
+            "CMxUOMwxvKbL0fPfwdoF8Sero1MwUTAdBgNVHQ4EFgQUpromtoolci000000\n"
+            "000000000000000000wHwYDVR0jBBgwFoAUpromtoolci0000000000000000\n"
+            "00000000wDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNJADBGAiEAzj2p\n"
+            "sJ5yQfztwfdlKZs8dcOQGv4qaZFrBFZyV0sCIQC3B0vY0FSk5Fhl33FjzZzz\n"
+            "TfGv9dbAQHbXQz8mqQ==\n"
+            "-----END CERTIFICATE-----\n"
+        )
 
         subprocess.run(
             [
@@ -197,6 +215,11 @@ def run_promtool_config(config_text: str) -> None:
                 "--entrypoint=promtool",
                 "-v",
                 f"{cfg_dir}:/etc/prometheus/conf",
+                "-v",
+                (
+                    f"{service_account_dir}:"
+                    "/var/run/secrets/kubernetes.io/serviceaccount:ro"
+                ),
                 PROMTOOL_IMAGE,
                 "check",
                 "config",

--- a/tests/test_garz_observability_kube_state_metrics.py
+++ b/tests/test_garz_observability_kube_state_metrics.py
@@ -86,7 +86,7 @@ class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
             rules,
         )
 
-    def test_kube_state_metrics_renders_job_source_for_alert(self) -> None:
+    def test_kube_state_metrics_renders_cluster_metadata_for_right_sizing(self) -> None:
         deployment = _find_doc(
             self.docs,
             kind="Deployment",
@@ -98,8 +98,14 @@ class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
             container["image"],
             "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1",
         )
-        self.assertIn("--resources=jobs", container["args"])
-        self.assertIn("--namespaces=agent-control-plane", container["args"])
+        self.assertIn(
+            "--resources=pods,nodes,deployments,replicasets,statefulsets,daemonsets,jobs",
+            container["args"],
+        )
+        self.assertFalse(
+            any(arg.startswith("--namespaces=") for arg in container["args"]),
+            "kube-state-metrics should watch all namespaces for right-sizing metadata",
+        )
         self.assertEqual(
             deployment["spec"]["template"]["spec"]["serviceAccountName"],
             "splattop-prod-kube-state-metrics",
@@ -113,31 +119,37 @@ class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
         )
         self.assertEqual(service["spec"]["ports"][0]["port"], 8080)
 
-        role = _find_doc(
+        cluster_role = _find_doc(
             self.docs,
-            kind="Role",
+            kind="ClusterRole",
             name="splattop-prod-kube-state-metrics",
-            namespace="agent-control-plane",
         )
-        self.assertEqual(
-            role["rules"],
-            [
-                {
-                    "apiGroups": ["batch"],
-                    "resources": ["jobs"],
-                    "verbs": ["list", "watch"],
-                }
-            ],
+        cluster_resources = {
+            resource
+            for rule in cluster_role["rules"]
+            for resource in rule["resources"]
+        }
+        self.assertTrue(
+            {
+                "pods",
+                "nodes",
+                "namespaces",
+                "deployments",
+                "replicasets",
+                "statefulsets",
+                "daemonsets",
+                "jobs",
+            }.issubset(cluster_resources)
         )
 
-        role_binding = _find_doc(
+        cluster_role_binding = _find_doc(
             self.docs,
-            kind="RoleBinding",
+            kind="ClusterRoleBinding",
             name="splattop-prod-kube-state-metrics",
-            namespace="agent-control-plane",
         )
+        self.assertEqual(cluster_role_binding["roleRef"]["kind"], "ClusterRole")
         self.assertEqual(
-            role_binding["subjects"],
+            cluster_role_binding["subjects"],
             [
                 {
                     "kind": "ServiceAccount",
@@ -158,6 +170,30 @@ class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
         self.assertIn("job_name: kube-state-metrics", prometheus_config)
         self.assertIn(
             "splattop-prod-kube-state-metrics.monitoring.svc.cluster.local:8080",
+            prometheus_config,
+        )
+
+    def test_prometheus_scrapes_kubelet_usage_for_right_sizing(self) -> None:
+        prometheus_config = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-config",
+            namespace="monitoring",
+        )["data"]["prometheus.yml"]
+
+        self.assertIn("job_name: kubernetes-cadvisor", prometheus_config)
+        self.assertIn("job_name: kubernetes-kubelet", prometheus_config)
+        self.assertIn(
+            "bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token",
+            prometheus_config,
+        )
+        self.assertIn("replacement: kubernetes.default.svc:443", prometheus_config)
+        self.assertIn(
+            "replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor",
+            prometheus_config,
+        )
+        self.assertIn(
+            "replacement: /api/v1/nodes/${1}/proxy/metrics",
             prometheus_config,
         )
 


### PR DESCRIPTION
## Summary
- Add Prometheus kubelet/cAdvisor scrape jobs through the Kubernetes API server so container CPU and memory usage are retained in Prometheus.
- Expand kube-state-metrics from `agent-control-plane` Jobs-only coverage to cluster-wide pods, nodes, workload controllers, and jobs so requests/limits metadata is available for right-sizing joins.
- Document that Metrics Server is for live `kubectl top`/autoscaling data, while Prometheus is the historical store.

## Impact
Once merged and synced, Prometheus should begin retaining the usage and resource metadata needed for a one-week reservation right-sizing window. Prometheus already has `--storage.tsdb.retention.time=15d`, so no retention increase is needed.

## Validation
- `helm template garz-observability helm/garz-observability --namespace monitoring -f helm/garz-observability/values-prod.yaml`
- `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --with pytest python -m pytest tests/test_garz_observability_kube_state_metrics.py` -> 4 passed
- `env UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --with pytest python -m pytest` -> 101 passed
- `git diff --check`