### PR TITLE
CES-602: re-pin CP to faec13c (restore readonly_query)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-e1b340f81d5a
+  tag: sha-faec13c1ff6b
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: e1b340f81d5af69f4e19bf53524801e75a453f61
+      targetRevision: faec13c1ff6b5c1868c3266af18862b92e20b20a
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-e1b340f81d5a` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-faec13c1ff6b` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-e1b340f81d5a
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-faec13c1ff6b
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Re-pins the control plane to agent-platform `faec13c` (CES-602 fix — release tuple removed from the worker-facing lease projection).

- `image.tag` -> `sha-faec13c1ff6b`, Application `targetRevision` -> `faec13c1ff6b…`, restore-runbook image ref synced.
- **No provider-pin change** (#360 is contract/schema/test only); `localWorker.env` pin (`72f9d4f2`/`73203a3f`, CES-601) preserved — render + pins-check confirm control-api=2010eb78, local-worker=72f9d4f2.
- **No migration** rides this one → plain sync (pods roll on the image bump).

Restores `agent_workloads.readonly_query`, which the e1b340f Core roll broke via the worker claim-response contract skew. Live-verify to follow the sync.

Refs CES-602, CES-573.