### PR TITLE
[bot] Update Citrus dev image 6708330a68ee9b2f0edeed0322a432f169c49e0c

### DIFF
--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 754670fbdc5591025242bd3c8ef9fccbf83cdc7f # allow-latest
+  tag: 6708330a68ee9b2f0edeed0322a432f169c49e0c # allow-latest
 
 application:
   # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)


### PR DESCRIPTION
Automated dev image update from Citrus deployment workflow.

Source branch: `dev`
Source commit: `6708330a68ee9b2f0edeed0322a432f169c49e0c`
Source commit subject: Merge pull request #43 from cesaregarza/cesar/ces-477-mediaasset-model-app-clean