### PR TITLE
[bot] Update Citrus dev image 6e93b1e471c87648a75a956d96da050c668603fe

### DIFF
--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: d1bfdebc0159fa4bb953de1d962f81f0025ad09c # allow-latest
+  tag: 6e93b1e471c87648a75a956d96da050c668603fe # allow-latest
 
 application:
   # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)


### PR DESCRIPTION
Automated dev image update from Citrus deployment workflow.

Source branch: `dev`
Source commit: `6e93b1e471c87648a75a956d96da050c668603fe`
Source commit subject: Merge pull request #52 from cesaregarza/cesar/ces-544-generate-tailwind-css-at-build-time-stop-committinggating