### PR TITLE
CES-428: CP train bump to agent-platform 9ddc5c8 (descent wave)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-f1bbc2acc7a4
+  tag: sha-9ddc5c8b732c
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -45,7 +45,7 @@ apiExtraSecretRefs:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:6cdbd880eb2e8912359878e903b9c98ff415d7045d9a4feb159a1919640827de","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:c17d395b7bb81e69e91fe20ed90c3859349f19b084f76a4e8d89efb27848cc43","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:73203a3ff8309cb762966f7559abf871f46a239c3136e7a5658eb069f52066c1","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -119,7 +119,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:dbb0d981c69e9d6f9ba7b2ce1de76f1e9eb88381f81be65314bfc9c4b5fa3a69","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2a3b6afc068849e07f65badc6a2ac83f1062ba062b3c8085d6188c2b28a45d64","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: f1bbc2acc7a49f9fa0a4682a39c1c9fa78ed278e
+      targetRevision: 9ddc5c8b732c0840e12ef7b1c5a07eb22c3106b4
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-f1bbc2acc7a4` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-9ddc5c8b732c` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-f1bbc2acc7a4
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-9ddc5c8b732c
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -784,18 +784,18 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             api_pins["model_gateway"]["digest"],
-            "sha256:a1bca8321b19f748de5b56ecfeb02081f7be44f2d362b00f79043db56805835e",
+            "sha256:c17d395b7bb81e69e91fe20ed90c3859349f19b084f76a4e8d89efb27848cc43",
         )
         self.assertEqual(
             api_pins["readonly-sql-broker"]["digest"],
-            "sha256:6cdbd880eb2e8912359878e903b9c98ff415d7045d9a4feb159a1919640827de",
+            "sha256:73203a3ff8309cb762966f7559abf871f46a239c3136e7a5658eb069f52066c1",
         )
         self.assertEqual(
             gateway_pins["model_gateway"],
             {
                 "digest": (
                     "sha256:"
-                    "dbb0d981c69e9d6f9ba7b2ce1de76f1e9eb88381f81be65314bfc9c4b5fa3a69"
+                    "2a3b6afc068849e07f65badc6a2ac83f1062ba062b3c8085d6188c2b28a45d64"
                 ),
                 "protocol": "model_gateway",
             },


### PR DESCRIPTION
## Train content
- **Image:** `sha-9ddc5c8b732c` (DOCR-verified; manifest-list `sha256:fc73048ff6a44610d2375fa2394512523526740491e35057d83e143553837bdf`, published 2026-07-11 16:39 UTC from publish run 29160059511 at exactly `9ddc5c8b732c0840e12ef7b1c5a07eb22c3106b4`)
- **Chart targetRevision:** `9ddc5c8b732c0840e12ef7b1c5a07eb22c3106b4` (audited frozen SHA, CES-525 CLOSE verdict)
- **Provider pins (all three move; CES-346 method validated against deployed digests at f1bbc2a first):** control-api model_gateway `c17d395b…`, readonly-sql-broker `73203a3f…`; gateway model_gateway `2a3b6afc…`
- **Fixtures synced:** overlay test pins + postgres-restore runbook image refs (CES-357 class)

## Migrations riding (migrate job applies before rollout; expect the documented brief CP crash-loop)
005 worker claim context · 006 retire control_jobs reply_target · 007/008/009 granted_authority expand→backfill→validate (CES-496)

## Pre-GO gates (all resolved on CES-428)
- CES-263 RLS: write rail NOT wired in prod (no write-SQL URL in runtime secret; no write capability in allowlist) — guard rides inert; RLS confirmation binds at wiring time
- CES-503 malformed-digest sweep: zero surface_scope_digest values configured anywhere — clean
- New chart secretKey (PRESET_ROUTES_JSON): inert — GarzAICluster values override secretKeys wholesale; analytical rail keeps its legacy URL route (factory fallback verified)
- Semantic diff: six coordinates only, no overlay/tuning values touched (CES-343 discipline)

Local gates: overlay tests 15 passed; `check_agent_control_plane_provider_pins.py --agent-platform-repo` confirms pins match 9ddc5c8 and the image tag.