### PR TITLE
CP bump f054783 → 176b406 (CES-556 worker-service grant fix)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-f054783b7eb5
+  tag: sha-176b406e8b32
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: f054783b7eb59371ccb7c6bd1363a93235c59504
+      targetRevision: 176b406e8b32131e38301e41f6f7d8927a867bd3
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-f054783b7eb5` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-176b406e8b32` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-f054783b7eb5
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-176b406e8b32
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Makes the CES-556 fix (ap#353, merged `176b406`) live in prod.

**Delta f054783..176b406 = only CES-556** (worker-service grant projection). CP-image-only bump:
- `values.yaml` image.tag → `sha-176b406e8b32` (DOCR-verified `sha256:634bf9d5…`)
- chart `targetRevision` → `176b406e8b32…`
- postgres-restore runbook image ref synced
- **No** migrations, overlay/registry change, aw re-pin, or token re-mint. Provider pins unchanged (no adapter delta; referee matches 176b406).

Post-merge: sync + roll CP, then readonly_query live-verify (the CES-556 acceptance).