### PR TITLE
CES-603: re-pin CP to d1f868e (restore opencode_orchestrate)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-faec13c1ff6b
+  tag: sha-d1f868e51233
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: faec13c1ff6b5c1868c3266af18862b92e20b20a
+      targetRevision: d1f868e51233b80f2bd0226e09d3444d46e44083
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-faec13c1ff6b` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-d1f868e51233` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-faec13c1ff6b
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-d1f868e51233
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Re-pins the control plane to agent-platform `d1f868e` (CES-603 fix — projects the `child_dispatch` worker grant so opencode_orchestrate gets its delegation ability again).

- `image.tag` -> `sha-d1f868e51233`, Application `targetRevision` -> `d1f868e51233…`, restore-runbook image ref synced.
- **No provider-pin change** (#361 is worker-services/contract/test only); `localWorker.env` pin (`72f9d4f2`/`73203a3f`, CES-601) preserved — render + pins-check confirm control-api=2010eb78, local-worker=72f9d4f2.
- **No migration** rides this one → plain sync (pods roll on the image bump; CES-352 scale-0→1 if the shared-PVC deadlock recurs).

Restores `agent_workloads.opencode_orchestrate`. Live-verify to follow the sync.

Refs CES-603.