### PR TITLE
CES-573: re-pin CP to e1b340f (Core K8s identity + CES-601 local-worker pin fix)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-bc4f2b7b2702
+  tag: sha-e1b340f81d5a
   pullPolicy: IfNotPresent
 
 secretKeys:
@@ -93,6 +93,12 @@ localWorker:
   capabilities: task.echo,approval.probe,readonly_sql,audit.digest,mandate.ops.inspect,mandate.deploy.smoke
   pollSeconds: 2
   batchSize: 1
+  # CES-601: the local worker is a credential-free model-gateway client, so its
+  # model_gateway provider fingerprints differently from the API process. Pin
+  # its true (no-auth) digests here instead of inheriting the shared auth-bearing
+  # top-level pin (which crash-loops it fail-closed).
+  env:
+    AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON: '{"model_gateway":{"digest":"sha256:72f9d4f2bb0220793aa81929272cfd8e93b45e55a97e59c371908b1bd393ead1","protocol":"model_gateway"},"readonly-sql-broker":{"digest":"sha256:73203a3ff8309cb762966f7559abf871f46a239c3136e7a5658eb069f52066c1","protocol":"readonly_sql"}}'
 
 callbackAdapter:
   health:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: bc4f2b7b27027a929113d103694001513a00e14e
+      targetRevision: e1b340f81d5af69f4e19bf53524801e75a453f61
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-bc4f2b7b2702` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-e1b340f81d5a` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-bc4f2b7b2702
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-e1b340f81d5a
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Re-pins the control plane to agent-platform `e1b340f` (CES-573 Core TokenReview verifier + CES-601 local-worker chart fix).

## Changes
- `image.tag` → `sha-e1b340f81d5a`, Application `targetRevision` → `e1b340f81d5af…`
- `localWorker.env.AGENT_PLATFORM_PROVIDER_DIGEST_PINS_JSON` = the credential-free worker's true no-auth digests (`model_gateway 72f9d4f2`, `readonly-sql 73203a3f`) via the new CES-601 chart override — fixes the fail-closed crash-loop.

## Safety
- **TokenReview disabled by default** (`workloadIdentity.kubernetesTokenReview.enabled=false`) → hybrid mode, HMAC still active. This roll lands the Core code + fixes the local-worker + applies the migration; it does **not** change auth behavior. Substrate-enable + worker + canary are later steps.
- Top-level / model-gateway pins unchanged (`2010eb78`/`73203a3f`); local provider-pins check passes for e1b340f + tag.
- Render verified: only the local-worker gets `72f9d4f2`; all other CP processes keep `2010eb78`.

## Deploy note
Carries migrations `014`+`015` → **sync with the hook strategy** so the PreSync migrate job runs (the 015 VALIDATE runs online).

Refs CES-573, CES-601.