### PR TITLE
CES-538: restore generated registry-overlay restart hook

### DIFF
--- a/apps/agent-control-plane-registry-overlay/README.md
+++ b/apps/agent-control-plane-registry-overlay/README.md
@@ -23,7 +23,9 @@ The generated ConfigMap keeps the existing runtime shape:
 
 ## Sync behavior
 
-The control plane builds its `RegistrySnapshot` once at boot and never re-reads the mounted overlay, so every overlay change requires a restart of all four control-plane Deployments to take effect. The `PostSync` hook Job in `restart-hook.yaml`, using the narrowly scoped ServiceAccount/Role in `restart-rbac.yaml`, performs the rollout restart and waits on rollout status for each target deployment.
+The control plane builds its `RegistrySnapshot` once at boot and never re-reads the mounted overlay, so every overlay change requires a restart of all five control-plane Deployments to take effect. The `PostSync` hook Job in `hooks/restart-hook.yaml`, using the narrowly scoped ServiceAccount/Role in `restart-rbac.yaml`, performs the rollout restart and waits on rollout status for each target deployment.
+
+The hook is an Argo CD raw-directory source rather than a Kustomize resource: Kubernetes must receive its native `generateName` field so Argo creates a fresh hook Job on every sync. Kustomize requires a fixed `metadata.name`, which can cause an operation-resume to silently skip the hook.
 
 The Argo Application intentionally does not set `ApplyOutOfSyncOnly=true`; selective syncs skip hooks, which would skip the restart job and leave the control plane serving the previous boot-cached registry snapshot.
 

--- a/apps/agent-control-plane-registry-overlay/hooks/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/hooks/restart-hook.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: agent-control-plane-registry-overlay-restart
+  generateName: registry-overlay-restart-
   namespace: agent-control-plane
   labels:
     app.kubernetes.io/name: agent-control-plane
@@ -22,14 +22,14 @@ spec:
       restartPolicy: Never
       containers:
         - name: rollout-restart
-          # CES-108: the control plane boot-caches the registry snapshot; an
-          # overlay sync without a rollout leaves stale authority serving.
+          # CES-108/CES-538: the control plane boot-caches the registry
+          # snapshot; an overlay sync without a rollout leaves stale authority.
           image: alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
           command:
             - /bin/sh
             - -ec
             - |
-              deploys="agent-control-plane agent-control-plane-callback-adapter agent-control-plane-local-worker agent-control-plane-model-gateway"
+              deploys="agent-control-plane agent-control-plane-callback-adapter agent-control-plane-git-deliverer agent-control-plane-local-worker agent-control-plane-model-gateway"
               for d in $deploys; do
                 kubectl -n agent-control-plane rollout restart "deploy/$d"
               done

--- a/apps/agent-control-plane-registry-overlay/kustomization.yaml
+++ b/apps/agent-control-plane-registry-overlay/kustomization.yaml
@@ -4,7 +4,6 @@ namespace: agent-control-plane
 
 resources:
   - restart-rbac.yaml
-  - restart-hook.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
+++ b/apps/agent-control-plane-registry-overlay/restart-rbac.yaml
@@ -21,6 +21,7 @@ rules:
     resourceNames:
       - agent-control-plane
       - agent-control-plane-callback-adapter
+      - agent-control-plane-git-deliverer
       - agent-control-plane-local-worker
       - agent-control-plane-model-gateway
     verbs: ["get", "watch", "patch"]

