### PR TITLE
CES-484 Add Citrus media lifecycle CronJobs

### DIFF
--- a/helm/citrus/templates/media-cronjobs.yaml
+++ b/helm/citrus/templates/media-cronjobs.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.mediaRequeue.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "citrus.fullname" . }}-media-requeue
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: media-requeue
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.mediaCronJobs | quote }}
+spec:
+  schedule: {{ .Values.mediaRequeue.schedule | quote }}
+  concurrencyPolicy: {{ .Values.mediaRequeue.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.mediaRequeue.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.mediaRequeue.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.mediaRequeue.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "citrus.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: media-requeue
+        spec:
+          {{- include "citrus.imagePullSecrets" . | nindent 10 }}
+          restartPolicy: OnFailure
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: media-requeue
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                {{- toYaml .Values.mediaRequeue.command | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: {{ .Values.application.configMapName }}
+                - secretRef:
+                    name: {{ .Values.application.secretName }}
+                    optional: true
+                {{- if .Values.application.emailSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.emailSecretName }}
+                    optional: true
+                {{- end }}
+                {{- if .Values.application.spacesSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.spacesSecretName }}
+                    optional: true
+                {{- end }}
+                {{- if .Values.application.generatedSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.generatedSecretName }}
+                    optional: true
+                {{- end }}
+              resources:
+                {{- toYaml .Values.mediaRequeue.resources | nindent 16 }}
+{{- end }}
+{{- if and .Values.mediaRequeue.enabled .Values.mediaGc.enabled }}
+---
+{{- end }}
+{{- if .Values.mediaGc.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "citrus.fullname" . }}-media-gc
+  labels:
+    {{- include "citrus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: media-gc
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.mediaCronJobs | quote }}
+spec:
+  schedule: {{ .Values.mediaGc.schedule | quote }}
+  concurrencyPolicy: {{ .Values.mediaGc.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.mediaGc.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.mediaGc.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.mediaGc.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "citrus.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: media-gc
+        spec:
+          {{- include "citrus.imagePullSecrets" . | nindent 10 }}
+          restartPolicy: OnFailure
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: media-gc
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                {{- toYaml .Values.mediaGc.command | nindent 16 }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: {{ .Values.application.configMapName }}
+                - secretRef:
+                    name: {{ .Values.application.secretName }}
+                    optional: true
+                {{- if .Values.application.emailSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.emailSecretName }}
+                    optional: true
+                {{- end }}
+                {{- if .Values.application.spacesSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.spacesSecretName }}
+                    optional: true
+                {{- end }}
+                {{- if .Values.application.generatedSecretName }}
+                - secretRef:
+                    name: {{ .Values.application.generatedSecretName }}
+                    optional: true
+                {{- end }}
+              resources:
+                {{- toYaml .Values.mediaGc.resources | nindent 16 }}
+{{- end }}

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -27,6 +27,12 @@ application:
 worker:
   enabled: true
 
+mediaRequeue:
+  enabled: true
+
+mediaGc:
+  enabled: true
+
 ingress:
   hosts:
     - dev.citrus-grace.com

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -116,7 +116,7 @@ worker:
       memory: 1Gi
 
 mediaRequeue:
-  enabled: true
+  enabled: false
   schedule: "*/10 * * * *"
   concurrencyPolicy: Forbid
   backoffLimit: 2
@@ -137,7 +137,7 @@ mediaRequeue:
       memory: 512Mi
 
 mediaGc:
-  enabled: true
+  enabled: false
   schedule: "22 8 * * *"
   concurrencyPolicy: Forbid
   backoffLimit: 2

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -23,6 +23,7 @@ syncWaves:
   migrations: "1"
   deployment: "2"
   worker: "2"
+  mediaCronJobs: "3"
 
 application:
   configMapName: django-config
@@ -113,6 +114,48 @@ worker:
     limits:
       cpu: 750m
       memory: 1Gi
+
+mediaRequeue:
+  enabled: true
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  backoffLimit: 2
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  command:
+    - python
+    - manage.py
+    - enqueue_pending_media
+    - --stale-minutes=10
+    - --limit=100
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 512Mi
+
+mediaGc:
+  enabled: true
+  schedule: "22 8 * * *"
+  concurrencyPolicy: Forbid
+  backoffLimit: 2
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  command:
+    - python
+    - manage.py
+    - collect_orphan_media
+    - --dry-run
+    - --limit=100
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 512Mi
 
 terminationGracePeriodSeconds: 60
 


### PR DESCRIPTION
## Summary
- add Citrus media lifecycle CronJobs for `enqueue_pending_media` and `collect_orphan_media`
- schedule requeue every 10 minutes and GC daily, with GC running `--dry-run` initially
- render both jobs with the Citrus image/env secret set, non-root pod/container security contexts, resources, and Argo sync-wave `"3"`

## Verification
- `helm lint helm/citrus`
- `helm lint helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- `helm template citrus helm/citrus --show-only templates/media-cronjobs.yaml`
- `helm template citrus-dev helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml --show-only templates/media-cronjobs.yaml`
- `helm template citrus helm/citrus`
- `helm template citrus-dev helm/citrus -f helm/citrus/values.yaml -f helm/citrus/values-dev.yaml`
- `git diff --check`