### PR TITLE
CES-428: raise daemon health-probe timeouts to 15s (probe import cost exceeds 3s)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -80,6 +80,11 @@ migrations:
   disableStartupSchemaMigration: true
 
 localWorker:
+  health:
+    startup:
+      timeoutSeconds: 15
+    liveness:
+      timeoutSeconds: 15
   resources:
     limits:
       memory: 512Mi
@@ -90,6 +95,11 @@ localWorker:
   batchSize: 1
 
 callbackAdapter:
+  health:
+    startup:
+      timeoutSeconds: 15
+    liveness:
+      timeoutSeconds: 15
   resources:
     limits:
       memory: 512Mi
@@ -108,6 +118,11 @@ callbackAdapter:
     autoArchiveMinutes: 1440
 
 gitDeliverer:
+  health:
+    startup:
+      timeoutSeconds: 15
+    liveness:
+      timeoutSeconds: 15
   resources:
     limits:
       memory: 512Mi


### PR DESCRIPTION
Second train follow-up, supersedes the memory-limit theory (#381 — harmless, kept): kubelet events show the real failure is `Startup probe failed: command timed out after 3s`. `mandate-daemon-health` cold-imports the package per exec; at 9ddc5c8 that exceeds 3s under the 250m cpu limit. Daemons themselves are healthy (heartbeat files fresh, status ok).

Values-only: `health.startup.timeoutSeconds: 15` + `health.liveness.timeoutSeconds: 15` for localWorker/callbackAdapter/gitDeliverer (deep-merge keeps periods/thresholds). Durable fix to ticket: stat-based probe instead of a package-importing interpreter.