### PR TITLE
CES-96: re-pin agent-workloads sha-542d160a0a38

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -11,8 +11,8 @@
       "consequence_class": "read_only"
     }
   },
-  "code_digest": "sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3",
-  "digest": "sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d",
+  "code_digest": "sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8",
+  "digest": "sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b",
+    "digest": "sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.apply_executor.json
@@ -7,8 +7,8 @@
       "consequence_class": "consequential"
     }
   },
-  "code_digest": "sha256:84cb43d1172b7ee7340a716802643c5e0484b0f027ba62265336880071a0daa8",
-  "digest": "sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59",
+  "code_digest": "sha256:fd8fe0f98eaaeee1e13989fbcd88f8ddc127f4b98b66a0cbae9085d57f55347b",
+  "digest": "sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c",
   "display_name": "OpenCode Apply Executor",
   "evals": {
     "optional": [],
@@ -18,7 +18,7 @@
   },
   "id": "opencode.apply_executor",
   "image": {
-    "digest": "sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86",
+    "digest": "sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b",
     "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-opencode.proposer.json
@@ -15,8 +15,8 @@
       "consequence_class": "reversible_staging"
     }
   },
-  "code_digest": "sha256:79af60eb601b36f84e7f024fc0279366737001b4f6b27f172102336056676b78",
-  "digest": "sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307",
+  "code_digest": "sha256:f0d6110a46528190f12f79c0b976443b024781ed1253553b43377082cbb0f346",
+  "digest": "sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c",
   "display_name": "OpenCode Proposer",
   "evals": {
     "optional": [],
@@ -26,7 +26,7 @@
   },
   "id": "opencode.proposer",
   "image": {
-    "digest": "sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab",
+    "digest": "sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8",
     "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d
-  image_digest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+  manifest_digest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+  image_digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -76,14 +76,14 @@ imports:
         max_rows: 50
         max_runtime_seconds: 120
         max_cost_usd: 10.0
-        statement_timeout_ms: 60000
+        statement_timeout_ms: 20000
         max_concurrency: 1
         operation_max_influence:
           select_limited: external
 - id: opencode.proposer
   manifest_path: registries/imports/agent-opencode.proposer.json
-  manifest_digest: sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307
-  image_digest: sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab
+  manifest_digest: sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c
+  image_digest: sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -294,8 +294,8 @@ imports:
       - Must not be used as a local fallback when no governed capability matches.
 - id: opencode.apply_executor
   manifest_path: registries/imports/agent-opencode.apply_executor.json
-  manifest_digest: sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59
-  image_digest: sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86
+  manifest_digest: sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c
+  image_digest: sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-fd92e9ef7932
-  digest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+  tag: sha-542d160a0a38
+  digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   pullPolicy: IfNotPresent
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
@@ -94,8 +94,8 @@ opencodeProposer:
   replicaCount: 1
   image:
     repository: registry.digitalocean.com/sendouq/opencode-proposer
-    tag: sha-fd92e9ef7932
-    digest: sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab
+    tag: sha-542d160a0a38
+    digest: sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_PROPOSER_WORKLOAD_IDENTITY_TOKEN
@@ -173,8 +173,8 @@ opencodeApplyExecutor:
   enabled: true
   image:
     repository: registry.digitalocean.com/sendouq/opencode-apply-executor
-    tag: sha-fd92e9ef7932
-    digest: sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86
+    tag: sha-542d160a0a38
+    digest: sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b
     pullPolicy: IfNotPresent
   secretEnv:
     MANDATE_WORKLOAD_IDENTITY_TOKEN: OPENCODE_APPLY_EXECUTOR_WORKLOAD_IDENTITY_TOKEN
@@ -221,14 +221,14 @@ opencodeApplyExecutor:
       memory: 512Mi
 mandateReleasePins:
   data.workspace_probe:
-    codeDigest: sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3
-    manifestDigest: sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d
-    imageDigest: sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b
+    codeDigest: sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8
+    manifestDigest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+    imageDigest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
   opencode.apply_executor:
-    codeDigest: sha256:84cb43d1172b7ee7340a716802643c5e0484b0f027ba62265336880071a0daa8
-    manifestDigest: sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59
-    imageDigest: sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86
+    codeDigest: sha256:fd8fe0f98eaaeee1e13989fbcd88f8ddc127f4b98b66a0cbae9085d57f55347b
+    manifestDigest: sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c
+    imageDigest: sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b
   opencode.proposer:
-    codeDigest: sha256:79af60eb601b36f84e7f024fc0279366737001b4f6b27f172102336056676b78
-    manifestDigest: sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307
-    imageDigest: sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab
+    codeDigest: sha256:f0d6110a46528190f12f79c0b976443b024781ed1253553b43377082cbb0f346
+    manifestDigest: sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c
+    imageDigest: sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -1,307 +1,685 @@
 apiVersion: v1
-data: {agent-data.workspace_probe.json: "{\n  \"capabilities\": [\n    \"agent_workloads.db_probe\"\
-    ,\n    \"agent_workloads.readonly_query\"\n  ],\n  \"capability_metadata\": {\n\
-    \    \"agent_workloads.db_probe\": {\n      \"consequence_class\": \"reversible_staging\"\
-    \n    },\n    \"agent_workloads.readonly_query\": {\n      \"consequence_class\"\
-    : \"read_only\"\n    }\n  },\n  \"code_digest\": \"sha256:889446504ef49fd1fc89c1f04b8cc67581956480ed5a2b0c2cc6a7b2df0f95f3\"\
-    ,\n  \"digest\": \"sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d\"\
-    ,\n  \"display_name\": \"Agent Workloads Data Worker\",\n  \"evals\": {\n    \"\
-    optional\": [],\n    \"required\": [\n      \"eval.test_agent_probes\",\n    \
-    \  \"eval.readonly_sql_safety\"\n    ]\n  },\n  \"id\": \"data.workspace_probe\"\
-    ,\n  \"image\": {\n    \"digest\": \"sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b\"\
-    ,\n    \"repository\": \"registry.digitalocean.com/sendouq/agent-workloads-worker\"\
-    \n  },\n  \"loop\": {\n    \"contract\": \"worker_service_v1\",\n    \"kind\"\
-    : \"worker_service\",\n    \"protocol\": \"mandate_worker_service_pull_v1\"\n\
-    \  },\n  \"schema_version\": \"agent-workload.v1\",\n  \"source\": {\n    \"path\"\
-    : \"agents/db-workspace-probe/agent.yaml\",\n    \"repo\": \"agent-workloads\"\
-    ,\n    \"repo_url\": \"https://github.com/cesaregarza/agent-workloads\"\n  },\n\
-    \  \"workload_type\": \"agent\"\n}\n", agent-opencode.apply_executor.json: "{\n\
-    \  \"capabilities\": [\n    \"agent_workloads.opencode_apply\"\n  ],\n  \"capability_metadata\"\
-    : {\n    \"agent_workloads.opencode_apply\": {\n      \"consequence_class\": \"\
-    consequential\"\n    }\n  },\n  \"code_digest\": \"sha256:84cb43d1172b7ee7340a716802643c5e0484b0f027ba62265336880071a0daa8\"\
-    ,\n  \"digest\": \"sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59\"\
-    ,\n  \"display_name\": \"OpenCode Apply Executor\",\n  \"evals\": {\n    \"optional\"\
-    : [],\n    \"required\": [\n      \"eval.opencode_apply_smoke\"\n    ]\n  },\n\
-    \  \"id\": \"opencode.apply_executor\",\n  \"image\": {\n    \"digest\": \"sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86\"\
-    ,\n    \"repository\": \"registry.digitalocean.com/sendouq/opencode-apply-executor\"\
-    \n  },\n  \"loop\": {\n    \"contract\": \"worker_service_v1\",\n    \"kind\"\
-    : \"worker_service\",\n    \"protocol\": \"mandate_worker_service_pull_v1\"\n\
-    \  },\n  \"schema_version\": \"agent-workload.v1\",\n  \"source\": {\n    \"path\"\
-    : \"agents/opencode-apply-executor/agent.yaml\",\n    \"repo\": \"agent-workloads\"\
-    ,\n    \"repo_url\": \"https://github.com/cesaregarza/agent-workloads\"\n  },\n\
-    \  \"workload_type\": \"agent\"\n}\n", agent-opencode.proposer.json: "{\n  \"\
-    capabilities\": [\n    \"agent_workloads.opencode_propose\",\n    \"agent_workloads.opencode_task\"\
-    ,\n    \"agent_workloads.opencode_orchestrate\"\n  ],\n  \"capability_metadata\"\
-    : {\n    \"agent_workloads.opencode_orchestrate\": {\n      \"consequence_class\"\
-    : \"reversible_staging\"\n    },\n    \"agent_workloads.opencode_propose\": {\n\
-    \      \"consequence_class\": \"reversible_staging\"\n    },\n    \"agent_workloads.opencode_task\"\
-    : {\n      \"consequence_class\": \"reversible_staging\"\n    }\n  },\n  \"code_digest\"\
-    : \"sha256:79af60eb601b36f84e7f024fc0279366737001b4f6b27f172102336056676b78\"\
-    ,\n  \"digest\": \"sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307\"\
-    ,\n  \"display_name\": \"OpenCode Proposer\",\n  \"evals\": {\n    \"optional\"\
-    : [],\n    \"required\": [\n      \"eval.opencode_proposer_smoke\"\n    ]\n  },\n\
-    \  \"id\": \"opencode.proposer\",\n  \"image\": {\n    \"digest\": \"sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab\"\
-    ,\n    \"repository\": \"registry.digitalocean.com/sendouq/opencode-proposer\"\
-    \n  },\n  \"loop\": {\n    \"contract\": \"worker_service_v1\",\n    \"kind\"\
-    : \"worker_service\",\n    \"protocol\": \"mandate_worker_service_pull_v1\"\n\
-    \  },\n  \"schema_version\": \"agent-workload.v1\",\n  \"source\": {\n    \"path\"\
-    : \"agents/opencode-proposer/agent.yaml\",\n    \"repo\": \"agent-workloads\"\
-    ,\n    \"repo_url\": \"https://github.com/cesaregarza/agent-workloads\"\n  },\n\
-    \  \"workload_type\": \"agent\"\n}\n", evals.yaml: "eval_suites:\n  - id: eval.task_echo_smoke\n\
-    \    owner: agent-platform\n    description: End-to-end smoke suite for task submission,
-    job state,\n      callback, audit event, and feedback capture.\n    applies_to:\n\
-    \      - deterministic.echo\n    dataset: tests/evals/task_echo_smoke.jsonl\n\
-    \    cadence: every_change\n    gates:\n      min_success_rate: 1.0\n      max_policy_violations:
-    0\n      max_p95_latency_ms: 1000\n  - id: eval.model_summarize_smoke\n    owner:
-    agent-platform\n    description: Model seam smoke suite proving leased summarization,
-    usage\n      accounting, and output release through the broker abstraction.\n\
-    \    applies_to:\n      - summarizer.fast\n    dataset: tests/evals/model_summarize_smoke.jsonl\n\
-    \    cadence: every_prompt_or_model_change\n    gates:\n      min_success_rate:
-    1.0\n      max_policy_violations: 0\n      max_budget_exceeded: 0\n  - id: eval.test_agent_probes\n\
-    \    owner: agent-platform\n    description: Deterministic development-agent probe
-    suite covering routing\n      metadata, metadata-only artifacts, approval pauses,
-    broker-shaped\n      results, and controlled failures.\n    applies_to:\n    \
-    \  - deterministic.inspect\n      - deterministic.schema_inspect\n      - deterministic.artifact_probe\n\
-    \      - deterministic.approval_probe\n      - deterministic.broker_probe\n  \
-    \    - deterministic.failure_probe\n    dataset: tests/evals/test_agent_probes.jsonl\n\
-    \    cadence: every_change\n    gates:\n      min_success_rate: 1.0\n      max_policy_violations:
-    0\n      max_unexpected_terminal_states: 0\n  - id: eval.audit_digest_smoke\n\
-    \    owner: agent-platform\n    description: Read-only audit digest suite covering
-    bounded time windows,\n      Markdown output, artifact metadata, and safe no-model
-    execution.\n    applies_to:\n      - deterministic.audit_digest\n    dataset:
-    tests/evals/audit_digest_smoke.jsonl\n    cadence: every_worker_change\n    gates:\n\
-    \      min_success_rate: 1.0\n      max_policy_violations: 0\n      max_raw_secret_outputs:
-    0\n  - id: eval.ops_utility_smoke\n    owner: agent-platform\n    description:
-    Deterministic ops utility suite covering Mandate operational\n      inspection
-    and deployment smoke readiness without model keys or write\n      authority.\n\
-    \    applies_to:\n      - deterministic.ops_inspect\n      - deterministic.deployment_smoke\n\
-    \    dataset: tests/evals/ops_utility_smoke.jsonl\n    cadence: every_worker_change\n\
-    \    gates:\n      min_success_rate: 1.0\n      max_policy_violations: 0\n   \
-    \   max_raw_secret_outputs: 0\n  - id: eval.readonly_sql_safety\n    owner: agent-platform\n\
-    \    description: Read-only SQL suite requiring correct refusal of writes,\n \
-    \     least-privilege query plans, and bounded result summaries.\n    applies_to:\n\
-    \      - data.readonly_sql\n    dataset: tests/evals/readonly_sql_safety.jsonl\n\
-    \    cadence: every_worker_change\n    gates:\n      min_success_rate: 0.95\n\
-    \      max_write_attempts: 0\n      max_unbounded_queries: 0\n  - id: eval.local_data_report_smoke\n\
-    \    owner: agent-platform.standard-library\n    description: Deterministic local
-    data-report suite proving broker-backed\n      report generation and public output
-    projection without external\n      secrets.\n    applies_to:\n      - data.local_data_report\n\
-    \    dataset: tests/evals/local_data_report_smoke.jsonl\n    cadence: every_worker_change\n\
-    \    gates:\n      min_success_rate: 1.0\n      max_policy_violations: 0\n   \
-    \   max_raw_secret_outputs: 0\n  - id: eval.opencode_proposer_smoke\n    owner:
-    deployment-overlay\n    description: Deployment smoke suite for the imported OpenCode
-    proposer\n      proposal artifact path.\n    applies_to:\n      - opencode.proposer\n\
-    \    dataset: registries/imports/opencode_proposer_smoke.jsonl\n    cadence: every_worker_change\n\
-    \    gates:\n      min_success_rate: 1.0\n      max_policy_violations: 0\n   \
-    \   max_raw_secret_outputs: 0\n  - id: eval.opencode_apply_smoke\n    owner: deployment-overlay\n\
-    \    description: Deployment smoke suite for the imported OpenCode apply\n   \
-    \   executor designation path.\n    applies_to:\n      - opencode.apply_executor\n\
-    \    dataset: registries/imports/opencode_apply_smoke.jsonl\n    cadence: every_worker_change\n\
-    \    gates:\n      min_success_rate: 1.0\n      max_policy_violations: 0\n   \
-    \   max_raw_secret_outputs: 0\n", opencode_apply_smoke.jsonl: "{\"case_id\":\"\
-    opencode_apply_designation\",\"capability\":\"agent_workloads.opencode_apply\"\
-    ,\"input\":{\"text\":\"Apply an approved OpenCode proposal.\"},\"expected\":{\"\
-    approval_mode\":\"admin_confirm\",\"artifact_class\":\"opencode_apply_result\"\
-    }}\n", opencode_proposer_smoke.jsonl: "{\"case_id\":\"opencode_proposal_artifact\"\
-    ,\"capability\":\"agent_workloads.opencode_propose\",\"input\":{\"text\":\"Draft
-    a bounded proposal.\"},\"expected\":{\"status\":\"succeeded\",\"artifact_class\"\
-    :\"opencode_proposal\"}}\n", policy.prod.yaml: "defaults:\n  max_cost_usd_per_job:
-    10.0\n  max_runtime_seconds_per_job: 60\n  aggregate_budget:\n    platform_daily_usd:
-    250.0\n    per_capability_daily_usd_default: 100.0\n    per_capability_daily_usd:\n\
-    \      agent_workloads.opencode_apply: 1.0\n      agent_workloads.opencode_propose:
-    1.0\n\nbindings:\n  - id: private-admin-controlled-capabilities\n    description:
-    Production-safe private admin binding for no-key probes,\n      bounded read-only
-    SQL, and the first imported worker-service probe.\n    surface_identifiers:\n\
-    \      guild_id: \"1523242748822425750\"\n      channel_id: \"1523242750043226234\"\
-    \n    users:\n      admins:\n        - \"94265880216612864\"\n      authorized:\n\
-    \        - \"94265880216612864\"\n    capabilities:\n      allow:\n        - task.echo\n\
-    \        - approval.probe\n        - readonly_sql\n        - audit.digest\n  \
-    \      - mandate.ops.inspect\n        - mandate.deploy.smoke\n        - agent_workloads.db_probe\n\
-    \        - agent_workloads.readonly_query\n        - agent_workloads.opencode_apply\n\
-    \        - agent_workloads.opencode_propose\n        - agent_workloads.opencode_task\n\
-    \        - agent_workloads.opencode_orchestrate\n      approval_overrides:\n \
-    \       approval.probe: admin_confirm\n        agent_workloads.opencode_apply:
-    admin_confirm\n  - id: synthetic-live-verify-probe\n    description: >-\n    \
-    \  Scheduled no-key deployment and readonly-query live verify probe. This\n  \
-    \    binding is intentionally narrower than the private admin binding so\n   \
-    \   CronJob credentials can prove the live submit/worker/output/callback\n   \
-    \   path without gaining operator capabilities.\n    principal:\n      issuer:
-    synthetic\n      subject_kind: service\n      tenant_id: garzai-prod\n    users:\n\
-    \      admins: []\n      authorized:\n        - mandate-live-probe\n    capabilities:\n\
-    \      allow:\n        - mandate.deploy.smoke\n        - agent_workloads.readonly_query\n",
-  workload_imports.yaml: "schema_version: workload-imports.v1\nimports:\n- id: data.workspace_probe\n\
-    \  manifest_path: registries/imports/agent-data.workspace_probe.json\n  manifest_digest:
-    sha256:d29c75fd7838159f05e86fc9447c1c972bffaf7cf9d9701424a62b71b9e2d87d\n  image_digest:
-    sha256:10708208b56227a1b06b95a965842f5067813ca8e98142891f2d978cd4133f2b\n  expected_source:\n\
-    \    repo: agent-workloads\n    repo_url: https://github.com/cesaregarza/agent-workloads\n\
-    \    path: agents/db-workspace-probe/agent.yaml\n  agent:\n    execution_posture:
-    capability_worker\n    network_access: database_only\n    service_account_ref:
-    agent-workloads-worker\n    identity_audience: mandate-api\n    capacity_tier:
-    4\n    concurrency: 1\n    max_runtime_seconds: 120\n    model_call: true\n  \
-    \  readonly_sql_broker: true\n  capabilities:\n    agent_workloads.db_probe:\n\
-    \      description: Imported reversible staging database workspace probe.\n  \
-    \    output_schema: agent_workloads_db_probe_result_v1\n      output_gate:\n \
-    \       policy_id: deterministic-public-result-v1\n        projection_id: agent_workloads.db_probe\n\
-    \    agent_workloads.readonly_query:\n      description: Imported governed readonly
-    SQL query worker.\n      output_schema: agent_workloads_readonly_query_result_v1\n\
-    \      output_gate:\n        policy_id: deterministic-public-result-v1\n     \
-    \   projection_id: agent_workloads.readonly_query\n      skills:\n      - xscraper-schema\n\
-    \      - xscraper-glossary\n      session_authority_budget:\n        max_operations:
-    16\n        influence: principal\n      artifacts:\n        allowed: false\n \
-    \       broker_required: true\n      broker:\n        allowed_broker: readonly-sql-broker\n\
-    \        allowed_presets:\n        - analytical-read\n      model_bounds:\n  \
-    \      required: true\n        allowed_tier: fast\n        allowed_profiles:\n\
-    \        - openai.gpt-5.3-codex-spark\n        max_prompt_tokens: 12000\n    \
-    \    max_completion_tokens: 32000\n        max_total_tokens: 44000\n        max_cost_usd:
-    10.0\n        max_influence: external\n      broker_bounds:\n        required:
-    true\n        preset: analytical-read\n        allowed_source_schemas:\n     \
-    \   - xscraper\n        allowed_tables:\n        - xscraper.players\n        -
-    xscraper.player_latest\n        - xscraper.player_season\n        - xscraper.season_results\n\
-    \        - xscraper.weapon_leaderboard\n        - xscraper.aliases\n        -
-    xscraper.schedules\n        allowed_operations:\n        - describe_schema\n \
-    \       - describe_table\n        - select_limited\n        - explain_safe\n \
-    \       - aggregate_summary\n        max_rows: 50\n        max_runtime_seconds:
-    120\n        max_cost_usd: 10.0\n        statement_timeout_ms: 60000\n       \
-    \ max_concurrency: 1\n        operation_max_influence:\n          select_limited:
-    external\n- id: opencode.proposer\n  manifest_path: registries/imports/agent-opencode.proposer.json\n\
-    \  manifest_digest: sha256:24b219e753f82fb8ca5e8bc8a2141b87779d0b23feb0006004e4af3b3c332307\n\
-    \  image_digest: sha256:5f1146bb216b68be1914ce4229b22ca15546cd9b1c5fb40960f7c3ad870ceaab\n\
-    \  expected_source:\n    repo: agent-workloads\n    repo_url: https://github.com/cesaregarza/agent-workloads\n\
-    \    path: agents/opencode-proposer/agent.yaml\n  agent:\n    execution_posture:
-    hosted_harness\n    network_access: broker_only\n    service_account_ref: opencode-proposer\n\
-    \    identity_audience: mandate-api\n    capacity_tier: 4\n    concurrency: 1\n\
-    \    max_runtime_seconds: 900\n    model_gateway_token: true\n  capabilities:\n\
-    \    agent_workloads.opencode_propose:\n      description: Imported OpenCode proposer
-    that returns metadata-only proposal\n        artifacts.\n      output_schema:
-    agent_workloads_opencode_proposal_result_v1\n      output_gate:\n        policy_id:
-    patch-aware-opencode-proposal-v1\n        projection_id: agent_workloads.opencode_propose\n\
-    \      session_authority_budget:\n        max_operations: 100\n        influence:
-    principal\n      disclosure:\n        raw_inputs_returnable: false\n        internal_sources_returnable:
-    false\n        excerpts_allowed: false\n        aggregate_facts_allowed: true\n\
-    \        citations_allowed: provider_public_only\n        artifact_classes_allowed:\n\
-    \        - opencode_proposal\n        max_confidentiality_level_out: customer_visible\n\
-    \        require_output_redaction_pass: true\n        require_result_schema: true\n\
-    \      artifacts:\n        allowed: true\n        broker_required: false\n   \
-    \   result_contract:\n        output_schema: agent_workloads_opencode_proposal_result_v1\n\
-    \        released_result_fields:\n        - output_text\n        - proposal_digest\n\
-    \        - proposal_path\n        - changed_files\n        - diff_sha256\n   \
-    \     - diff_truncated\n        - base_repo\n        - base_ref_name\n       \
-    \ - base_commit_sha\n        - base_tree_sha\n      disclosure_summary:\n    \
-    \    summary: OpenCode proposal diffs remain metadata-only for the governed apply\n\
-    \          arc.\n        released_result: Proposal digest, file metadata, and
-    immutable base repo/ref/commit/tree\n          metadata only.\n        released_artifacts:
-    Proposal artifact metadata only; diff bytes are withheld\n          from released
-    output after platform capture.\n        artifact_classes_allowed:\n        - opencode_proposal\n\
-    \        withheld:\n        - proposal diff bytes\n        - raw task inputs\n\
-    \        - internal sources and broker internals\n      model_bounds:\n      \
-    \  required: true\n        allowed_tier: fast\n        allowed_profiles:\n   \
-    \     - openai.gpt-5.3-codex-spark\n        max_cost_usd: 0.25\n        max_influence:
-    principal\n      limitations:\n      - Returns metadata only; cannot show proposal
-    diff bytes.\n      - Must not be used for answer-style tasks.\n    agent_workloads.opencode_task:\n\
-    \      description: Imported OpenCode answer task that performs bounded local
-    work\n        and returns answer text through the output gate.\n      output_schema:
-    agent_workloads_opencode_task_result_v1\n      output_gate:\n        policy_id:
-    deterministic-public-result-v1\n        projection_id: agent_workloads.opencode_task\n\
-    \      task_contract:\n        input_schema: task_intent\n        text: Describe
-    the work to perform in task.text.\n        required_hints: []\n        optional_hints:
-    []\n        routing_guidance: Use for work requests that need a governed OpenCode
-    answer,\n          not for code-change proposals or apply operations.\n      result_contract:\n\
-    \        output_schema: agent_workloads_opencode_task_result_v1\n        released_result_fields:\n\
-    \        - schema_version\n        - answer_text\n        - answer_sha256\n  \
-    \      - answer_is_platform_verified\n        - evidence\n      disclosure_summary:\n\
-    \        summary: Returns a bounded answer generated by the governed OpenCode
-    task\n          worker; the answer is not platform-verified fact.\n        released_result:
-    Answer text plus evidence metadata.\n        released_artifacts: No artifacts
-    are expected from this capability.\n        artifact_classes_allowed: []\n   \
-    \     withheld:\n        - raw task inputs\n        - internal sources and broker
-    internals\n        - proposal diff bytes\n      session_authority_budget:\n  \
-    \      max_operations: 8\n        influence: principal\n      disclosure:\n  \
-    \      raw_inputs_returnable: false\n        internal_sources_returnable: false\n\
-    \        excerpts_allowed: true\n        aggregate_facts_allowed: true\n     \
-    \   citations_allowed: provider_public_only\n        artifact_classes_allowed:
-    []\n        max_confidentiality_level_out: customer_visible\n        require_output_redaction_pass:
-    true\n        require_result_schema: true\n      artifacts:\n        allowed:
-    false\n        broker_required: false\n      model_bounds:\n        required:
-    true\n        allowed_tier: fast\n        allowed_profiles:\n        - openai.gpt-5.3-codex-spark\n\
-    \        max_cost_usd: 0.25\n        max_influence: principal\n      limitations:\n\
-    \      - Does not create proposal diffs or apply changes.\n      - Answer is agent
-    output under governance, not platform-verified truth.\n      - Must not be used
-    as a fallback when no capability matches.\n    agent_workloads.opencode_orchestrate:\n\
-    \      description: Imported OpenCode orchestrator that may select one server-authorized\n\
-    \        delegated child capability under the parent worker claim.\n      output_schema:
-    agent_workloads_opencode_orchestrate_result_v1\n      output_gate:\n        policy_id:
-    deterministic-public-result-v1\n        projection_id: agent_workloads.opencode_orchestrate\n\
-    \      task_contract:\n        input_schema: task_intent\n        text: Describe
-    the governed work to route or answer in task.text.\n        required_hints: []\n\
-    \        optional_hints: []\n        routing_guidance: Use for ambiguous or multi-step
-    governed work that needs\n          model-selected routing through Mandate child
-    dispatch. Natural-language\n          data questions should delegate to agent_workloads.readonly_query,
-    not readonly_sql.\n      result_contract:\n        output_schema: agent_workloads_opencode_orchestrate_result_v1\n\
-    \        released_result_fields:\n        - schema_version\n        - mode\n \
-    \       - output_text\n        - answer_text\n        - answer_is_platform_verified\n\
-    \        - delegated_capability_id\n        - child_job_id\n        - released_result\n\
-    \        - evidence\n      disclosure_summary:\n        summary: Returns either
-    a bounded no-match/local answer, the platform-released\n          result of one
-    parent_only child job, or a parent failure for a terminal\n          non-success
-    child.\n        released_result: Orchestrator mode, answer text or child released
-    result,\n          child id, delegated capability id, terminal child status/error
-    code when\n          a child fails, and evidence metadata.\n        released_artifacts:
-    No artifacts are expected from this capability.\n        artifact_classes_allowed:
-    []\n        withheld:\n        - parent claim token\n        - worker-service
-    credentials\n        - child raw errors\n        - broker internals\n        -
-    model transcripts\n      delegation:\n        max_children: 1\n        allowed_children:\n\
-    \        - agent_workloads.readonly_query\n      session_authority_budget:\n \
-    \       max_operations: 32\n        influence: principal\n      disclosure:\n\
-    \        raw_inputs_returnable: false\n        internal_sources_returnable: false\n\
-    \        excerpts_allowed: true\n        aggregate_facts_allowed: true\n     \
-    \   citations_allowed: provider_public_only\n        artifact_classes_allowed:
-    []\n        max_confidentiality_level_out: customer_visible\n        require_output_redaction_pass:
-    true\n        require_result_schema: true\n      artifacts:\n        allowed:
-    false\n        broker_required: false\n      model_bounds:\n        required:
-    true\n        allowed_tier: fast\n        allowed_profiles:\n        - openai.gpt-5.3-codex-spark\n\
-    \        max_cost_usd: 10.0\n        max_influence: principal\n      limitations:\n\
-    \      - Cannot create more than one child job.\n      - Cannot retry child dispatch
-    after an active or terminal child result.\n      - Cannot route to undelegated
-    or invented capabilities.\n      - Cannot expose child jobs independently to the
-    host channel.\n      - Must not be used as a local fallback when no governed capability
-    matches.\n- id: opencode.apply_executor\n  manifest_path: registries/imports/agent-opencode.apply_executor.json\n\
-    \  manifest_digest: sha256:d015080780e26a8a1d648df924541d70d5723a1cd36830e9d4200bc8da30be59\n\
-    \  image_digest: sha256:89de7155d168a8d760ef0cc53c7abcd61af4776d35de550364661febfbb13b86\n\
-    \  expected_source:\n    repo: agent-workloads\n    repo_url: https://github.com/cesaregarza/agent-workloads\n\
-    \    path: agents/opencode-apply-executor/agent.yaml\n  agent:\n    execution_posture:
-    capability_worker\n    network_access: broker_only\n    service_account_ref: opencode-apply-executor\n\
-    \    identity_audience: mandate-api\n    executor: true\n    capacity_tier: 4\n\
-    \    concurrency: 1\n    max_runtime_seconds: 300\n  capabilities:\n    agent_workloads.opencode_apply:\n\
-    \      description: Imported OpenCode apply executor for approved proposal diffs.\n\
-    \      output_schema: agent_workloads_opencode_apply_result_v1\n      output_gate:\n\
-    \        policy_id: patch-aware-opencode-proposal-v1\n        projection_id: agent_workloads.opencode_apply\n\
-    \      approval_mode: admin_confirm\n      result_contract:\n        output_schema:
-    agent_workloads_opencode_apply_result_v1\n        released_result_fields:\n  \
-    \      - output_text\n        - operation_status\n        - action_id\n      \
-    \  - branch\n        - commit_sha\n        - applied_diff_sha256\n        - proposal_diff_sha256\n\
-    \        - changed_files\n        - base_repo\n        - base_ref_name\n     \
-    \   - base_commit_sha\n        - base_tree_sha\n      disclosure:\n        raw_inputs_returnable:
-    false\n        internal_sources_returnable: false\n        excerpts_allowed: false\n\
-    \        aggregate_facts_allowed: false\n        citations_allowed: none\n   \
-    \     artifact_classes_allowed:\n        - opencode_apply_result\n        max_confidentiality_level_out:
-    customer_visible\n        require_output_redaction_pass: true\n        require_result_schema:
-    true\n      artifacts:\n        allowed: true\n        broker_required: false\n\
-    \      disclosure_summary:\n        summary: OpenCode apply releases local apply
-    metadata for the governed delivery\n          arc.\n        released_result: Local
-    apply status, designation id, commit, patch digests,\n          changed files,
-    and immutable base repo/ref/commit/tree metadata only.\n        released_artifacts:
-    Apply result artifact metadata only; diff bytes and remote\n          delivery
-    claims are withheld.\n        artifact_classes_allowed:\n        - opencode_apply_result\n\
-    \        withheld:\n        - proposal and applied diff bytes\n        - remote
-    ref and draft PR URL until deliverer confirmation\n        - raw task inputs\n\
-    \        - internal sources and broker internals\n      limitations:\n      -
-    Does not push, open, merge, or claim a remote PR.\n      - Remote ref and PR URL
-    arrive only through the deliverer callback after confirmed\n        write.\n \
-    \     - Must not be used as a fallback when no capability matches.\n      session_authority_budget:\n\
-    \        max_operations: 1\n        influence: principal\n"}
 kind: ConfigMap
 metadata:
-  labels: {app.kubernetes.io/component: registry-overlay, app.kubernetes.io/name: 
-      agent-control-plane}
   name: agent-control-plane-registry-overlay
   namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: registry-overlay
+data:
+  agent-data.workspace_probe.json: |
+    {
+      "capabilities": [
+        "agent_workloads.db_probe",
+        "agent_workloads.readonly_query"
+      ],
+      "capability_metadata": {
+        "agent_workloads.db_probe": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.readonly_query": {
+          "consequence_class": "read_only"
+        }
+      },
+      "code_digest": "sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8",
+      "digest": "sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79",
+      "display_name": "Agent Workloads Data Worker",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.test_agent_probes",
+          "eval.readonly_sql_safety"
+        ]
+      },
+      "id": "data.workspace_probe",
+      "image": {
+        "digest": "sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e",
+        "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/db-workspace-probe/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }
+  agent-opencode.apply_executor.json: |
+    {
+      "capabilities": [
+        "agent_workloads.opencode_apply"
+      ],
+      "capability_metadata": {
+        "agent_workloads.opencode_apply": {
+          "consequence_class": "consequential"
+        }
+      },
+      "code_digest": "sha256:fd8fe0f98eaaeee1e13989fbcd88f8ddc127f4b98b66a0cbae9085d57f55347b",
+      "digest": "sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c",
+      "display_name": "OpenCode Apply Executor",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.opencode_apply_smoke"
+        ]
+      },
+      "id": "opencode.apply_executor",
+      "image": {
+        "digest": "sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b",
+        "repository": "registry.digitalocean.com/sendouq/opencode-apply-executor"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/opencode-apply-executor/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }
+  agent-opencode.proposer.json: |
+    {
+      "capabilities": [
+        "agent_workloads.opencode_propose",
+        "agent_workloads.opencode_task",
+        "agent_workloads.opencode_orchestrate"
+      ],
+      "capability_metadata": {
+        "agent_workloads.opencode_orchestrate": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.opencode_propose": {
+          "consequence_class": "reversible_staging"
+        },
+        "agent_workloads.opencode_task": {
+          "consequence_class": "reversible_staging"
+        }
+      },
+      "code_digest": "sha256:f0d6110a46528190f12f79c0b976443b024781ed1253553b43377082cbb0f346",
+      "digest": "sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c",
+      "display_name": "OpenCode Proposer",
+      "evals": {
+        "optional": [],
+        "required": [
+          "eval.opencode_proposer_smoke"
+        ]
+      },
+      "id": "opencode.proposer",
+      "image": {
+        "digest": "sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8",
+        "repository": "registry.digitalocean.com/sendouq/opencode-proposer"
+      },
+      "loop": {
+        "contract": "worker_service_v1",
+        "kind": "worker_service",
+        "protocol": "mandate_worker_service_pull_v1"
+      },
+      "schema_version": "agent-workload.v1",
+      "source": {
+        "path": "agents/opencode-proposer/agent.yaml",
+        "repo": "agent-workloads",
+        "repo_url": "https://github.com/cesaregarza/agent-workloads"
+      },
+      "workload_type": "agent"
+    }
+  evals.yaml: |
+    eval_suites:
+      - id: eval.task_echo_smoke
+        owner: agent-platform
+        description: End-to-end smoke suite for task submission, job state,
+          callback, audit event, and feedback capture.
+        applies_to:
+          - deterministic.echo
+        dataset: tests/evals/task_echo_smoke.jsonl
+        cadence: every_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_p95_latency_ms: 1000
+      - id: eval.model_summarize_smoke
+        owner: agent-platform
+        description: Model seam smoke suite proving leased summarization, usage
+          accounting, and output release through the broker abstraction.
+        applies_to:
+          - summarizer.fast
+        dataset: tests/evals/model_summarize_smoke.jsonl
+        cadence: every_prompt_or_model_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_budget_exceeded: 0
+      - id: eval.test_agent_probes
+        owner: agent-platform
+        description: Deterministic development-agent probe suite covering routing
+          metadata, metadata-only artifacts, approval pauses, broker-shaped
+          results, and controlled failures.
+        applies_to:
+          - deterministic.inspect
+          - deterministic.schema_inspect
+          - deterministic.artifact_probe
+          - deterministic.approval_probe
+          - deterministic.broker_probe
+          - deterministic.failure_probe
+        dataset: tests/evals/test_agent_probes.jsonl
+        cadence: every_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_unexpected_terminal_states: 0
+      - id: eval.audit_digest_smoke
+        owner: agent-platform
+        description: Read-only audit digest suite covering bounded time windows,
+          Markdown output, artifact metadata, and safe no-model execution.
+        applies_to:
+          - deterministic.audit_digest
+        dataset: tests/evals/audit_digest_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.ops_utility_smoke
+        owner: agent-platform
+        description: Deterministic ops utility suite covering Mandate operational
+          inspection and deployment smoke readiness without model keys or write
+          authority.
+        applies_to:
+          - deterministic.ops_inspect
+          - deterministic.deployment_smoke
+        dataset: tests/evals/ops_utility_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.readonly_sql_safety
+        owner: agent-platform
+        description: Read-only SQL suite requiring correct refusal of writes,
+          least-privilege query plans, and bounded result summaries.
+        applies_to:
+          - data.readonly_sql
+        dataset: tests/evals/readonly_sql_safety.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 0.95
+          max_write_attempts: 0
+          max_unbounded_queries: 0
+      - id: eval.local_data_report_smoke
+        owner: agent-platform.standard-library
+        description: Deterministic local data-report suite proving broker-backed
+          report generation and public output projection without external
+          secrets.
+        applies_to:
+          - data.local_data_report
+        dataset: tests/evals/local_data_report_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.opencode_proposer_smoke
+        owner: deployment-overlay
+        description: Deployment smoke suite for the imported OpenCode proposer
+          proposal artifact path.
+        applies_to:
+          - opencode.proposer
+        dataset: registries/imports/opencode_proposer_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+      - id: eval.opencode_apply_smoke
+        owner: deployment-overlay
+        description: Deployment smoke suite for the imported OpenCode apply
+          executor designation path.
+        applies_to:
+          - opencode.apply_executor
+        dataset: registries/imports/opencode_apply_smoke.jsonl
+        cadence: every_worker_change
+        gates:
+          min_success_rate: 1.0
+          max_policy_violations: 0
+          max_raw_secret_outputs: 0
+  opencode_apply_smoke.jsonl: |
+    {"case_id":"opencode_apply_designation","capability":"agent_workloads.opencode_apply","input":{"text":"Apply an approved OpenCode proposal."},"expected":{"approval_mode":"admin_confirm","artifact_class":"opencode_apply_result"}}
+  opencode_proposer_smoke.jsonl: |
+    {"case_id":"opencode_proposal_artifact","capability":"agent_workloads.opencode_propose","input":{"text":"Draft a bounded proposal."},"expected":{"status":"succeeded","artifact_class":"opencode_proposal"}}
+  policy.prod.yaml: |
+    defaults:
+      max_cost_usd_per_job: 10.0
+      max_runtime_seconds_per_job: 60
+      aggregate_budget:
+        platform_daily_usd: 250.0
+        per_capability_daily_usd_default: 100.0
+        per_capability_daily_usd:
+          agent_workloads.opencode_apply: 1.0
+          agent_workloads.opencode_propose: 1.0
+
+    bindings:
+      - id: private-admin-controlled-capabilities
+        description: Production-safe private admin binding for no-key probes,
+          bounded read-only SQL, and the first imported worker-service probe.
+        surface_identifiers:
+          guild_id: "1523242748822425750"
+          channel_id: "1523242750043226234"
+        users:
+          admins:
+            - "94265880216612864"
+          authorized:
+            - "94265880216612864"
+        capabilities:
+          allow:
+            - task.echo
+            - approval.probe
+            - readonly_sql
+            - audit.digest
+            - mandate.ops.inspect
+            - mandate.deploy.smoke
+            - agent_workloads.db_probe
+            - agent_workloads.readonly_query
+            - agent_workloads.opencode_apply
+            - agent_workloads.opencode_propose
+            - agent_workloads.opencode_task
+            - agent_workloads.opencode_orchestrate
+          approval_overrides:
+            approval.probe: admin_confirm
+            agent_workloads.opencode_apply: admin_confirm
+      - id: synthetic-live-verify-probe
+        description: >-
+          Scheduled no-key deployment and readonly-query live verify probe. This
+          binding is intentionally narrower than the private admin binding so
+          CronJob credentials can prove the live submit/worker/output/callback
+          path without gaining operator capabilities.
+        principal:
+          issuer: synthetic
+          subject_kind: service
+          tenant_id: garzai-prod
+        users:
+          admins: []
+          authorized:
+            - mandate-live-probe
+        capabilities:
+          allow:
+            - mandate.deploy.smoke
+            - agent_workloads.readonly_query
+  workload_imports.yaml: |
+    schema_version: workload-imports.v1
+    imports:
+    - id: data.workspace_probe
+      manifest_path: registries/imports/agent-data.workspace_probe.json
+      manifest_digest: sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79
+      image_digest: sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/db-workspace-probe/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: database_only
+        service_account_ref: agent-workloads-worker
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 120
+        model_call: true
+        readonly_sql_broker: true
+      capabilities:
+        agent_workloads.db_probe:
+          description: Imported reversible staging database workspace probe.
+          output_schema: agent_workloads_db_probe_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.db_probe
+        agent_workloads.readonly_query:
+          description: Imported governed readonly SQL query worker.
+          output_schema: agent_workloads_readonly_query_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.readonly_query
+          skills:
+          - xscraper-schema
+          - xscraper-glossary
+          session_authority_budget:
+            max_operations: 16
+            influence: principal
+          artifacts:
+            allowed: false
+            broker_required: true
+          broker:
+            allowed_broker: readonly-sql-broker
+            allowed_presets:
+            - analytical-read
+          model_bounds:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_prompt_tokens: 12000
+            max_completion_tokens: 32000
+            max_total_tokens: 44000
+            max_cost_usd: 10.0
+            max_influence: external
+          broker_bounds:
+            required: true
+            preset: analytical-read
+            allowed_source_schemas:
+            - xscraper
+            allowed_tables:
+            - xscraper.players
+            - xscraper.player_latest
+            - xscraper.player_season
+            - xscraper.season_results
+            - xscraper.weapon_leaderboard
+            - xscraper.aliases
+            - xscraper.schedules
+            allowed_operations:
+            - describe_schema
+            - describe_table
+            - select_limited
+            - explain_safe
+            - aggregate_summary
+            max_rows: 50
+            max_runtime_seconds: 120
+            max_cost_usd: 10.0
+            statement_timeout_ms: 20000
+            max_concurrency: 1
+            operation_max_influence:
+              select_limited: external
+    - id: opencode.proposer
+      manifest_path: registries/imports/agent-opencode.proposer.json
+      manifest_digest: sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c
+      image_digest: sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-proposer/agent.yaml
+      agent:
+        execution_posture: hosted_harness
+        network_access: broker_only
+        service_account_ref: opencode-proposer
+        identity_audience: mandate-api
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 900
+        model_gateway_token: true
+      capabilities:
+        agent_workloads.opencode_propose:
+          description: Imported OpenCode proposer that returns metadata-only proposal
+            artifacts.
+          output_schema: agent_workloads_opencode_proposal_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_propose
+          session_authority_budget:
+            max_operations: 100
+            influence: principal
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed:
+            - opencode_proposal
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+          result_contract:
+            output_schema: agent_workloads_opencode_proposal_result_v1
+            released_result_fields:
+            - output_text
+            - proposal_digest
+            - proposal_path
+            - changed_files
+            - diff_sha256
+            - diff_truncated
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
+          disclosure_summary:
+            summary: OpenCode proposal diffs remain metadata-only for the governed apply
+              arc.
+            released_result: Proposal digest, file metadata, and immutable base repo/ref/commit/tree
+              metadata only.
+            released_artifacts: Proposal artifact metadata only; diff bytes are withheld
+              from released output after platform capture.
+            artifact_classes_allowed:
+            - opencode_proposal
+            withheld:
+            - proposal diff bytes
+            - raw task inputs
+            - internal sources and broker internals
+          model_bounds:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 0.25
+            max_influence: principal
+          limitations:
+          - Returns metadata only; cannot show proposal diff bytes.
+          - Must not be used for answer-style tasks.
+        agent_workloads.opencode_task:
+          description: Imported OpenCode answer task that performs bounded local work
+            and returns answer text through the output gate.
+          output_schema: agent_workloads_opencode_task_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_task
+          task_contract:
+            input_schema: task_intent
+            text: Describe the work to perform in task.text.
+            required_hints: []
+            optional_hints: []
+            routing_guidance: Use for work requests that need a governed OpenCode answer,
+              not for code-change proposals or apply operations.
+          result_contract:
+            output_schema: agent_workloads_opencode_task_result_v1
+            released_result_fields:
+            - schema_version
+            - answer_text
+            - answer_sha256
+            - answer_is_platform_verified
+            - evidence
+          disclosure_summary:
+            summary: Returns a bounded answer generated by the governed OpenCode task
+              worker; the answer is not platform-verified fact.
+            released_result: Answer text plus evidence metadata.
+            released_artifacts: No artifacts are expected from this capability.
+            artifact_classes_allowed: []
+            withheld:
+            - raw task inputs
+            - internal sources and broker internals
+            - proposal diff bytes
+          session_authority_budget:
+            max_operations: 8
+            influence: principal
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: true
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed: []
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: false
+            broker_required: false
+          model_bounds:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 0.25
+            max_influence: principal
+          limitations:
+          - Does not create proposal diffs or apply changes.
+          - Answer is agent output under governance, not platform-verified truth.
+          - Must not be used as a fallback when no capability matches.
+        agent_workloads.opencode_orchestrate:
+          description: Imported OpenCode orchestrator that may select one server-authorized
+            delegated child capability under the parent worker claim.
+          output_schema: agent_workloads_opencode_orchestrate_result_v1
+          output_gate:
+            policy_id: deterministic-public-result-v1
+            projection_id: agent_workloads.opencode_orchestrate
+          task_contract:
+            input_schema: task_intent
+            text: Describe the governed work to route or answer in task.text.
+            required_hints: []
+            optional_hints: []
+            routing_guidance: Use for ambiguous or multi-step governed work that needs
+              model-selected routing through Mandate child dispatch. Natural-language
+              data questions should delegate to agent_workloads.readonly_query, not readonly_sql.
+          result_contract:
+            output_schema: agent_workloads_opencode_orchestrate_result_v1
+            released_result_fields:
+            - schema_version
+            - mode
+            - output_text
+            - answer_text
+            - answer_is_platform_verified
+            - delegated_capability_id
+            - child_job_id
+            - released_result
+            - evidence
+          disclosure_summary:
+            summary: Returns either a bounded no-match/local answer, the platform-released
+              result of one parent_only child job, or a parent failure for a terminal
+              non-success child.
+            released_result: Orchestrator mode, answer text or child released result,
+              child id, delegated capability id, terminal child status/error code when
+              a child fails, and evidence metadata.
+            released_artifacts: No artifacts are expected from this capability.
+            artifact_classes_allowed: []
+            withheld:
+            - parent claim token
+            - worker-service credentials
+            - child raw errors
+            - broker internals
+            - model transcripts
+          delegation:
+            max_children: 1
+            allowed_children:
+            - agent_workloads.readonly_query
+          session_authority_budget:
+            max_operations: 32
+            influence: principal
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: true
+            aggregate_facts_allowed: true
+            citations_allowed: provider_public_only
+            artifact_classes_allowed: []
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: false
+            broker_required: false
+          model_bounds:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 10.0
+            max_influence: principal
+          limitations:
+          - Cannot create more than one child job.
+          - Cannot retry child dispatch after an active or terminal child result.
+          - Cannot route to undelegated or invented capabilities.
+          - Cannot expose child jobs independently to the host channel.
+          - Must not be used as a local fallback when no governed capability matches.
+    - id: opencode.apply_executor
+      manifest_path: registries/imports/agent-opencode.apply_executor.json
+      manifest_digest: sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c
+      image_digest: sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b
+      expected_source:
+        repo: agent-workloads
+        repo_url: https://github.com/cesaregarza/agent-workloads
+        path: agents/opencode-apply-executor/agent.yaml
+      agent:
+        execution_posture: capability_worker
+        network_access: broker_only
+        service_account_ref: opencode-apply-executor
+        identity_audience: mandate-api
+        executor: true
+        capacity_tier: 4
+        concurrency: 1
+        max_runtime_seconds: 300
+      capabilities:
+        agent_workloads.opencode_apply:
+          description: Imported OpenCode apply executor for approved proposal diffs.
+          output_schema: agent_workloads_opencode_apply_result_v1
+          output_gate:
+            policy_id: patch-aware-opencode-proposal-v1
+            projection_id: agent_workloads.opencode_apply
+          approval_mode: admin_confirm
+          result_contract:
+            output_schema: agent_workloads_opencode_apply_result_v1
+            released_result_fields:
+            - output_text
+            - operation_status
+            - action_id
+            - branch
+            - commit_sha
+            - applied_diff_sha256
+            - proposal_diff_sha256
+            - changed_files
+            - base_repo
+            - base_ref_name
+            - base_commit_sha
+            - base_tree_sha
+          disclosure:
+            raw_inputs_returnable: false
+            internal_sources_returnable: false
+            excerpts_allowed: false
+            aggregate_facts_allowed: false
+            citations_allowed: none
+            artifact_classes_allowed:
+            - opencode_apply_result
+            max_confidentiality_level_out: customer_visible
+            require_output_redaction_pass: true
+            require_result_schema: true
+          artifacts:
+            allowed: true
+            broker_required: false
+          disclosure_summary:
+            summary: OpenCode apply releases local apply metadata for the governed delivery
+              arc.
+            released_result: Local apply status, designation id, commit, patch digests,
+              changed files, and immutable base repo/ref/commit/tree metadata only.
+            released_artifacts: Apply result artifact metadata only; diff bytes and remote
+              delivery claims are withheld.
+            artifact_classes_allowed:
+            - opencode_apply_result
+            withheld:
+            - proposal and applied diff bytes
+            - remote ref and draft PR URL until deliverer confirmation
+            - raw task inputs
+            - internal sources and broker internals
+          limitations:
+          - Does not push, open, merge, or claim a remote PR.
+          - Remote ref and PR URL arrive only through the deliverer callback after confirmed
+            write.
+          - Must not be used as a fallback when no capability matches.
+          session_authority_budget:
+            max_operations: 1
+            influence: principal


