### PR TITLE
Probe binding: test-admin resolver for approval.probe resume verification

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -48,7 +48,8 @@ bindings:
       subject_kind: service
       tenant_id: garzai-prod
     users:
-      admins: []
+      admins:
+        - test-admin
       authorized:
         - mandate-live-probe
     capabilities:

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -423,7 +423,8 @@ data:
           subject_kind: service
           tenant_id: garzai-prod
         users:
-          admins: []
+          admins:
+            - test-admin
           authorized:
             - mandate-live-probe
         capabilities:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -510,7 +510,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
                 "agent_workloads.opencode_orchestrate",
             ],
         )
-        self.assertEqual(synthetic_binding["users"].get("admins"), [])
+        self.assertEqual(synthetic_binding["users"].get("admins"), ["test-admin"])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])
 
         self.assertIn(


### PR DESCRIPTION
Second test-grant PR (operator-acked). Adds `test-admin` to the probe binding admins so the parked `approval.probe` approval (admin_confirm, required_subjects test-admin) can be resolved and the resume→session-authority transition verified live. Fixtures synced (golden + overlay test).