### PR TITLE
CES-559/CES-564 Ship time-governed readonly-query train

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -11,8 +11,8 @@
       "consequence_class": "read_only"
     }
   },
-  "code_digest": "sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3",
-  "digest": "sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d",
+  "code_digest": "sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8",
+  "digest": "sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b",
+    "digest": "sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -1,6 +1,8 @@
 defaults:
   max_cost_usd_per_job: 10.0
   max_runtime_seconds_per_job: 60
+  max_runtime_seconds_per_capability:
+    agent_workloads.readonly_query: 180
   aggregate_budget:
     platform_daily_usd: 250.0
     per_capability_daily_usd_default: 100.0

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -76,7 +76,7 @@ imports:
         max_rows: 50
         max_runtime_seconds: 120
         max_cost_usd: 10.0
-        statement_timeout_ms: 60000
+        statement_timeout_ms: 20000
         max_concurrency: 1
         operation_max_influence:
           select_limited: external

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d
-  image_digest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+  manifest_digest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+  image_digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -49,9 +49,9 @@ imports:
         allowed_tier: fast
         allowed_profiles:
         - openai.gpt-5.3-codex-spark
-        max_prompt_tokens: 12000
-        max_completion_tokens: 32000
-        max_total_tokens: 44000
+        max_prompt_tokens: null
+        max_completion_tokens: null
+        max_total_tokens: null
         max_cost_usd: 10.0
         max_influence: external
       broker_bounds:

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-e11e13262fb0
+  tag: sha-bc4f2b7b2702
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -45,7 +45,7 @@ apiExtraSecretRefs:
 
 env:
   AGENT_PLATFORM_ENVIRONMENT: prod
-  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2a3b6afc068849e07f65badc6a2ac83f1062ba062b3c8085d6188c2b28a45d64","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:73203a3ff8309cb762966f7559abf871f46a239c3136e7a5658eb069f52066c1","protocol":"readonly_sql"}}'
+  AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2010eb78000580e9bc9ad74b57b70500318014a397193133005fae153b39c336","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:73203a3ff8309cb762966f7559abf871f46a239c3136e7a5658eb069f52066c1","protocol":"readonly_sql"}}'
   AGENT_PLATFORM_OUTPUT_GATE_BACKEND: patch_aware
   AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE: "0"
   AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE: "2"
@@ -143,7 +143,7 @@ modelGateway:
   enabled: true
   replicaCount: 1
   env:
-    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2a3b6afc068849e07f65badc6a2ac83f1062ba062b3c8085d6188c2b28a45d64","protocol":"model_gateway"}}'
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:2010eb78000580e9bc9ad74b57b70500318014a397193133005fae153b39c336","protocol":"model_gateway"}}'
   codexAuthPersistence:
     enabled: true
     accessModes:

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-fd92e9ef7932
-  digest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+  tag: sha-542d160a0a38
+  digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -38,7 +38,7 @@ extraVolumeMounts:
   mountPath: /var/run/mandate/workload-identity
   readOnly: true
 rolloutChecksums:
-  workloadIdentityTokenSecret: sha256:71f41fffb7a25950fdc76f08f3e6832d649507f02039a3ef8b9cb6dd5e00f2f9
+  workloadIdentityTokenSecret: sha256:d0133e27a2be7a989dd75bfe9ec44c9eec2f562988c1beb025c25b1ac7da5c8d
 resources:
   requests:
     cpu: 25m
@@ -221,9 +221,9 @@ opencodeApplyExecutor:
       memory: 512Mi
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3
-    manifestDigest: sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d
-    imageDigest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+    codeDigest: sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8
+    manifestDigest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+    imageDigest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   opencode.apply_executor:
     codeDigest: sha256:84cb43d1172b7ee7340a716802643c5e0484b0f027ba62265336880071a0daa8
     manifestDigest: sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: e11e13262fb04a30cc991d93480bf2237ad53d3e
+      targetRevision: bc4f2b7b27027a929113d103694001513a00e14e
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-e11e13262fb0` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-bc4f2b7b2702` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-e11e13262fb0
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-bc4f2b7b2702
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets

--- a/secrets/agent-workloads/workload-identity-tokens.enc.yaml
+++ b/secrets/agent-workloads/workload-identity-tokens.enc.yaml
@@ -4,12 +4,17 @@ metadata:
     name: agent-workloads-workload-identity-tokens
     namespace: agent-workloads
 stringData:
