### PR TITLE
CES-607: Add trusted read/query policy binding

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -39,6 +39,22 @@ bindings:
       approval_overrides:
         approval.probe: admin_confirm
         agent_workloads.opencode_apply: admin_confirm
+  - id: private-admin-trusted-read-query
+    description: Narrow read and query access for a trusted non-admin user on
+      the private admin surface.
+    surface_identifiers:
+      guild_id: "1523242748822425750"
+      channel_id: "1523242750043226234"
+    users:
+      admins: []
+      authorized:
+        - "98610679895846912"
+    capabilities:
+      allow:
+        - agent_workloads.readonly_query
+        - agent_workloads.opencode_orchestrate
+        - agent_workloads.opencode_task
+        - audit.digest
   - id: synthetic-live-verify-probe
     description: >-
       Scheduled no-key deployment and readonly-query live verify probe. This

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -296,6 +296,22 @@ data:
           approval_overrides:
             approval.probe: admin_confirm
             agent_workloads.opencode_apply: admin_confirm
+      - id: private-admin-trusted-read-query
+        description: Narrow read and query access for a trusted non-admin user on
+          the private admin surface.
+        surface_identifiers:
+          guild_id: "1523242748822425750"
+          channel_id: "1523242750043226234"
+        users:
+          admins: []
+          authorized:
+            - "98610679895846912"
+        capabilities:
+          allow:
+            - agent_workloads.readonly_query
+            - agent_workloads.opencode_orchestrate
+            - agent_workloads.opencode_task
+            - audit.digest
       - id: synthetic-live-verify-probe
         description: >-
           Scheduled no-key deployment and readonly-query live verify probe. This


### PR DESCRIPTION
## Summary

- add a separate private-admin-surface binding for Discord user `98610679895846912`
- keep the user non-admin with an empty `admins` list
- allow only `agent_workloads.readonly_query`, `agent_workloads.opencode_orchestrate`, `agent_workloads.opencode_task`, and `audit.digest`
- update the rendered registry overlay ConfigMap golden

## Why

CES-607 requires trusted read/query access on the existing private-admin guild/channel without inheriting the broader private admin capability set or approval authority.

## Impact

The user can submit only the four explicitly listed capabilities from guild `1523242748822425750` / channel `1523242750043226234`. No propose, apply, operations, deployment, probe, or admin-confirm rights are granted.

## Validation

- `uv run python scripts/check_agent_control_plane_registry_overlay_render.py` with kustomize v5.4.3
- focused YAML assertions for surface, authorized/admin membership, exact allow-list, and binding separation
- `uv run python -m unittest discover -s tests` (112 tests)

Linear: CES-607