### PR TITLE
Retire SplatNLP and add Prometheus memory guardrails

### DIFF
--- a/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
+++ b/helm/garz-observability/templates/monitoring-prometheus-configmap.yaml
@@ -31,12 +31,13 @@ data:
 
       - job_name: fastapi
         metrics_path: /metrics
+        sample_limit: {{ .Values.monitoring.prometheus.fastapiScrape.sampleLimit }}
         kubernetes_sd_configs:
           - role: endpoints
         relabel_configs:
           - action: keep
             source_labels: [__meta_kubernetes_namespace]
-            regex: {{ .Release.Namespace | quote }}
+            regex: {{ .Values.monitoring.prometheus.fastapiScrape.namespace | quote }}
           - action: keep
             source_labels:
               - __meta_kubernetes_service_name

--- a/helm/garz-observability/templates/prometheus-statefulset.yaml
+++ b/helm/garz-observability/templates/prometheus-statefulset.yaml
@@ -18,6 +18,11 @@ spec:
       {{- include "garzObservability.componentSelectorLabels" (dict "component" "prometheus" "root" .) | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/prometheus-config: {{ include (print $.Template.BasePath "/monitoring-prometheus-configmap.yaml") . | sha256sum }}
+        {{- if .Values.monitoring.prometheus.rules.enabled }}
+        checksum/prometheus-rules: {{ include (print $.Template.BasePath "/monitoring-prometheus-rules-configmap.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "garzObservability.componentSelectorLabels" (dict "component" "prometheus" "root" .) | nindent 8 }}
     spec:
@@ -36,7 +41,13 @@ spec:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus"
             - "--storage.tsdb.retention.time={{ .Values.monitoring.prometheus.retention }}"
+            - "--query.max-samples={{ .Values.monitoring.prometheus.query.maxSamples }}"
+            - "--query.max-concurrency={{ .Values.monitoring.prometheus.query.maxConcurrency }}"
+            - "--query.timeout={{ .Values.monitoring.prometheus.query.timeout }}"
             - "--web.enable-lifecycle"
+          env:
+            - name: GOMEMLIMIT
+              value: {{ .Values.monitoring.prometheus.goMemoryLimit | quote }}
           ports:
             - name: http
               containerPort: 9090

--- a/helm/garz-observability/values.yaml
+++ b/helm/garz-observability/values.yaml
@@ -64,6 +64,24 @@ monitoring:
           targetPort: http
     configMapName: prometheus-config
     retention: 15d
+    # Keep the Go runtime below the 2 GiB container limit so Prometheus retains
+    # headroom for queries, WAL replay, and compaction instead of relying on the
+    # cgroup OOM killer.
+    goMemoryLimit: 1200MiB
+    query:
+      # Quote large integers so Helm does not render them in scientific
+      # notation, which Prometheus's integer flag parser does not accept.
+      maxSamples: "5000000"
+      maxConcurrency: 5
+      timeout: 60s
+    fastapiScrape:
+      # The SplatTop application runs in default while this chart is released
+      # into monitoring, so discovery must not use .Release.Namespace.
+      namespace: default
+      # This is per target. Two FastAPI replicas can expose at most 30k samples
+      # per scrape, while a runaway per-player label cannot return hundreds of
+      # thousands of samples to Prometheus again.
+      sampleLimit: 15000
     kubeletScrape:
       enabled: false
     staticScrapeConfigs: []

--- a/helm/splattop/templates/extra-services.yaml
+++ b/helm/splattop/templates/extra-services.yaml
@@ -43,7 +43,7 @@ spec:
 
 {{- range $component, $config := dict "fastapi" .Values.fastapi "react" .Values.react "celeryWorker" .Values.celeryWorker "celeryBeat" .Values.celeryBeat "redis" .Values.redis "splatnlp" .Values.splatnlp -}}
   {{- $extraServices := dig "service" "extraServices" list $config -}}
-  {{- $enabled := default true (dig "enabled" nil $config) -}}
+  {{- $enabled := dig "enabled" true $config -}}
   {{- if and $enabled $extraServices }}
     {{- range $service := $extraServices }}
 ---

--- a/helm/splattop/values-prod.yaml
+++ b/helm/splattop/values-prod.yaml
@@ -76,6 +76,9 @@ redis:
 
 # SplatNLP compatibility service overrides
 splatnlp:
+  # Retired in production: the service has no active consumers and its loaded
+  # model held roughly 529 MiB of working-set memory continuously.
+  enabled: false
   service:
     extraServices:
     - name: splatnlp-service

--- a/tests/test_garz_observability_kube_state_metrics.py
+++ b/tests/test_garz_observability_kube_state_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import unittest
@@ -195,6 +196,53 @@ class GarzObservabilityKubeStateMetricsTests(unittest.TestCase):
         self.assertIn(
             "replacement: /api/v1/nodes/${1}/proxy/metrics",
             prometheus_config,
+        )
+
+    def test_fastapi_scrape_discovers_default_namespace_with_sample_guardrail(
+        self,
+    ) -> None:
+        prometheus_config = _find_doc(
+            self.docs,
+            kind="ConfigMap",
+            name="prometheus-config",
+            namespace="monitoring",
+        )["data"]["prometheus.yml"]
+
+        self.assertIn("job_name: fastapi", prometheus_config)
+        self.assertIn("sample_limit: 15000", prometheus_config)
+        self.assertIn('regex: "default"', prometheus_config)
+
+    def test_prometheus_has_runtime_and_query_memory_guardrails(self) -> None:
+        stateful_set = _find_doc(
+            self.docs,
+            kind="StatefulSet",
+            name="splattop-prod-prometheus",
+            namespace="monitoring",
+        )
+        container = stateful_set["spec"]["template"]["spec"]["containers"][0]
+
+        self.assertIn("--query.max-samples=5000000", container["args"])
+        self.assertIn("--query.max-concurrency=5", container["args"])
+        self.assertIn("--query.timeout=60s", container["args"])
+        self.assertIn(
+            {"name": "GOMEMLIMIT", "value": "1200MiB"},
+            container["env"],
+        )
+
+        pod_annotations = stateful_set["spec"]["template"]["metadata"][
+            "annotations"
+        ]
+        self.assertTrue(
+            re.fullmatch(
+                r"[a-f0-9]{64}",
+                pod_annotations["checksum/prometheus-config"],
+            )
+        )
+        self.assertTrue(
+            re.fullmatch(
+                r"[a-f0-9]{64}",
+                pod_annotations["checksum/prometheus-rules"],
+            )
         )
 
 

--- a/tests/test_splattop_memory_tuning.py
+++ b/tests/test_splattop_memory_tuning.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+
+def _render_splattop_prod() -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "splattop-prod",
+            "helm/splattop",
+            "--namespace",
+            "default",
+            "-f",
+            "helm/splattop/values-prod.yaml",
+        ],
+        check=True,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    return [
+        doc
+        for doc in YAML_PARSER.load_all(result.stdout)
+        if isinstance(doc, dict) and doc
+    ]
+
+
+class SplatTopMemoryTuningTests(unittest.TestCase):
+    def test_splatnlp_is_not_rendered_in_production(self) -> None:
+        docs = _render_splattop_prod()
+        splatnlp_objects = [
+            doc
+            for doc in docs
+            if "splatnlp" in doc.get("metadata", {}).get("name", "")
+        ]
+
+        self.assertEqual(splatnlp_objects, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Retire production SplatNLP, reclaiming approximately 529 MiB of persistent working-set memory.
- Fix Helm handling of explicit `enabled: false` values so disabled components do not retain compatibility Services.
- Fix FastAPI Prometheus discovery to target the `default` namespace.
- Limit FastAPI scrapes to 15,000 samples per replica.
- Add Prometheus safeguards:
  - `GOMEMLIMIT=1200MiB`
  - 5,000,000 maximum query samples
  - 5 concurrent queries
  - 60-second query timeout
- Add config and rules checksums to the Prometheus pod template so future ConfigMap changes trigger a rollout.

Celery, PyVips workers, Redis, resource limits, and replica counts are unchanged.

## Expected impact

SplatNLP retirement should immediately recover about 529 MiB after Argo pruning. Prometheus gains bounded query/cardinality failure modes and explicit Go runtime headroom below its 2 GiB container limit. The 15k limit permits roughly 30k samples across two FastAPI replicas while rejecting a return to hundreds of thousands of per-player series.

`GOMEMLIMIT` is a soft Go runtime target, so Prometheus memory should be observed for 24-72 hours after rollout.

## Validation

- Helm lint passed for `splattop` and `garz-observability`.
- Production render confirms no SplatNLP objects.
- All 104 GitOps tests passed.
- Prometheus v2.52 `promtool` accepted the configuration.
- All 15 alert rules passed `promtool`.
- `git diff --check` passed.

## Rollout order

1. Merge and deploy [SplatTop #80](https://github.com/cesaregarza/SplatTop/pull/80), which removes `player_id` metric labels.
2. Merge this PR.
3. Manually sync `splattop-prod` with prune to deploy the label-free image and delete SplatNLP.
4. Manually sync `garz-observability`; expect one Prometheus restart and WAL replay.
5. Verify Prometheus readiness, FastAPI target health, query flags, and SplatNLP removal.
6. Observe memory, scrape failures, and query behavior for 24-72 hours.

Argo automation is disabled, so merging alone does not change the cluster. If the application metric change is delayed, the sample limit safely rejects an oversized FastAPI scrape.

Linear: [CES-571](https://linear.app/cegarza/issue/CES-571/right-size-pod-resource-reservations-from-metrics-server-data-unstick)