### PR TITLE
CES-607: add trusted read/query user (private-admin surface, non-admin narrow binding)

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -57,3 +57,21 @@ bindings:
       allow:
         - mandate.deploy.smoke
         - agent_workloads.readonly_query
+  - id: private-admin-trusted-readonly
+    description: Narrower trusted-user binding on the private admin surface for a
+      non-admin trusted user. Read/query capabilities only (no propose, apply,
+      ops, deploy, or probes); cannot approve admin-gated actions or act on
+      other users' jobs.
+    surface_identifiers:
+      guild_id: "1523242748822425750"
+      channel_id: "1523242750043226234"
+    users:
+      admins: []
+      authorized:
+        - "98610679895846912"
+    capabilities:
+      allow:
+        - agent_workloads.readonly_query
+        - agent_workloads.opencode_orchestrate
+        - agent_workloads.opencode_task
+        - audit.digest

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -314,6 +314,24 @@ data:
           allow:
             - mandate.deploy.smoke
             - agent_workloads.readonly_query
+      - id: private-admin-trusted-readonly
+        description: Narrower trusted-user binding on the private admin surface for a
+          non-admin trusted user. Read/query capabilities only (no propose, apply,
+          ops, deploy, or probes); cannot approve admin-gated actions or act on
+          other users' jobs.
+        surface_identifiers:
+          guild_id: "1523242748822425750"
+          channel_id: "1523242750043226234"
+        users:
+          admins: []
+          authorized:
+            - "98610679895846912"
+        capabilities:
+          allow:
+            - agent_workloads.readonly_query
+            - agent_workloads.opencode_orchestrate
+            - agent_workloads.opencode_task
+            - audit.digest
   workload_imports.yaml: |
     schema_version: workload-imports.v1
     imports:


### PR DESCRIPTION
## What

Adds one new policy binding, `private-admin-trusted-readonly`, to `apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml`, and regenerates the kustomize-render golden fixture (`tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml`).

## Why

Grant a single **non-admin trusted user** read/query access on the existing private admin surface, narrower than the operator (`private-admin-controlled-capabilities`) binding.

## The binding

```yaml
  - id: private-admin-trusted-readonly
    description: Narrower trusted-user binding on the private admin surface for a
      non-admin trusted user. Read/query capabilities only (no propose, apply,
      ops, deploy, or probes); cannot approve admin-gated actions or act on
      other users' jobs.
    surface_identifiers:
      guild_id: "1523242748822425750"
      channel_id: "1523242750043226234"
    users:
      admins: []
      authorized:
        - "98610679895846912"
    capabilities:
      allow:
        - agent_workloads.readonly_query
        - agent_workloads.opencode_orchestrate
        - agent_workloads.opencode_task
        - audit.digest
```

## Authority notes (security-sensitive)

- **Authorized, not admin**: `admins: []`, single `authorized` user. This user cannot approve admin-gated actions and cannot act on other users' jobs.
- **Narrow allow-list**: read/query capabilities only. No `opencode_propose`/`opencode_apply`, no `readonly_sql`, no `db_probe`, no `mandate.ops.inspect`/`mandate.deploy.smoke`, no `task.echo`/`approval.probe`. No `approval_overrides`.
- Same private admin surface (`guild_id`/`channel_id`) as the operator binding; does **not** modify the existing `private-admin-controlled-capabilities` or `synthetic-live-verify-probe` bindings, or `defaults`.

## Golden regenerated / tests green

- `scripts/check_agent_control_plane_registry_overlay_render.py` PASS (kustomize v5.4.3, matching CI). Only semantic delta in the ConfigMap golden is the added binding inside the embedded `policy.prod.yaml` value; no other key/value churn.
- `python -m unittest discover -s tests`: 112 passed (incl. `test_agent_control_plane_registry_overlay`, `test_agent_control_plane_registry_compat`, `test_workload_enablement`).
- `scripts/generate_grant_ownership.py --check` and `scripts/check_control_plane_release_pin.py`: PASS.

Linear: CES-607