### PR TITLE
[bot] Update Citrus dev image 44a0bfcb4220baee0f846e503688e251a96c88b5

### DIFF
--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 6e93b1e471c87648a75a956d96da050c668603fe # allow-latest
+  tag: 44a0bfcb4220baee0f846e503688e251a96c88b5 # allow-latest
 
 application:
   # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)


### PR DESCRIPTION
Automated dev image update from Citrus deployment workflow.

Source branch: `dev`
Source commit: `44a0bfcb4220baee0f846e503688e251a96c88b5`
Source commit subject: Merge to recover CES-515 + CES-544 after dev rewind