### PR TITLE
Probe binding: test grants for post-train live verification (propose/orchestrate/approval.probe)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -55,3 +55,6 @@ bindings:
       allow:
         - mandate.deploy.smoke
         - agent_workloads.readonly_query
+        - approval.probe
+        - agent_workloads.opencode_propose
+        - agent_workloads.opencode_orchestrate

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -430,6 +430,9 @@ data:
           allow:
             - mandate.deploy.smoke
             - agent_workloads.readonly_query
+            - approval.probe
+            - agent_workloads.opencode_propose
+            - agent_workloads.opencode_orchestrate
   evals.yaml: |
     eval_suites:
       - id: eval.task_echo_smoke

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -502,7 +502,13 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             synthetic_binding["capabilities"]["allow"],
-            ["mandate.deploy.smoke", "agent_workloads.readonly_query"],
+            [
+                "mandate.deploy.smoke",
+                "agent_workloads.readonly_query",
+                "approval.probe",
+                "agent_workloads.opencode_propose",
+                "agent_workloads.opencode_orchestrate",
+            ],
         )
         self.assertEqual(synthetic_binding["users"].get("admins"), [])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])


### PR DESCRIPTION
Operator-acked extension of the `synthetic-live-verify-probe` binding so the post-CES-428 test ladder can exercise the rails no probe has touched on the new CP: model gateway (propose), **first live FrozenGrant child delegation** (orchestrate), approval park→resolve→resume (approval.probe). Registry overlay is boot-cached → sync + 4-pod restart after merge. Grants can be reverted after the test session if desired.