-    MANDATE_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:ZmcahZpHcwDWWF3hxQzLRt9MnAfUY4uhJ7YF8JCDUHZpxZrwIs391KeElYTktBgExHNN6d7GfqN4H8xUrGaI/1alGvR42eo3aUo/bbnRgENK21iR5aFAYRDsbLxQvo1IbqycnCbiYIxGOWGAaSxnh8WM1JxQdCxdi6duE0rygsXJs0c2ojsC4lQAzN5Vx0ZdHKCTkLizNrRJbHPPAXDL6M+5tnmlWLXfQ17NGN5xfPlU18nY/MRTojg0rcDyolKp5Aj2fUaQk7+0D4IoeE+581zB1lD+KDZSJF8FUWK21MeDQD1sRf5eI/hN9Ll0sfTmHBY1/pV6oMEeGQPIwKtOkKdJnjSVRXhNGuKHnRtrgOh8J+gVt6M/wqfreFJW1errrgI7yg7qaOzOrfsfqzQYhs39AtQBRlZZCh7haBI6IowdnQcYIHpPLzibESou3wXLZtDxrNSRhoerDslvKcmf4xBjZGxxkjKmBwucEBNk3U38F+DRy2Co3LN8SDE8cIY3b45j3eWsczFRs8xbQbh+OKiEWYoxE6HGkFk8KZs6T/0Wi6V8m0lmsP2rluJpxeM4XFNzqc/XTtxnqxVe0fpoL7qz9WakdefklRkD3d5LmBr9/Y3P2YMlEXhTNuZR/SOXFyKgBWAJdi2v97neSoW01cPH66AblYGWpBxpi2jt3sGO4nOBLbHLRenkrneeKG1yhJ84OacdoETave1GKKr/Y0O1PtAlZ5fuCbL6UeKE6Q4GiboPE//P2tL+CpSa59B1l1mRL3uTtCQKlNP/etzcOpjUHin3YjbP5g49TPiCpnBb+Wqxm31/eKdciEUlXMivvrVnti2N8CDvoymdqrqgl5SUwRlq16Vnfjm835pztfEd3VeBxCfvBdbLxgHGvkGI9BDMvnlCXz0McDJPCCYstKiSRoTrrXWfj9DdD907,iv:aE8zy6pj+zz3TnoXBoM0F36tWkNh9Opaoez+aezPUdo=,tag:cp5Domgt7a462DJr96wQnw==,type:str]
+    MANDATE_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:NW8YLFdad+429TcWThgS6GhcYzk6z5rsTbcvgOopjML36rxNAAXuU/Scyppw9nVxjWUJi2L3ykTJITKi6O/JLtqxISb6AdQvwhl5uTALSUXIQ/9uAyRN0Wtme1KOv02HnyKZ4zbzITCeT0ZOTL8UzJaRSeohKMFmO6fvhSfff7K9xRARtIB5JN38hKr8eDo+4OYyWP1KPM4ovv3Xrhjc2s10Doi9Q31sXwD5nOVfaJgcygeA1q5NiVq1ngJhMdgDLDlf3q4NbDm2bfgmY0zZgsuA/PqDic9Yo1aZ8fZWMGVNb15bKdeZxgPZVksIXbIZHrqlLif++wDAuVOBmdIbrhO2EZNsigp2dQszE2a/WGV5hMt4S4nHSdfMMYLTNSeDOe73BZBHZCdZu4ZFhWmKXGL9ANoK6ZK1s/pEsWTL4G8fA4Wm08j5vWayWyxTTQrmGfYa1gMeX3Y7ozsEf+ILNDizQVXv+3CEtJXGfEOH9ZvrJhw930oB5grNHqRYzciv64GKbczNidQgfg71izFy6IR5+W4yLRmmQX8znn8Y1Ple0iyjkd/QTtMukGxnNu/jzP3QQxWizl8BSWSO6IsAM/+Iwf3EiVlYS/DjID7YJK7WgVnc0sU8XoDGHj8WoMXz9OHQ5CuglsV+x+s0mgjeQvRE9ov0Thww93Qh6+4ggeMY014lCx4WbbUxBu1d3OB1qhUXs3jDMbvlmsDv73LSHkuUhDOrkqMDGtnMaFtd76Xp3dO/WSvD0TmLdr3AQPMxQDqMYmE6tbo6xBZ1ng+b77RxDo7ZxzhVBsgEXoqn4UpJTYzSjguRBwlpBTSdOfK9KyRoqeZIiaUxWJWk3i9x2SSA1ia43GA4M5e+EBOLjdIoFjfjLc4bmymFIEmFx35MYQw5dIf3y0+ptgypnvF26cq3O4WLNG4tP0JMJsj0,iv:0skmc2qWAVWfqMFjS5SaG57/nHgbOBONZIV4BqmmFW0=,tag:qnkpivIZw9UlR1LactkFrw==,type:str]
     OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:YJfMNktvVcBlFSDy/THVhGjD7GLMSqmkWPC5GT7lKBUUlMdHFfcrnGOhrpIpCO4Fo298KM+5Mo7k4KFiu/2XqU6/AX3iYXpMbBsgyoVrI1uhog9hrBrBNyWUKjdgKLAltQEzh1y978L6YhJAZoBvnPvHpGJ9UA99/9/nb/0Maq3ZBDIYVY7CbMg0Isn0HB9wSNPxYK116M0vLCsc0GrLSD6OgUQlkhTWpRHOWhWRQx/AB7rr9TxhYFK+xvj6iuHEzBKfdXnh9zAHAX5G+VYMgOjFuov3iitZi0mtQj0HFQYv1qRDRcSdSMLEjGEcpFtFEi3pUbFPlpBb8Uerf61Io4GMl+5K7a1iwhV+sAXJBTogmDiA9sbPyQIA9UyUGvoiSqGhGnuNbMF2vAs4gVX0dZC1iS8ntsT/0uTbWePKPzOP49sozY+jwuo0RGgbVNXfHFMScoi2oKdfTnZIosyLljHmYcunxZG0ViIp2Z+bT1QY++iAxe3y2evNxD2rsxytuAnGED/yWKlrkQ0sTGCDSinM89J68EyosbYoh4rvDLt3aFTjHH1YCfQcOEpajfeXX+WEw1vylxTCC2UvHu6y6HXApU9WlJrzklJjvPWbAn73lWEBGmiTsudlC+1HUTkKBNWlNqVgFtEJmWniNxqbQTK354MPa/3ghQw1hHzmMDmcn/BKrlAn7dWlaxyXpS/0QfXBV1TVQ1ub8Fbpw23x0rEjefdNz8OtIywWOPCQCFUX0Gq6qNe3GnHgFlvA4dmLKv8d8JdS2XuuFgWW6iERVPE3Nfeabh+hAHC2FkiX5UDWmlZcYuOcAwjcYuXW7k0YDqEWM2kE8B0kI0KL2wZy/o21e7f9RwF2KzlL60yswcdTxjTz9+i9mzEdutDbZJqE2Qo0DEouO2gVtfEYX1QST+DDaMZ1yFWf/CZZYsgV8Fhaww==,iv:sj/xDcuBeanP2hi/qpgKP6AATGQa4lej4C8n7msk1uI=,tag:nyEMuqvVr8udMglFup4Zmg==,type:str]
     OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN: ENC[AES256_GCM,data:Db0RAhv4FS/+idVmLN5MhEnxcPotYKjct6cv7WQyTgujecwArHMTr+m8A3rIrH2qAA+s/BxsFQEOMz7ZQTh1rv0sODCFR+kTAxA+tLP7cROnSmI5n929WjIg6feta3LATffgSPJnNpKjzDLvB4aiu+C90BzHQXN3NZttFFb8A3xTiDfl32ZinactDhNaSXxPER0Mb4hIptgj1Ky3I/a+B/rCreETuQJSHY6z+w4qXkUdEceBLmQHB710ItD4Uy1oxXl9Na41GV+XUt38XBuyHLDXvFdsc8xVsEq9ZUH6J8/wgxLsDYGYJdB0aiikd/eJCjtWwgTKrQFBsAyho9lFcT/ohuqHIqZDz9moJd19uOf58NH+F6GElbGE9T2YIcZHG+c5QD7rAk3HAjTQnnxLDOCEf85GJ0uWvWyqO38V6NDZ0mINikbh8liNsChKLWs5nbGrN/8mTv8y8GlY768jT3Rafwt8YozpUzHmBYkcy/ULnRnc8VifenYAJ891ZVqhWXsreaxiNswOnkdmLXdTI+HaPb3n9xfrq/uDwIqQOj9FkF/z9yvGiS8q6AM6QjTwk6MpMbgOv8YpThw5ZfSUWCK53b7K4xEciiLxfoaoLbZQWOJS47uCg43cfK4Cza/KYj6MOuPzE/Bq2fXgm6LX4m26hv1YET8roKyRf4zDSNVI8KIYebHzrsVkkWJmIEzUq2odsmr/wvK8S/678687uXprZPQiz1rOQirJ23cpr2mKp2BZ4fEZJxhBhItKBSqBAs2YP5Y5SVrQpDmWuiIk7SKFW82iOfqXjS72v4dzeEjArF7/CV5JpMMet8+L+P7ABHLvwlieQIjiBbYemtjmKcIybyzZgSICl0rOa9wMOLjnBx4N7olJL5hpqQksAvLGKpOor2xExs57x+S0WbJ7YGNAAqiTWJQZvU8=,iv:EZxDMFUVjzwWdHAUpGxsgHDy7bhScfHObYPlKcZWcog=,tag:rooNDW+Euf/gd6X3op+NvA==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
-        - enc: |
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6bWJjaFpHejZRcDNvdEpw
             ejh0NTdmMUNQbnNXUGRlLzNDemprcFlIUFRjCnhDRk5EL1JpUEJwL1JGTkZiZFk5
@@ -17,8 +22,8 @@ sops:
             elhBbmNaQU12V1VEazZvNmMzMnVVc2cK54KGVzace5S+PzkS4Pkle0YcCnVEiRYw
             FtKIGYnWfqSicoG90bOUFpeBMNyBjP6O8hen14EBiNOP6cZp0dEmuA==
             -----END AGE ENCRYPTED FILE-----
-          recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
-        - enc: |
+        - recipient: age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau
+          enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjb2Q0eTZXYnMwM0xlNlA5
             elI1elNWVndZc2hWRnRzMUVrSmZkeGk1WFFJCjYrWEQxY3IvR0ZsaC9nMENqQVJQ
@@ -26,8 +31,8 @@ sops:
             a05LWTdDdmpQV3dEYVV1N3NVNExWY1EK2COVjLEdBCguAPlDBNHekmbrLZXBNr73
             SR9inZz4J/vADyuvxCEGoOAzwoA7VK5YuCcfG8SjseopEbZfSMfyNg==
             -----END AGE ENCRYPTED FILE-----
-          recipient: age1qny3qstwqglwdyau5x7sp3vy0qmd3petzp4f3slf7u3qrudhdq0qf4cjau
+    lastmodified: "2026-07-16T00:52:10Z"
+    mac: ENC[AES256_GCM,data:vdH0f97/TqHEaCfwEPVrrwOnXhxlovrBcKLuX2fGnbYd8NDxJTmiPdC7y4/GFqjzZaUOIU/C2QtLxVM8sPjRDlKkxMup0JIH6ejEa0Ta7RZk7lJXNHscHLWUlbKWUCBfK/HlegyR2jFGLgvTVNchwYUHC/TgPnEMyyrMFqElTec=,iv:eOv85aLoaojSOUI9VvRD183cSG+7AhoGCy99Hrgi9qQ=,tag:SLpZ9M2WLowJPjK0ys2Dlw==,type:str]
+    pgp: []
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-14T07:33:49Z"
-    mac: ENC[AES256_GCM,data:RdRACBj7Sy0gLnPmhHg4yvPYyMnWPzZdCInAd6uuRm1nWXThNQVLTtg7XvjDzlzsQMv43zW090C0Rc49OfdvkC/RMb1sP/CSBkbCXGIXzjfLRZu6DQt40Rsh2X6ou2ukgILu9ymIRnYJy4OEJrAvwquo1J7yZ89giDoyyJqmhJQ=,iv:0aRUizNs+bmUyMalkFv+xRlEV6dy69l1nNJB8wjkyvQ=,tag:HoS21IN6qunEFkW13C2KBQ==,type:str]
     version: 3.13.2

--- a/secrets/agent-workloads/workload-identity-tokens.metadata.yaml
+++ b/secrets/agent-workloads/workload-identity-tokens.metadata.yaml
@@ -4,20 +4,20 @@ tokens:
   data.workspace_probe:
     agent_id: data.workspace_probe
     token_key: MANDATE_WORKLOAD_IDENTITY_TOKEN
-    code_digest: sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3
-    manifest_digest: sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d
-    image_digest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
-    bundle_digest: sha256:325f20d4660762da9ba875d59024c838202c49a9da9a65bd3cbb746dfab8a211
-    iat: 1784014330
-    exp: 1791790330
+    code_digest: sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8
+    manifest_digest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+    image_digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
+    bundle_digest: sha256:7463afe5ad220c6c443f936bf22a2b5e75789a069d2b926d3ac4d492649ed6c5
+    iat: 1784163130
+    exp: 1791939130
     iss: kubernetes
     sub: data.workspace_probe
     aud: mandate-api
     scp:
-    - worker_service
+      - worker_service
     digest_spec_version: agent-workloads-code-digest-v2
-    source_commit: fd92e9ef7932fcc6304c73ea593bd30c04805951
-    ciphertext_sha256: sha256:71f41fffb7a25950fdc76f08f3e6832d649507f02039a3ef8b9cb6dd5e00f2f9
+    source_commit: 542d160a0a38e65902fa83f7bfcf9b8ae1add673
+    ciphertext_sha256: sha256:d0133e27a2be7a989dd75bfe9ec44c9eec2f562988c1beb025c25b1ac7da5c8d
   opencode.apply_executor:
     agent_id: opencode.apply_executor
     token_key: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -31,10 +31,10 @@ tokens:
     sub: opencode.apply_executor
     aud: mandate-api
     scp:
-    - worker_service
+      - worker_service
     digest_spec_version: agent-workloads-code-digest-v2
     source_commit: fd92e9ef7932fcc6304c73ea593bd30c04805951
-    ciphertext_sha256: sha256:71f41fffb7a25950fdc76f08f3e6832d649507f02039a3ef8b9cb6dd5e00f2f9
+    ciphertext_sha256: sha256:d0133e27a2be7a989dd75bfe9ec44c9eec2f562988c1beb025c25b1ac7da5c8d
   opencode.proposer:
     agent_id: opencode.proposer
     token_key: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -48,7 +48,7 @@ tokens:
     sub: opencode.proposer
     aud: mandate-api
     scp:
-    - worker_service
+      - worker_service
     digest_spec_version: agent-workloads-code-digest-v2
     source_commit: fd92e9ef7932fcc6304c73ea593bd30c04805951
-    ciphertext_sha256: sha256:71f41fffb7a25950fdc76f08f3e6832d649507f02039a3ef8b9cb6dd5e00f2f9
+    ciphertext_sha256: sha256:d0133e27a2be7a989dd75bfe9ec44c9eec2f562988c1beb025c25b1ac7da5c8d

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -3,12 +3,12 @@ data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_w
     ,\n    \"agent_workloads.readonly_query\"\n  ],\n  \"capability_metadata\": {\n\
     \    \"agent_workloads.db_probe\": {\n      \"consequence_class\": \"reversible_staging\"\
     \n    },\n    \"agent_workloads.readonly_query\": {\n      \"consequence_class\"\
-    : \"read_only\"\n    }\n  },\n  \"code_digest\": \"sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3\"\
-    ,\n  \"digest\": \"sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d\"\
+    : \"read_only\"\n    }\n  },\n  \"code_digest\": \"sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8\"\
+    ,\n  \"digest\": \"sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79\"\
     ,\n  \"display_name\": \"Agent Workloads Data Worker\",\n  \"evals\": {\n    \"\
     optional\": [],\n    \"required\": [\n      \"eval.test_agent_probes\",\n    \
     \  \"eval.readonly_sql_safety\"\n    ]\n  },\n  \"id\": \"data.workspace_probe\"\
-    ,\n  \"image\": {\n    \"digest\": \"sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b\"\
+    ,\n  \"image\": {\n    \"digest\": \"sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e\"\
     ,\n    \"repository\": \"registry.digitalocean.com/sendouq/agent-workloads-worker\"\
     \n  },\n  \"loop\": {\n    \"contract\": \"worker_service_v1\",\n    \"kind\"\
     : \"worker_service\",\n    \"protocol\": \"mandate_worker_service_pull_v1\"\n\
@@ -132,8 +132,8 @@ data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_w
     \      allow:\n        - mandate.deploy.smoke\n        - agent_workloads.readonly_query\n",
   workload_imports.yaml: "schema_version: workload-imports.v1\nimports:\n- id: data.workspace_probe\n\
     \  manifest_path: registries/imports/agent-data.workspace_probe.json\n  manifest_digest:
-    sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d\n  image_digest:
-    sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b\n  expected_source:\n\
+    sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79\n  image_digest:
+    sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e\n  expected_source:\n\
     \    repo: agent-workloads\n    repo_url: https://github.com/cesaregarza/agent-workloads\n\
     \    path: agents/db-workspace-probe/agent.yaml\n  agent:\n    execution_posture:
     capability_worker\n    network_access: database_only\n    service_account_ref:
@@ -152,8 +152,8 @@ data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_w
     \       broker_required: true\n      broker:\n        allowed_broker: readonly-sql-broker\n\
     \        allowed_presets:\n        - analytical-read\n      model_bounds:\n  \
     \      required: true\n        allowed_tier: fast\n        allowed_profiles:\n\
-    \        - openai.gpt-5.3-codex-spark\n        max_prompt_tokens: 12000\n    \
-    \    max_completion_tokens: 32000\n        max_total_tokens: 44000\n        max_cost_usd:
+    \        - openai.gpt-5.3-codex-spark\n        max_prompt_tokens: null\n    \
+    \    max_completion_tokens: null\n        max_total_tokens: null\n        max_cost_usd:
     10.0\n        max_influence: external\n      broker_bounds:\n        required:
     true\n        preset: analytical-read\n        allowed_source_schemas:\n     \
     \   - xscraper\n        allowed_tables:\n        - xscraper.players\n        -

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -106,7 +106,8 @@ data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_w
     ,\"capability\":\"agent_workloads.opencode_propose\",\"input\":{\"text\":\"Draft
     a bounded proposal.\"},\"expected\":{\"status\":\"succeeded\",\"artifact_class\"\
     :\"opencode_proposal\"}}\n", policy.prod.yaml: "defaults:\n  max_cost_usd_per_job:
-    10.0\n  max_runtime_seconds_per_job: 60\n  aggregate_budget:\n    platform_daily_usd:
+    10.0\n  max_runtime_seconds_per_job: 60\n  max_runtime_seconds_per_capability:\n\
+    \    agent_workloads.readonly_query: 180\n  aggregate_budget:\n    platform_daily_usd:
     250.0\n    per_capability_daily_usd_default: 100.0\n    per_capability_daily_usd:\n\
     \      agent_workloads.opencode_apply: 1.0\n      agent_workloads.opencode_propose:
     1.0\n\nbindings:\n  - id: private-admin-controlled-capabilities\n    description:
@@ -161,7 +162,7 @@ data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_w
     xscraper.schedules\n        allowed_operations:\n        - describe_schema\n \
     \       - describe_table\n        - select_limited\n        - explain_safe\n \
     \       - aggregate_summary\n        max_rows: 50\n        max_runtime_seconds:
-    120\n        max_cost_usd: 10.0\n        statement_timeout_ms: 60000\n       \
+    120\n        max_cost_usd: 10.0\n        statement_timeout_ms: 20000\n       \
     \ max_concurrency: 1\n        operation_max_influence:\n          select_limited:
     external\n- id: opencode.proposer\n  manifest_path: registries/imports/agent-opencode.proposer.json\n\
     \  manifest_digest: sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307\n\

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -849,7 +849,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             {
                 "digest": (
                     "sha256:"
-                    "2a3b6afc068849e07f65badc6a2ac83f1062ba062b3c8085d6188c2b28a45d64"
+                    "2010eb78000580e9bc9ad74b57b70500318014a397193133005fae153b39c336"
                 ),
                 "protocol": "model_gateway",
             },

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -153,6 +153,8 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             readonly_query["skills"],
             ["xscraper-schema", "xscraper-glossary"],
         )
