### PR TITLE
CES-577: re-pin agent-control-plane to sha-11df8fcd999c (Core governed-handoff)

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-d1f868e51233
+  tag: sha-11df8fcd999c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: d1f868e51233b80f2bd0226e09d3444d46e44083
+      targetRevision: 11df8fcd999c0d08067f9fc753ab1d12da056140
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-d1f868e51233` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-d1f868e51233
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
Core CP roll for **ap#362** (CES-577: govern OpenCode proposal handoff), merged `11df8fcd9`.

**Backward-compatible, no cutover:** the new Core executor-action/governed-handoff machinery supports both the governed and legacy handoff modes and is inert until the worker split + gaic#413 cutover land. Deploying this CP alone changes no behavior.

Train recon (d1f868e..11df8fc) is clean:
- No `audit/schema/` migrations.
- No `mandate/adapters/model|readonly_sql|write_sql` changes → **provider pins unchanged** (no recompute).
- No `helm/` or `registries/` delta.

Change is image.tag + Application targetRevision + the postgres-restore.md CP image ref (python-contracts fixture). Gated + deployed by Claude under operator merge+deploy authorization; staged 'Core CP now, cutover next'.