--- a/argocd/applications/agent-control-plane-registry-overlay.yaml
+++ b/argocd/applications/agent-control-plane-registry-overlay.yaml
@@ -9,10 +9,17 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: splattop
-  source:
-    repoURL: https://github.com/cesaregarza/GarzAICluster
-    targetRevision: main
-    path: apps/agent-control-plane-registry-overlay
+  sources:
+    - repoURL: https://github.com/cesaregarza/GarzAICluster
+      targetRevision: main
+      path: apps/agent-control-plane-registry-overlay
+    # Kustomize requires metadata.name on resources. Keep the PostSync Job as
+    # a raw directory source so Kubernetes receives its native generateName.
+    - repoURL: https://github.com/cesaregarza/GarzAICluster
+      targetRevision: main
+      path: apps/agent-control-plane-registry-overlay/hooks
+      directory:
+        recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-control-plane

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -100,7 +100,10 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             REPO_ROOT / "argocd" / "projects" / "splattop-project.yaml"
         )
         cls.registry_overlay_restart_hook = _load_yaml(
-            REGISTRY_OVERLAY_DIR / "restart-hook.yaml"
+            REGISTRY_OVERLAY_DIR / "hooks" / "restart-hook.yaml"
+        )
+        cls.registry_overlay_restart_rbac = _load_yaml_documents(
+            REGISTRY_OVERLAY_DIR / "restart-rbac.yaml"
         )
         cls.model_gateway_controls = _load_yaml(
             REPO_ROOT
@@ -113,8 +116,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         kustomization = _load_yaml(REGISTRY_OVERLAY_DIR / "kustomization.yaml")
         self.assertFalse((REGISTRY_OVERLAY_DIR / "configmap.yaml").exists())
         self.assertEqual(kustomization["kind"], "Kustomization")
-        self.assertIn("restart-rbac.yaml", kustomization["resources"])
-        self.assertIn("restart-hook.yaml", kustomization["resources"])
+        self.assertEqual(kustomization["resources"], ["restart-rbac.yaml"])
+        self.assertTrue(
+            (REGISTRY_OVERLAY_DIR / "hooks" / "restart-hook.yaml").exists()
+        )
+        self.assertFalse((REGISTRY_OVERLAY_DIR / "hooks" / "kustomization.yaml").exists())
         self.assertTrue(kustomization["generatorOptions"]["disableNameSuffixHash"])
 
         generator = next(
@@ -272,6 +278,13 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertNotIn("kubectl create -f", script)
 
     def test_registry_overlay_restart_hook_runs_without_selective_sync(self) -> None:
+        expected_deployments = [
+            "agent-control-plane",
+            "agent-control-plane-callback-adapter",
+            "agent-control-plane-git-deliverer",
+            "agent-control-plane-local-worker",
+            "agent-control-plane-model-gateway",
+        ]
         annotations = self.registry_overlay_restart_hook["metadata"]["annotations"]
         self.assertEqual(annotations["argocd.argoproj.io/hook"], "PostSync")
         self.assertEqual(
@@ -279,10 +292,47 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "BeforeHookCreation",
         )
         self.assertEqual(
-            self.registry_overlay_restart_hook["metadata"]["name"],
-            "agent-control-plane-registry-overlay-restart",
+            self.registry_overlay_restart_hook["metadata"]["generateName"],
+            "registry-overlay-restart-",
         )
-        self.assertNotIn("generateName", self.registry_overlay_restart_hook["metadata"])
+        self.assertNotIn("name", self.registry_overlay_restart_hook["metadata"])
+
+        restart_script = self.registry_overlay_restart_hook["spec"]["template"]["spec"][
+            "containers"
+        ][0]["command"][-1]
+        self.assertEqual(
+            restart_script.split('deploys="', 1)[1].split('"', 1)[0].split(),
+            expected_deployments,
+        )
+        restart_role = next(
+            document
+            for document in self.registry_overlay_restart_rbac
+            if document["kind"] == "Role"
+        )
+        restart_rule = next(
+            rule
+            for rule in restart_role["rules"]
+            if rule["resources"] == ["deployments"] and "resourceNames" in rule
+        )
+        self.assertEqual(restart_rule["resourceNames"], expected_deployments)
+
+        self.assertNotIn("source", self.registry_overlay_application["spec"])
+        self.assertEqual(
+            self.registry_overlay_application["spec"]["sources"],
+            [
+                {
+                    "repoURL": "https://github.com/cesaregarza/GarzAICluster",
+                    "targetRevision": "main",
+                    "path": "apps/agent-control-plane-registry-overlay",
+                },
+                {
+                    "repoURL": "https://github.com/cesaregarza/GarzAICluster",
+                    "targetRevision": "main",
+                    "path": "apps/agent-control-plane-registry-overlay/hooks",
+                    "directory": {"recurse": False},
+                },
+            ],
+        )
 
         sync_options = set(
             self.registry_overlay_application["spec"]["syncPolicy"].get(


### PR DESCRIPTION
## Summary
- Restore the registry-overlay PostSync hook as a native generated Job through a raw Argo CD directory source.
- Restart all five boot-cache consumers, including `agent-control-plane-git-deliverer`, with matching least-privilege RBAC.
- Cover the source split, hook lifecycle, rollout targets, and RBAC in tests.

## Root cause
Kustomize requires a fixed `metadata.name`, which regressed the CES-108 hook behavior. A fixed-name PostSync Job can be silently skipped when Argo resumes an operation. The raw source preserves Kubernetes `generateName` plus `BeforeHookCreation`.

## Validation
- `pytest tests/test_agent_control_plane_registry_overlay.py -q` (15 passed)
- `pytest tests/test_agent_control_plane_registry_compat.py -q` (10 passed)
- `pytest tests -q` (101 passed)
- pinned Kustomize registry-overlay render gate
- `git diff --check`

Ref: CES-538