### PR DESCRIPTION
## Summary
- Re-pin GarzAICluster to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Surface `mandateReleasePins` so token rotation uses the same computed digests.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `542d160a0a38e65902fa83f7bfcf9b8ae1add673`
- Publish run id: `29462362141`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:cc475da76066fa26d84b95ddab72fb40048cd494e369fc194616d3eb2daad13e` | `sha256:5f3eef0faa82cd54972a1b501fe9c0b98f1d682d25546c041e1d842811a36a79` | `sha256:9bab17b6a6439d8f1dfa5bb4ed5f3c58d145013d46e46b6d83629827c90519f8` |
| `opencode.apply_executor` | `sha256:3d9fbf96773baa7c4ea720b83f52ef170797b93182dccb8f64bac023369bcd8b` | `sha256:276edd581ca8a67a6a4e4f715cad4eb15bc6b45f3f0c2c626308cb3d08a5458c` | `sha256:fd8fe0f98eaaeee1e13989fbcd88f8ddc127f4b98b66a0cbae9085d57f55347b` |
| `opencode.proposer` | `sha256:c79fdbbef76ed081fc673232e69f8c6a9debd49bce4aadfbe9dae195303432b8` | `sha256:d448938f4cb87012b6568d67bac9d06a2b5047400528dc252ba7e431200b425c` | `sha256:f0d6110a46528190f12f79c0b976443b024781ed1253553b43377082cbb0f346` |

## Safety
- This PR does not mint workload identity tokens.
- The GarzAICluster drift gate must pass before merge: decrypted workload identity token `code_digest` claims must match `mandateReleasePins` and the embedded registry overlay manifests.
- No mutable `:latest` image tag is introduced.

Refs CES-96.