### PR TITLE
CES-573: add release-scoped worker identity chart contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,6 +190,10 @@ jobs:
             path: helm/skyquiet-server
             release: skyquiet-server
             prod_values: helm/skyquiet-server/values.yaml
+          - name: agent-workloads
+            path: helm/agent-workloads
+            release: agent-workloads
+            prod_values: apps/agent-workloads/values.yaml
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/helm/agent-workloads/templates/_helpers.tpl
+++ b/helm/agent-workloads/templates/_helpers.tpl
@@ -98,6 +98,63 @@ Service account name.
 {{- end }}
 
 {{/*
+Normalize a worker id for a DNS-label ServiceAccount name.
+*/}}
+{{- define "agent-workloads.projectedIdentityWorkerName" -}}
+{{- regexReplaceAll "[^a-z0-9]+" (lower .Values.projectedWorkloadIdentity.workerId) "-" | trimAll "-" -}}
+{{- end }}
+
+{{/*
+Build a release-scoped ServiceAccount name from the trusted immutable release
+tuple. The 20-hex (80-bit) suffix is part of the verifier binding, so fail
+rather than truncating it.
+*/}}
+{{- define "agent-workloads.releaseScopedServiceAccountName" -}}
+{{- $root := .root -}}
+{{- $release := required "release-scoped ServiceAccount requires an immutable release tuple" .release -}}
+{{- $codeDigest := required "release-scoped ServiceAccount requires codeDigest" $release.codeDigest -}}
+{{- $manifestDigest := required "release-scoped ServiceAccount requires manifestDigest" $release.manifestDigest -}}
+{{- $imageDigest := required "release-scoped ServiceAccount requires imageDigest" $release.imageDigest -}}
+{{- range $label, $digest := dict "codeDigest" $codeDigest "manifestDigest" $manifestDigest "imageDigest" $imageDigest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $digest) -}}
+{{- fail (printf "release-scoped ServiceAccount %s must be lowercase sha256:<64 hex>" $label) -}}
+{{- end -}}
+{{- end -}}
+{{- $workerName := include "agent-workloads.projectedIdentityWorkerName" $root -}}
+{{- if not (regexMatch "^[a-z0-9]+(-[a-z0-9]+)*$" $workerName) -}}
+{{- fail "projectedWorkloadIdentity.workerId must normalize to a DNS label" -}}
+{{- end -}}
+{{- $bundlePayload := printf "{\"code_digest\":\"%s\",\"image_digest\":\"%s\",\"manifest_digest\":\"%s\",\"schema_version\":\"workload_identity_bundle.v1\"}" $codeDigest $imageDigest $manifestDigest -}}
+{{- $digestSuffix := trunc 20 (sha256sum $bundlePayload) -}}
+{{- $name := printf "%s-%s-%s" $root.Values.projectedWorkloadIdentity.serviceAccountNamePrefix $workerName $digestSuffix -}}
+{{- if gt (len $name) 63 -}}
+{{- fail "release-scoped ServiceAccount name exceeds 63 characters" -}}
+{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $name) -}}
+{{- fail "release-scoped ServiceAccount name must be a DNS label" -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/* Current projected-identity ServiceAccount. */}}
+{{- define "agent-workloads.projectedIdentityServiceAccountName" -}}
+{{- $workerId := .Values.projectedWorkloadIdentity.workerId -}}
+{{- $releasePins := required "projected identity requires mandateReleasePins" .Values.mandateReleasePins -}}
+{{- $workerPins := required (printf "projected identity requires mandateReleasePins[%s]" $workerId) (index $releasePins $workerId) -}}
+{{- include "agent-workloads.releaseScopedServiceAccountName" (dict "root" . "release" $workerPins) -}}
+{{- end }}
+
+{{/* Previous projected-identity ServiceAccount retained during rollout overlap. */}}
+{{- define "agent-workloads.previousProjectedIdentityServiceAccountName" -}}
+{{- include "agent-workloads.releaseScopedServiceAccountName" (dict "root" . "release" .Values.projectedWorkloadIdentity.previousRelease) -}}
+{{- end }}
+
+{{/* Full projected worker token path. */}}
+{{- define "agent-workloads.projectedIdentityTokenPath" -}}
+{{- printf "%s/%s" (trimSuffix "/" .Values.projectedWorkloadIdentity.token.mountPath) .Values.projectedWorkloadIdentity.token.fileName -}}
+{{- end }}
+
+{{/*
 Runtime environment.
 */}}
 {{- define "agent-workloads.runtimeEnv" -}}

