### PR TITLE
Enable Citrus media worker + lifecycle CronJobs on prod

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -100,7 +100,7 @@ migrations:
     - --noinput
 
 worker:
-  enabled: false
+  enabled: true
   replicas: 1
   command: >-
     exec celery -A Mycore worker --loglevel=INFO --queues=media --concurrency=1
@@ -116,7 +116,7 @@ worker:
       memory: 1Gi
 
 mediaRequeue:
-  enabled: false
+  enabled: true
   schedule: "*/10 * * * *"
   concurrencyPolicy: Forbid
   backoffLimit: 2
@@ -137,7 +137,7 @@ mediaRequeue:
       memory: 512Mi
 
 mediaGc:
-  enabled: false
+  enabled: true
   schedule: "22 8 * * *"
   concurrencyPolicy: Forbid
   backoffLimit: 2


### PR DESCRIPTION
Flips worker.enabled + mediaRequeue.enabled + mediaGc.enabled to true in base helm/citrus/values.yaml. Part of the CES-475 media pipeline prod cutover — the prod image now (master @ 4c1e5eadb) has the celery worker + management commands, so prod can run the worker and the requeue/dry-run-GC CronJobs. Must merge together with the prod image bump so the worker rolls on the epic image. GC stays --dry-run.