### PR TITLE
Probe binding: temporary opencode_task grant for the CES-536 N=5 acceptance

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -55,3 +55,4 @@ bindings:
       allow:
         - mandate.deploy.smoke
         - agent_workloads.readonly_query
+        - agent_workloads.opencode_task

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -430,6 +430,7 @@ data:
           allow:
             - mandate.deploy.smoke
             - agent_workloads.readonly_query
+            - agent_workloads.opencode_task
   evals.yaml: |
     eval_suites:
       - id: eval.task_echo_smoke

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -502,7 +502,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             synthetic_binding["capabilities"]["allow"],
-            ["mandate.deploy.smoke", "agent_workloads.readonly_query"],
+            [
+                "mandate.deploy.smoke",
+                "agent_workloads.readonly_query",
+                "agent_workloads.opencode_task",
+            ],
         )
         self.assertEqual(synthetic_binding["users"].get("admins"), [])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])


### PR DESCRIPTION
Adds `agent_workloads.opencode_task` to the `synthetic-live-verify-probe` binding's allow list — one line, policy overlay only (no digests, no re-mint).

Mirrors the CES-428 train pattern: grant → N=5 verify → least-privilege revert (revert PR follows immediately after the run).

Refs CES-536, CES-537.