--- a/helm/agent-workloads/templates/deployment.yaml
+++ b/helm/agent-workloads/templates/deployment.yaml
@@ -1,3 +1,74 @@
+{{- if .Values.projectedWorkloadIdentity.enabled }}
+{{- $workerId := required "projected identity requires workerId" .Values.projectedWorkloadIdentity.workerId }}
+{{- $releasePins := required "projected identity requires mandateReleasePins" .Values.mandateReleasePins }}
+{{- $currentRelease := required (printf "projected identity requires mandateReleasePins[%s]" $workerId) (index $releasePins $workerId) }}
+{{- $pinnedImageDigest := required "projected identity current release requires imageDigest" $currentRelease.imageDigest }}
+{{- $runtimeImageDigest := required "projected identity requires immutable image.digest" .Values.image.digest }}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $runtimeImageDigest) }}
+{{- fail "projected identity image.digest must be lowercase sha256:<64 hex>" }}
+{{- end }}
+{{- if ne $runtimeImageDigest $pinnedImageDigest }}
+{{- fail "projected identity image.digest must equal current release imageDigest" }}
+{{- end }}
+{{- $projectedTokenAudience := required "projected worker identity audience is required" .Values.projectedWorkloadIdentity.token.audience }}
+{{- if ne $projectedTokenAudience (trim $projectedTokenAudience) }}
+{{- fail "projected worker identity audience must not have surrounding whitespace" }}
+{{- end }}
+{{- $projectedTokenExpirationSeconds := int .Values.projectedWorkloadIdentity.token.expirationSeconds }}
+{{- if or (lt $projectedTokenExpirationSeconds 600) (gt $projectedTokenExpirationSeconds 3600) }}
+{{- fail "projected worker identity expirationSeconds must be between 600 and 3600" }}
+{{- end }}
+{{- $projectedTokenMountPath := required "projected worker identity mountPath is required" .Values.projectedWorkloadIdentity.token.mountPath }}
+{{- if or (ne $projectedTokenMountPath (trim $projectedTokenMountPath)) (not (regexMatch "^/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$" $projectedTokenMountPath)) (regexMatch "(^|/)\\.\\.?(/|$)" $projectedTokenMountPath) }}
+{{- fail "projected worker identity mountPath must be a normalized absolute path" }}
+{{- end }}
+{{- $projectedTokenFileName := required "projected worker identity fileName is required" .Values.projectedWorkloadIdentity.token.fileName }}
+{{- if or (ne $projectedTokenFileName (trim $projectedTokenFileName)) (not (regexMatch "^[A-Za-z0-9._-]+$" $projectedTokenFileName)) (eq $projectedTokenFileName ".") (eq $projectedTokenFileName "..") }}
+{{- fail "projected worker identity fileName must be a normalized basename" }}
+{{- end }}
+{{- $currentProjectedServiceAccount := include "agent-workloads.projectedIdentityServiceAccountName" . }}
+{{- $sharedServiceAccount := include "agent-workloads.serviceAccountName" . }}
+{{- if eq $currentProjectedServiceAccount $sharedServiceAccount }}
+{{- fail "projected current release ServiceAccount must differ from the shared legacy ServiceAccount" }}
+{{- end }}
+{{- with .Values.projectedWorkloadIdentity.previousRelease }}
+{{- $previousProjectedServiceAccount := include "agent-workloads.previousProjectedIdentityServiceAccountName" $ }}
+{{- if eq $previousProjectedServiceAccount $currentProjectedServiceAccount }}
+{{- fail "projected previous and current release ServiceAccounts must differ" }}
+{{- end }}
+{{- if eq $previousProjectedServiceAccount $sharedServiceAccount }}
+{{- fail "projected previous release ServiceAccount must differ from the shared legacy ServiceAccount" }}
+{{- end }}
+{{- end }}
+{{- if ne .Values.projectedWorkloadIdentity.workerId .Values.env.AGENT_WORKLOADS_WORKER_ID }}
+{{- fail "projected identity workerId must match AGENT_WORKLOADS_WORKER_ID" }}
+{{- end }}
+{{- if has "MANDATE_WORKLOAD_IDENTITY_TOKEN" .Values.secretKeys }}
+{{- fail "projected identity pod must not inject a static workload identity token" }}
+{{- end }}
+{{- if hasKey .Values.secretEnv "MANDATE_WORKLOAD_IDENTITY_TOKEN" }}
+{{- fail "projected identity pod must not inject a static workload identity token" }}
+{{- end }}
+{{- if hasKey .Values.env "MANDATE_WORKLOAD_IDENTITY_TOKEN" }}
+{{- fail "projected identity pod must not inject a static workload identity token" }}
+{{- end }}
+{{- if hasKey .Values.env "MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE" }}
+{{- fail "projected identity token file env is chart-owned" }}
+{{- end }}
+{{- range .Values.extraVolumes }}
+{{- with .secret }}
+{{- if eq .secretName "agent-workloads-workload-identity-tokens" }}
+{{- fail "projected identity pod must not mount the legacy identity Secret" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- range .Values.extraVolumeMounts }}
+{{- $extraMountPath := clean (required "extra volume mount requires mountPath" .mountPath) }}
+{{- if or (eq $extraMountPath "/") (eq $extraMountPath $projectedTokenMountPath) (hasPrefix (printf "%s/" $projectedTokenMountPath) $extraMountPath) (hasPrefix (printf "%s/" $extraMountPath) $projectedTokenMountPath) }}
+{{- fail "extra volume mount must not overlap the projected identity token path" }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,12 +89,19 @@ spec:
         {{- end }}
       annotations:
         checksum.garz.ai/agent-workloads-release-pins: {{ include "agent-workloads.releasePinsChecksum" . | quote }}
+        {{- if not .Values.projectedWorkloadIdentity.enabled }}
         checksum.garz.ai/agent-workloads-token-secret: {{ include "agent-workloads.workloadIdentityTokenSecretChecksum" . | quote }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: false
+      {{- if .Values.projectedWorkloadIdentity.enabled }}
+      serviceAccountName: {{ include "agent-workloads.projectedIdentityServiceAccountName" . }}
+      {{- else }}
       serviceAccountName: {{ include "agent-workloads.serviceAccountName" . }}
+      {{- end }}
       {{- include "agent-workloads.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -39,6 +117,10 @@ spec:
           {{- end }}
           env:
             {{- include "agent-workloads.runtimeEnv" . | nindent 12 }}
+            {{- if .Values.projectedWorkloadIdentity.enabled }}
+            - name: MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE
+              value: {{ include "agent-workloads.projectedIdentityTokenPath" . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
@@ -46,12 +128,28 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.projectedWorkloadIdentity.enabled }}
+            - name: projected-workload-identity-token
+              mountPath: {{ .Values.projectedWorkloadIdentity.token.mountPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.projectedWorkloadIdentity.enabled }}
+        - name: projected-workload-identity-token
+          projected:
+            # Decimal 288 is octal 0440; decimal avoids YAML 1.1/1.2 ambiguity.
+            defaultMode: 288
+            sources:
+              - serviceAccountToken:
+                  audience: {{ required "projected worker identity audience is required" .Values.projectedWorkloadIdentity.token.audience | quote }}
+                  expirationSeconds: {{ int .Values.projectedWorkloadIdentity.token.expirationSeconds }}
+                  path: {{ .Values.projectedWorkloadIdentity.token.fileName | quote }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
+++ b/helm/agent-workloads/templates/opencode-proposer-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: false
       serviceAccountName: {{ include "agent-workloads.serviceAccountName" . }}
       enableServiceLinks: false
       {{- include "agent-workloads.imagePullSecrets" . | nindent 6 }}

--- a/helm/agent-workloads/templates/serviceaccount.yaml
+++ b/helm/agent-workloads/templates/serviceaccount.yaml
@@ -11,3 +11,35 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
+{{- if and .Values.projectedWorkloadIdentity.enabled .Values.projectedWorkloadIdentity.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-workloads.projectedIdentityServiceAccountName" . }}
+  labels:
+    {{- include "agent-workloads.labels" . | nindent 4 }}
+    app.kubernetes.io/component: projected-workload-identity
+    mandate.cesaregarza.io/worker-id: {{ .Values.projectedWorkloadIdentity.workerId | quote }}
+  {{- with .Values.projectedWorkloadIdentity.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- with .Values.projectedWorkloadIdentity.previousRelease }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-workloads.previousProjectedIdentityServiceAccountName" $ }}
+  labels:
+    {{- include "agent-workloads.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: projected-workload-identity-previous
+    mandate.cesaregarza.io/worker-id: {{ $.Values.projectedWorkloadIdentity.workerId | quote }}
+  {{- with $.Values.projectedWorkloadIdentity.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}
+{{- end }}

--- a/helm/agent-workloads/values.schema.json
+++ b/helm/agent-workloads/values.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "projectedWorkloadIdentity": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "workerId",
+        "serviceAccountNamePrefix",
+        "serviceAccount",
+        "token"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "workerId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "serviceAccountNamePrefix": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+        },
+        "serviceAccount": {
+          "type": "object",
+          "required": [
+            "create",
+            "annotations"
+          ],
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "token": {
+          "type": "object",
+          "required": [
+            "audience",
+            "expirationSeconds",
+            "mountPath",
+            "fileName"
+          ],
+          "properties": {
+            "audience": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expirationSeconds": {
+              "type": "integer",
+              "minimum": 600,
+              "maximum": 3600
+            },
+            "mountPath": {
+              "type": "string",
+              "minLength": 2
+            },
+            "fileName": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "previousRelease": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "codeDigest",
+            "manifestDigest",
+            "imageDigest"
+          ],
+          "properties": {
+            "codeDigest": {
+              "$ref": "#/definitions/sha256Digest"
+            },
+            "manifestDigest": {
+              "$ref": "#/definitions/sha256Digest"
+            },
+            "imageDigest": {
+              "$ref": "#/definitions/sha256Digest"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/helm/agent-workloads/values.yaml
+++ b/helm/agent-workloads/values.yaml
@@ -18,6 +18,24 @@ serviceAccount:
   automountServiceAccountToken: false
   annotations: {}
 
+# Release-scoped projected ServiceAccount identity. Keep disabled in generic
+# installs and enable a worker explicitly during its identity migration. The
+# ServiceAccount name binds the worker id to the immutable full release tuple.
+projectedWorkloadIdentity:
+  enabled: false
+  workerId: data.workspace_probe
+  serviceAccountNamePrefix: agent-workloads
+  serviceAccount:
+    create: true
+    annotations: {}
+  token:
+    audience: mandate-api
+    expirationSeconds: 3600
+    mountPath: /var/run/mandate/workload-identity
+    fileName: token
+  # During a re-pin, retain the prior immutable tuple until old pods drain.
+  previousRelease: null
+
 podAnnotations: {}
 podLabels: {}
 extraVolumes: []

--- a/tests/test_agent_workloads_projected_identity_chart.py
+++ b/tests/test_agent_workloads_projected_identity_chart.py
@@ -418,7 +418,7 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
         result = _render_process(values)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "projectedWorkloadIdentity.token.audience",
+            "audience",
             result.stderr,
         )
 
@@ -456,14 +456,14 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
                 lambda values: values["projectedWorkloadIdentity"]["token"].update(
                     {"expirationSeconds": 0}
                 ),
-                "Must be greater than or equal to 600",
+                "expirationSeconds",
             ),
             (
                 "long expiration",
                 lambda values: values["projectedWorkloadIdentity"]["token"].update(
                     {"expirationSeconds": 3601}
                 ),
-                "Must be less than or equal to 3600",
+                "expirationSeconds",
             ),
             (
                 "whitespace audience",

--- a/tests/test_agent_workloads_projected_identity_chart.py
+++ b/tests/test_agent_workloads_projected_identity_chart.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART_PATH = REPO_ROOT / "helm" / "agent-workloads"
+PRODUCTION_VALUES_PATH = REPO_ROOT / "apps" / "agent-workloads" / "values.yaml"
+YAML_PARSER = YAML(typ="safe")
+
+CURRENT_RELEASE = {
+    "codeDigest": "sha256:" + "1" * 64,
+    "manifestDigest": "sha256:" + "2" * 64,
+    "imageDigest": "sha256:" + "3" * 64,
+}
+PREVIOUS_RELEASE = {
+    **CURRENT_RELEASE,
+    "imageDigest": "sha256:" + "4" * 64,
+}
+CURRENT_SERVICE_ACCOUNT = "agent-workloads-data-workspace-probe-2495342f395034d0f1c9"
+PREVIOUS_SERVICE_ACCOUNT = "agent-workloads-data-workspace-probe-6a4b1ee0b9d51c8f72b8"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    value = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"{path} must contain a mapping")
+    return value
+
+
+def _render_process(
+    values: dict[str, Any] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        if values is None:
+            values_path = PRODUCTION_VALUES_PATH
+        else:
+            values_path = Path(temp_dir) / "values.yaml"
+            with values_path.open("w", encoding="utf-8") as values_file:
+                YAML_PARSER.dump(values, values_file)
+
+        return subprocess.run(
+            [
+                "helm",
+                "template",
+                "agent-workloads",
+                str(CHART_PATH),
+                "-f",
+                str(values_path),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+def _render(values: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    result = _render_process(values)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    documents = [
+        document
+        for document in YAML_PARSER.load_all(result.stdout)
+        if isinstance(document, dict) and document
+    ]
+    if not documents:
+        raise AssertionError("helm rendered no Kubernetes documents")
+    return documents
+
+
+def _find_document(
+    documents: list[dict[str, Any]],
+    *,
+    kind: str,
+    name: str,
+) -> dict[str, Any]:
+    for document in documents:
+        if (
+            document.get("kind") == kind
+            and document.get("metadata", {}).get("name") == name
+        ):
+            return document
+    raise AssertionError(f"{kind}/{name} not rendered")
+
+
+def _container(
+    deployment: dict[str, Any],
+    name: str,
+) -> dict[str, Any]:
+    for container in deployment["spec"]["template"]["spec"]["containers"]:
+        if container["name"] == name:
+            return container
+    raise AssertionError(f"container {name} not rendered")
+
+
+def _environment(container: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entry["name"]: entry for entry in container.get("env", [])}
+
+
+class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.production_values = _load_yaml(PRODUCTION_VALUES_PATH)
+
+    def _projected_values(self) -> dict[str, Any]:
+        values = copy.deepcopy(self.production_values)
+        values["projectedWorkloadIdentity"] = {
+            "enabled": True,
+            "workerId": "data.workspace_probe",
+            "serviceAccountNamePrefix": "agent-workloads",
+            "serviceAccount": {
+                "create": True,
+                "annotations": {},
+            },
+            "token": {
+                "audience": "mandate-api-staging",
+                "expirationSeconds": 1800,
+                "mountPath": "/var/run/mandate/workload-identity",
+                "fileName": "token",
+            },
+            "previousRelease": copy.deepcopy(PREVIOUS_RELEASE),
+        }
+        values["mandateReleasePins"]["data.workspace_probe"] = copy.deepcopy(
+            CURRENT_RELEASE
+        )
+        values["image"]["digest"] = CURRENT_RELEASE["imageDigest"]
+        values["env"].pop("MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE")
+        values["extraVolumes"] = []
+        values["extraVolumeMounts"] = []
+        return values
+
+    def test_production_values_remain_legacy_and_render_successfully(self) -> None:
+        documents = _render()
+        worker = _find_document(
+            documents,
+            kind="Deployment",
+            name="agent-workloads",
+        )
+        worker_pod = worker["spec"]["template"]["spec"]
+        worker_volumes = {volume["name"]: volume for volume in worker_pod["volumes"]}
+
+        self.assertIs(worker_pod["automountServiceAccountToken"], False)
+        self.assertEqual(worker_pod["serviceAccountName"], "agent-workloads")
+        self.assertEqual(
+            worker_volumes["workload-identity-token"]["secret"]["secretName"],
+            "agent-workloads-workload-identity-tokens",
+        )
+        self.assertEqual(
+            _environment(_container(worker, "worker"))[
+                "MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE"
+            ]["value"],
+            "/var/run/mandate/workload-identity/token",
+        )
+        self.assertIn(
+            "checksum.garz.ai/agent-workloads-token-secret",
+            worker["spec"]["template"]["metadata"]["annotations"],
+        )
+
+        service_accounts = [
+            document
+            for document in documents
+            if document.get("kind") == "ServiceAccount"
+        ]
+        self.assertEqual(
+            {account["metadata"]["name"] for account in service_accounts},
+            {"agent-workloads"},
+        )
+
+        opencode = _find_document(
+            documents,
+            kind="Deployment",
+            name="agent-workloads-opencode-proposer",
+        )
+        opencode_pod = opencode["spec"]["template"]["spec"]
+        self.assertIs(opencode_pod["automountServiceAccountToken"], False)
+        self.assertEqual(opencode_pod["serviceAccountName"], "agent-workloads")
+        self.assertNotIn(
+            "projected-workload-identity-token",
+            {volume["name"] for volume in opencode_pod["volumes"]},
+        )
+
+    def test_projected_current_and_previous_release_identity_render(self) -> None:
+        canonical_payload = {
+            "schema_version": "workload_identity_bundle.v1",
+            "code_digest": CURRENT_RELEASE["codeDigest"],
+            "manifest_digest": CURRENT_RELEASE["manifestDigest"],
+            "image_digest": CURRENT_RELEASE["imageDigest"],
+        }
+        expected_suffix = hashlib.sha256(
+            json.dumps(
+                canonical_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()[:20]
+        self.assertEqual(expected_suffix, "2495342f395034d0f1c9")
+
+        documents = _render(self._projected_values())
+        service_accounts = {
+            document["metadata"]["name"]: document
+            for document in documents
+            if document.get("kind") == "ServiceAccount"
+        }
+        self.assertEqual(
+            set(service_accounts),
+            {
+                "agent-workloads",
+                CURRENT_SERVICE_ACCOUNT,
+                PREVIOUS_SERVICE_ACCOUNT,
+            },
+        )
+        self.assertNotEqual(CURRENT_SERVICE_ACCOUNT, PREVIOUS_SERVICE_ACCOUNT)
+        for name in (CURRENT_SERVICE_ACCOUNT, PREVIOUS_SERVICE_ACCOUNT):
+            self.assertIs(service_accounts[name]["automountServiceAccountToken"], False)
+
+        worker = _find_document(
+            documents,
+            kind="Deployment",
+            name="agent-workloads",
+        )
+        worker_template = worker["spec"]["template"]
+        worker_pod = worker_template["spec"]
+        self.assertIs(worker_pod["automountServiceAccountToken"], False)
+        self.assertEqual(worker_pod["serviceAccountName"], CURRENT_SERVICE_ACCOUNT)
+        self.assertNotIn(
+            "checksum.garz.ai/agent-workloads-token-secret",
+            worker_template["metadata"]["annotations"],
+        )
+
+        worker_volumes = {volume["name"]: volume for volume in worker_pod["volumes"]}
+        self.assertNotIn("workload-identity-token", worker_volumes)
+        self.assertEqual(
+            worker_volumes["projected-workload-identity-token"]["projected"],
+            {
+                "defaultMode": 0o440,
+                "sources": [
+                    {
+                        "serviceAccountToken": {
+                            "audience": "mandate-api-staging",
+                            "expirationSeconds": 1800,
+                            "path": "token",
+                        }
+                    }
+                ],
+            },
+        )
+        self.assertFalse(
+            any("secret" in volume for volume in worker_pod["volumes"]),
+            "projected worker must not inject any legacy Secret volume",
+        )
+        worker_env = _environment(_container(worker, "worker"))
+        self.assertEqual(
+            worker_env["MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE"]["value"],
+            "/var/run/mandate/workload-identity/token",
+        )
+        self.assertNotIn("MANDATE_WORKLOAD_IDENTITY_TOKEN", worker_env)
+
+        opencode = _find_document(
+            documents,
+            kind="Deployment",
+            name="agent-workloads-opencode-proposer",
+        )
+        opencode_template = opencode["spec"]["template"]
+        opencode_pod = opencode_template["spec"]
+        self.assertIs(opencode_pod["automountServiceAccountToken"], False)
+        self.assertEqual(opencode_pod["serviceAccountName"], "agent-workloads")
+        self.assertNotIn(
+            "projected-workload-identity-token",
+            {volume["name"] for volume in opencode_pod["volumes"]},
+        )
+        self.assertIn(
+            "checksum.garz.ai/agent-workloads-token-secret",
+            opencode_template["metadata"]["annotations"],
+        )
+        for container_name in ("opencode-proposer", "opencode-apply-executor"):
+            token = _environment(_container(opencode, container_name))[
+                "MANDATE_WORKLOAD_IDENTITY_TOKEN"
+            ]
+            self.assertIn("secretKeyRef", token["valueFrom"])
+
+    def test_projected_worker_is_decoupled_from_legacy_token_checksum(self) -> None:
+        values = self._projected_values()
+        original_documents = _render(values)
+        values["rolloutChecksums"]["workloadIdentityTokenSecret"] = "sha256:" + "9" * 64
+        changed_documents = _render(values)
+
+        def annotations(
+            documents: list[dict[str, Any]],
+            deployment_name: str,
+        ) -> dict[str, str]:
+            deployment = _find_document(
+                documents,
+                kind="Deployment",
+                name=deployment_name,
+            )
+            return deployment["spec"]["template"]["metadata"]["annotations"]
+
+        self.assertEqual(
+            annotations(original_documents, "agent-workloads"),
+            annotations(changed_documents, "agent-workloads"),
+        )
+        self.assertNotEqual(
+            annotations(original_documents, "agent-workloads-opencode-proposer"),
+            annotations(changed_documents, "agent-workloads-opencode-proposer"),
+        )
+
+    def test_projected_identity_rejects_static_identity_injection(self) -> None:
+        def add_static_secret_key(values: dict[str, Any]) -> None:
+            values["secretKeys"].append("MANDATE_WORKLOAD_IDENTITY_TOKEN")
+
+        def add_static_secret_env(values: dict[str, Any]) -> None:
+            values["secretEnv"]["MANDATE_WORKLOAD_IDENTITY_TOKEN"] = "TOKEN"
+
+        def add_static_env(values: dict[str, Any]) -> None:
+            values["env"]["MANDATE_WORKLOAD_IDENTITY_TOKEN"] = "static"
+
+        def add_token_file_env(values: dict[str, Any]) -> None:
+            values["env"]["MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE"] = "/tmp/token"
+
+        def add_legacy_secret_volume(values: dict[str, Any]) -> None:
+            values["extraVolumes"] = [
+                {
+                    "name": "legacy-token",
+                    "secret": {
+                        "secretName": "agent-workloads-workload-identity-tokens"
+                    },
+                }
+            ]
+
+        def claim_projected_mount_path(values: dict[str, Any]) -> None:
+            values["extraVolumeMounts"] = [
+                {
+                    "name": "other-token",
+                    "mountPath": "/var/run/mandate/workload-identity",
+                }
+            ]
+
+        def shadow_projected_token_file(values: dict[str, Any]) -> None:
+            values["extraVolumes"] = [
+                {
+                    "name": "shadow-token",
+                    "secret": {"secretName": "unrelated-secret"},
+                }
+            ]
+            values["extraVolumeMounts"] = [
+                {
+                    "name": "shadow-token",
+                    "mountPath": "/var/run/mandate/workload-identity/token",
+                    "subPath": "token",
+                    "readOnly": True,
+                }
+            ]
+
+        cases: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+            (
+                "secret key",
+                add_static_secret_key,
+                "must not inject a static workload identity token",
+            ),
+            (
+                "secret env",
+                add_static_secret_env,
+                "must not inject a static workload identity token",
+            ),
+            (
+                "plain env",
+                add_static_env,
+                "must not inject a static workload identity token",
+            ),
+            (
+                "token file env",
+                add_token_file_env,
+                "token file env is chart-owned",
+            ),
+            (
+                "legacy secret volume",
+                add_legacy_secret_volume,
+                "must not mount the legacy identity Secret",
+            ),
+            (
+                "projected mount path",
+                claim_projected_mount_path,
+                "must not overlap the projected identity token path",
+            ),
+            (
+                "shadow projected token file",
+                shadow_projected_token_file,
+                "must not overlap the projected identity token path",
+            ),
+        )
+
+        for label, mutation, expected_error in cases:
+            with self.subTest(label=label):
+                values = self._projected_values()
+                mutation(values)
+                result = _render_process(values)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
+    def test_projected_identity_requires_a_nonempty_audience(self) -> None:
+        values = self._projected_values()
+        values["projectedWorkloadIdentity"]["token"]["audience"] = ""
+        result = _render_process(values)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "projectedWorkloadIdentity.token.audience",
+            result.stderr,
+        )
+
+    def test_projected_identity_binds_the_runtime_image_digest(self) -> None:
+        cases = (
+            (
+                "missing runtime digest",
+                "",
+                "projected identity requires immutable image.digest",
+            ),
+            (
+                "mutable-looking digest",
+                "latest",
+                "image.digest must be lowercase sha256:<64 hex>",
+            ),
+            (
+                "different immutable digest",
+                "sha256:" + "9" * 64,
+                "image.digest must equal current release imageDigest",
+            ),
+        )
+
+        for label, digest, expected_error in cases:
+            with self.subTest(label=label):
+                values = self._projected_values()
+                values["image"]["digest"] = digest
+                result = _render_process(values)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
+    def test_projected_identity_rejects_unsafe_token_settings(self) -> None:
+        cases: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+            (
+                "short expiration",
+                lambda values: values["projectedWorkloadIdentity"]["token"].update(
+                    {"expirationSeconds": 0}
+                ),
+                "Must be greater than or equal to 600",
+            ),
+            (
+                "long expiration",
+                lambda values: values["projectedWorkloadIdentity"]["token"].update(
+                    {"expirationSeconds": 3601}
+                ),
+                "Must be less than or equal to 3600",
+            ),
+            (
+                "whitespace audience",
+                lambda values: values["projectedWorkloadIdentity"]["token"].update(
+                    {"audience": " mandate-api"}
+                ),
+                "audience must not have surrounding whitespace",
+            ),
+            (
+                "non-normalized mount path",
+                lambda values: values["projectedWorkloadIdentity"]["token"].update(
+                    {"mountPath": "/var/run/../workload-identity"}
+                ),
+                "mountPath must be a normalized absolute path",
+            ),
+            (
+                "nested file name",
+                lambda values: values["projectedWorkloadIdentity"]["token"].update(
+                    {"fileName": "nested/token"}
+                ),
+                "fileName must be a normalized basename",
+            ),
+        )
+
+        for label, mutation, expected_error in cases:
+            with self.subTest(label=label):
+                values = self._projected_values()
+                mutation(values)
+                result = _render_process(values)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
+    def test_projected_identity_rejects_service_account_collisions(self) -> None:
+        cases: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+            (
+                "current equals previous",
+                lambda values: values["projectedWorkloadIdentity"].__setitem__(
+                    "previousRelease",
+                    copy.deepcopy(CURRENT_RELEASE),
+                ),
+                "projected previous and current release ServiceAccounts must differ",
+            ),
+            (
+                "current equals shared",
+                lambda values: values.setdefault("serviceAccount", {}).update(
+                    {"create": False, "name": CURRENT_SERVICE_ACCOUNT}
+                ),
+                (
+                    "projected current release ServiceAccount must differ from the "
+                    "shared legacy ServiceAccount"
+                ),
+            ),
+            (
+                "previous equals shared",
+                lambda values: values.setdefault("serviceAccount", {}).update(
+                    {"create": False, "name": PREVIOUS_SERVICE_ACCOUNT}
+                ),
+                (
+                    "projected previous release ServiceAccount must differ from the "
+                    "shared legacy ServiceAccount"
+                ),
+            ),
+        )
+
+        for label, mutation, expected_error in cases:
+            with self.subTest(label=label):
+                values = self._projected_values()
+                mutation(values)
+                result = _render_process(values)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a disabled-by-default projected workload identity contract to the reusable `agent-workloads` Helm chart
- derive current and optional previous release-scoped ServiceAccounts from the canonical full release tuple
- project a short-lived, audience-bound Kubernetes token into only the selected worker
- keep OpenCode proposer/apply on their existing shared ServiceAccount and HMAC credentials
- add chart values validation plus default/production/projected render coverage to CI

## Fail-closed guarantees

- projected mode requires an immutable runtime `image.digest` that exactly equals the current release tuple's `imageDigest`
- current, previous, and shared legacy ServiceAccount identities must remain distinct
- static workload-token injection is rejected
- extra mounts cannot shadow or overlap the projected token path, including Secret `subPath` mounts
- token audience, TTL (600–3600 seconds), mount path, and filename are validated
- the legacy token-secret checksum no longer rolls the projected worker, but still rolls OpenCode

## Scope

This PR adds chart infrastructure only. It does **not** enable projected identity in production and does not change application values, registry bindings, RBAC, source pins, secrets, tokens, or rollout orchestration.

The production render does gain explicit `automountServiceAccountToken: false` on worker and OpenCode pod templates. That is semantically equivalent to the existing shared ServiceAccount setting, but merging this PR will cause a one-time pod-template rollout.

Runtime workflow digest recomputation/attestation remains CES-576. OpenCode identity separation remains CES-577.

## Validation

- focused projected-identity suite: 8 passed, 18 subtests
- full repository suite: 112 passed
- independent adversarial remediation audit: clean
- Helm lint/render: default, production, and projected profiles passed
- kubeconform: 12/12 resources valid
- Ruff check/format, JSON schema parse, and `git diff --check`: clean

## Rollout order

This capability may merge while disabled. Enabling it remains ordered behind the compatible Core release and immutable worker release: Core substrate first, then the data-probe canary subject/tuple binding.

Refs CES-573, CES-576, CES-577.