### PR TITLE
Revert probe-binding test grants to least-privilege (post-CES-428 verification complete)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -48,14 +48,10 @@ bindings:
       subject_kind: service
       tenant_id: garzai-prod
     users:
-      admins:
-        - test-admin
+      admins: []
       authorized:
         - mandate-live-probe
     capabilities:
       allow:
         - mandate.deploy.smoke
         - agent_workloads.readonly_query
-        - approval.probe
-        - agent_workloads.opencode_propose
-        - agent_workloads.opencode_orchestrate

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -423,17 +423,13 @@ data:
           subject_kind: service
           tenant_id: garzai-prod
         users:
-          admins:
-            - test-admin
+          admins: []
           authorized:
             - mandate-live-probe
         capabilities:
           allow:
             - mandate.deploy.smoke
             - agent_workloads.readonly_query
-            - approval.probe
-            - agent_workloads.opencode_propose
-            - agent_workloads.opencode_orchestrate
   evals.yaml: |
     eval_suites:
       - id: eval.task_echo_smoke

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -502,15 +502,9 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             synthetic_binding["capabilities"]["allow"],
-            [
-                "mandate.deploy.smoke",
-                "agent_workloads.readonly_query",
-                "approval.probe",
-                "agent_workloads.opencode_propose",
-                "agent_workloads.opencode_orchestrate",
-            ],
+            ["mandate.deploy.smoke", "agent_workloads.readonly_query"],
         )
-        self.assertEqual(synthetic_binding["users"].get("admins"), ["test-admin"])
+        self.assertEqual(synthetic_binding["users"].get("admins"), [])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])
 
         self.assertIn(


### PR DESCRIPTION
The post-train test ladder passed end-to-end. Restore the `synthetic-live-verify-probe` binding to steady state (smoke + readonly_query, no admin resolver), reverting PRs #383 and #384. Boot-cached overlay → sync + 4-pod restart after merge.