### PR TITLE
CES-428: bump daemon memory limits (probe OOM on new image)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -80,6 +80,9 @@ migrations:
   disableStartupSchemaMigration: true
 
 localWorker:
+  resources:
+    limits:
+      memory: 512Mi
   enabled: true
   replicaCount: 1
   capabilities: task.echo,approval.probe,readonly_sql,audit.digest,mandate.ops.inspect,mandate.deploy.smoke
@@ -87,6 +90,9 @@ localWorker:
   batchSize: 1
 
 callbackAdapter:
+  resources:
+    limits:
+      memory: 512Mi
   enabled: true
   replicaCount: 1
   sink: http
@@ -102,6 +108,9 @@ callbackAdapter:
     autoArchiveMinutes: 1440
 
 gitDeliverer:
+  resources:
+    limits:
+      memory: 512Mi
   enabled: true
   replicaCount: 1
   secretKeys:


### PR DESCRIPTION
Train follow-up. The three exec-probe daemons (local-worker, callback-adapter, git-deliverer) restart-loop on the new image: `mandate-daemon-health` execs a second Python interpreter per check and gets OOM-killed (exit 137) under the shared 256Mi limit, while the daemon's own heartbeat file is healthy (`status: ok`, fresh timestamps verified in-container). Gateway/API unaffected (HTTP probes / 512Mi).

Fix: per-component `resources.limits.memory: 512Mi` overrides (Helm deep-merge keeps cpu limits + requests at chart defaults; no scheduling-pressure change on the memory-tight cluster).

Durable fix to be ticketed separately: make the health probe a file-stat instead of a package-importing Python process.