### PR TITLE
Probe binding: revert temporary opencode_task grant to least-privilege (CES-536 N=5 complete)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -55,4 +55,3 @@ bindings:
       allow:
         - mandate.deploy.smoke
         - agent_workloads.readonly_query
-        - agent_workloads.opencode_task

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -430,7 +430,6 @@ data:
           allow:
             - mandate.deploy.smoke
             - agent_workloads.readonly_query
-            - agent_workloads.opencode_task
   evals.yaml: |
     eval_suites:
       - id: eval.task_echo_smoke

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -502,11 +502,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertEqual(
             synthetic_binding["capabilities"]["allow"],
-            [
-                "mandate.deploy.smoke",
-                "agent_workloads.readonly_query",
-                "agent_workloads.opencode_task",
-            ],
+            ["mandate.deploy.smoke", "agent_workloads.readonly_query"],
         )
         self.assertEqual(synthetic_binding["users"].get("admins"), [])
         self.assertNotIn("approval_overrides", synthetic_binding["capabilities"])


### PR DESCRIPTION
Reverts #387 (merge `ea8be128`) — restores the `synthetic-live-verify-probe` binding, golden configmap fixture, and least-privilege test pin to `[mandate.deploy.smoke, agent_workloads.readonly_query]`.

The N=5 acceptance ran 5/5 green under the temporary grant (jobs `job_e3089446…`, `job_433240e5…`, `job_82990796…`, `job_48267ff9…`, `job_b379d727…` — evidence on CES-536).

Refs CES-536, CES-537.