+        self.assertEqual(readonly_query["broker_bounds"]["max_runtime_seconds"], 120)
+        self.assertEqual(readonly_query["broker_bounds"]["statement_timeout_ms"], 20000)
 
         skills = self.control_plane_values["skills"]
         self.assertEqual(
@@ -572,6 +574,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             "admin_confirm",
         )
         self.assertEqual(policy["defaults"]["max_cost_usd_per_job"], 10.0)
+        self.assertEqual(policy["defaults"]["max_runtime_seconds_per_job"], 60)
+        self.assertEqual(
+            policy["defaults"]["max_runtime_seconds_per_capability"],
+            {"agent_workloads.readonly_query": 180},
+        )
         self.assertEqual(
             policy["defaults"]["aggregate_budget"]["per_capability_daily_usd"][
                 "agent_workloads.opencode_propose"


### PR DESCRIPTION
## Summary

- Complete the CES-559 production budget tuple for `agent_workloads.readonly_query`: 180s whole job, 120s broker operation, and 20s SQL statement timeout.
- Pin the reviewed CES-564 control plane at `bc4f2b7b27027a929113d103694001513a00e14e` / `sha-bc4f2b7b2702` and refresh its model-gateway provider fingerprint.
- Pin only `data.workspace_probe` at agent-workloads `542d160a0a38e65902fa83f7bfcf9b8ae1add673` / `sha-542d160a0a38`.
- Clear the live prompt, completion, and total token caps explicitly while retaining the `$10` cost cap and exact Spark profile restriction.
- Re-mint only the `data.workspace_probe` workload identity token against the new code, manifest, image, and bundle digests; update the encrypted token ledger and rollout checksum.

This is the coordinated GitOps release train for [CES-559](https://linear.app/cegarza/issue/CES-559/readonly-query-60s-job-lease-ttl-120s-broker-query-budget-real) and [CES-564](https://linear.app/cegarza/issue/CES-564/readonly-query-remove-token-caps-entirely-govern-by-time).

## Immutable provenance

| component | source | image tag | image digest |
| --- | --- | --- | --- |
| control plane | `bc4f2b7b27027a929113d103694001513a00e14e` | `sha-bc4f2b7b2702` | `sha256:2cecd37024740dcdc24ecefa434e0daffcca443d9fffc3c739b88f74192fbe04` |
| `data.workspace_probe` | `542d160a0a38e65902fa83f7bfcf9b8ae1add673` | `sha-542d160a0a38` | `sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e` |

Data-worker identity bundle:

- code: `sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8`
- release manifest: `sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79`
- bundle: `sha256:7463afe5ad220c6c443f936bf22a2b5e75789a069d2b926d3ac4d492649ed6c5`

The OpenCode proposer and apply-executor image pins and identity claims are unchanged. Only their shared ciphertext checksum metadata changes because the encrypted token Secret changed.

## Required rollout order

The control-plane and workload Applications are both sync wave `10`; merge alone does not enforce runtime ordering.

1. Sync `agent-control-plane` and wait for the `bc4f2b7b…` rollout to become healthy.
2. Sync `agent-control-plane-registry-overlay` and wait for the control-plane restart hook/health checks.
3. Sync `agent-workloads-secrets`, then `agent-workloads`, and wait for the `data.workspace_probe` rollout.

Do not sync the reminted worker before the CES-563 truncation handling and CES-564 reservation-only authorization in the pinned control plane are live.

## Source prerequisites

- CES-559 platform support: https://github.com/cesaregarza/agent-platform/pull/355 (merged)
- CES-559 worker alignment: https://github.com/cesaregarza/agent-workloads/pull/94 (merged)
- CES-564 platform support: https://github.com/cesaregarza/agent-platform/pull/357 (merged)
- CES-564 worker support: https://github.com/cesaregarza/agent-workloads/pull/101 (merged)

## Validation

- Exact-sha `main` CI passed for both source repositories.
- Both immutable image publications passed; the control-plane image smoke test passed.
- `data.workspace_probe` release-helper dry run passed before mutation.
- Workload identity digest gate passed against decrypted claims.
- Real Kustomize registry-overlay render/golden gate passed.
- Registry compatibility passed against exact platform commit `bc4f2b7b…`.
- Provider-fingerprint and control-plane release-pin gates passed.
- Full GarzAICluster contract suite: 101 tests passed.
- Agent-workloads and control-plane Helm lints passed.
- `git diff --check` passed.

## Superseded automation PR

The publish workflow also opened #400, which re-pins all three workers without re-minting their identities and therefore fails the identity-drift gate. This scoped, fully re-minted train supersedes it.
