### PR TITLE
CES-608: schedule control-plane Postgres sweep

### DIFF
--- a/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
+++ b/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: agent-control-plane-postgres-sweep
+  namespace: agent-control-plane
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/instance: agent-control-plane
+    app.kubernetes.io/component: postgres-sweep
+    app.kubernetes.io/managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+    mandate.cesaregarza.io/purpose: expire-orphaned-jobs-and-archive-terminal-rows
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      ttlSecondsAfterFinished: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: agent-control-plane
+            app.kubernetes.io/instance: agent-control-plane
+            app.kubernetes.io/component: postgres-sweep
+        spec:
+          serviceAccountName: agent-control-plane
+          automountServiceAccountToken: false
+          imagePullSecrets:
+            - name: regcred
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: postgres-sweep
+              image: registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c
+              imagePullPolicy: IfNotPresent
+              command:
+                - mandate-postgres-sweep
+              args:
+                - --queued-lease-expiry-limit
+                - "100"
+                - --approval-expiry-limit
+                - "100"
+                - --retention-days
+                - "30"
+                - --batch-size
+                - "100"
+              envFrom:
+                - secretRef:
+                    name: agent-control-plane-secrets
+              env:
+                - name: AGENT_PLATFORM_ENVIRONMENT
+                  value: prod
+                - name: AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE
+                  value: "0"
+                - name: AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE
+                  value: "1"
+                - name: AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE
+                  value: hmac
+                - name: AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER
+                  value: kubernetes
+                - name: AGENT_PLATFORM_WORKLOAD_IDENTITY_AUDIENCE
+                  value: mandate-api
+                - name: AGENT_PLATFORM_WORKLOAD_IDENTITY_REQUIRED_SCOPES
+                  value: worker_service
+                - name: AGENT_PLATFORM_WORKLOAD_IDENTITY_ALLOWED_SUBJECTS_JSON
+                  value: '{"worker_service":["data.workspace_probe","opencode.apply_executor","opencode.proposer"]}'
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 96Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/apps/agent-control-plane/README.md
+++ b/apps/agent-control-plane/README.md
@@ -67,10 +67,19 @@ Required before activation:
   Secret. The live DigitalOcean block claim is `ReadWriteOnce`, so the chart
   co-locates the API with the gateway on one node; use ReadWriteMany storage
   before scaling this pair across nodes.
-- `postgresSweep.enabled=false` while the current
-  `db-postgresql-nyc3-xscraper` `db-amd-1vcpu-2gb` plan is connection-slot
-  saturated by the live control-plane services. Re-enable it only after the
-  database connection budget is raised or the service pool footprint is reduced.
+- `apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml` owns
+  the production maintenance schedule. It runs `mandate-postgres-sweep` every
+  ten minutes with `concurrencyPolicy: Forbid`, a five-minute missed-start
+  deadline, and a zero-minimum/one-maximum Postgres pool. That single transient
+  connection ceiling supersedes the July 5 connection-pressure suspension
+  without restoring a long-lived maintenance pool. Keep the reusable chart's
+  `postgresSweep.enabled=false` to prevent a second CronJob from running.
+- The production terminal-row retention decision is 30 days. The sweep archives
+  eligible terminal control-job rows and their dependent rows transactionally
+  before deleting the live copies, skips jobs whose callbacks are not terminal,
+  and leaves permanent `agent_runs` and `run_events` audit history in place.
+  Queued-lease and approval expiry sweeps run on every invocation regardless of
+  whether any terminal rows are old enough to archive.
 - `syntheticLiveVerify.enabled=true` runs the scheduled deployment smoke and
   readonly-query probes every five minutes through the trusted-edge `/v1/tasks`
   path with signed `mctx_v2` assertions. The dedicated

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -279,6 +279,9 @@ extraVolumeMounts:
     readOnly: true
 
 postgresSweep:
+  # CES-608: production owns this as a raw runtime-control CronJob so it can
+  # set startingDeadlineSeconds and a one-connection pool ceiling. Keep the
+  # reusable chart CronJob disabled to prevent duplicate sweeps.
   enabled: false
 
 syntheticLiveVerify:

--- a/tests/test_agent_control_plane_postgres_sweep.py
+++ b/tests/test_agent_control_plane_postgres_sweep.py
@@ -1,0 +1,188 @@
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+
+class AgentControlPlanePostgresSweepTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cronjob = _load_yaml(
+            REPO_ROOT
+            / "apps"
+            / "agent-control-plane-runtime-controls"
+            / "postgres-sweep-cronjob.yaml"
+        )
+        cls.values = _load_yaml(
+            REPO_ROOT / "apps" / "agent-control-plane" / "values.yaml"
+        )
+        cls.application = _load_yaml(
+            REPO_ROOT / "argocd" / "applications" / "agent-control-plane.yaml"
+        )
+        cls.readme = (
+            REPO_ROOT / "apps" / "agent-control-plane" / "README.md"
+        ).read_text()
+
+    def test_cronjob_is_scheduled_and_bounded(self) -> None:
+        self.assertEqual(self.cronjob["apiVersion"], "batch/v1")
+        self.assertEqual(self.cronjob["kind"], "CronJob")
+        self.assertEqual(
+            self.cronjob["metadata"]["name"],
+            "agent-control-plane-postgres-sweep",
+        )
+        self.assertEqual(
+            self.cronjob["metadata"]["namespace"],
+            self.application["spec"]["destination"]["namespace"],
+        )
+
+        spec = self.cronjob["spec"]
+        self.assertEqual(spec["schedule"], "*/10 * * * *")
+        self.assertEqual(spec["concurrencyPolicy"], "Forbid")
+        self.assertEqual(spec["startingDeadlineSeconds"], 300)
+        self.assertEqual(spec["successfulJobsHistoryLimit"], 1)
+        self.assertEqual(spec["failedJobsHistoryLimit"], 3)
+        self.assertEqual(spec["jobTemplate"]["spec"]["backoffLimit"], 1)
+        self.assertEqual(
+            spec["jobTemplate"]["spec"]["activeDeadlineSeconds"],
+            600,
+        )
+        self.assertEqual(
+            spec["jobTemplate"]["spec"]["ttlSecondsAfterFinished"],
+            600,
+        )
+
+    def test_cronjob_uses_the_pinned_control_plane_image_and_secret(self) -> None:
+        pod_spec = _pod_spec(self.cronjob)
+        container = pod_spec["containers"][0]
+        expected_image = (
+            f"{self.values['image']['repository']}:{self.values['image']['tag']}"
+        )
+
+        self.assertEqual(container["name"], "postgres-sweep")
+        self.assertEqual(container["image"], expected_image)
+        self.assertEqual(container["imagePullPolicy"], "IfNotPresent")
+        self.assertEqual(container["command"], ["mandate-postgres-sweep"])
+        self.assertEqual(
+            container["args"],
+            [
+                "--queued-lease-expiry-limit",
+                "100",
+                "--approval-expiry-limit",
+                "100",
+                "--retention-days",
+                "30",
+                "--batch-size",
+                "100",
+            ],
+        )
+        self.assertEqual(
+            container["envFrom"],
+            [{"secretRef": {"name": "agent-control-plane-secrets"}}],
+        )
+        self.assertEqual(pod_spec["imagePullSecrets"], [{"name": "regcred"}])
+
+    def test_cronjob_has_one_connection_budget_and_prod_validation_config(
+        self,
+    ) -> None:
+        env = {
+            item["name"]: item["value"]
+            for item in _pod_spec(self.cronjob)["containers"][0]["env"]
+        }
+        self.assertEqual(env["AGENT_PLATFORM_POSTGRES_POOL_MIN_SIZE"], "0")
+        self.assertEqual(env["AGENT_PLATFORM_POSTGRES_POOL_MAX_SIZE"], "1")
+
+        for name in (
+            "AGENT_PLATFORM_ENVIRONMENT",
+            "AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE",
+            "AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER",
+            "AGENT_PLATFORM_WORKLOAD_IDENTITY_AUDIENCE",
+            "AGENT_PLATFORM_WORKLOAD_IDENTITY_REQUIRED_SCOPES",
+            "AGENT_PLATFORM_WORKLOAD_IDENTITY_ALLOWED_SUBJECTS_JSON",
+        ):
+            self.assertEqual(env[name], self.values["env"][name])
+
+    def test_cronjob_is_non_root_and_covered_by_control_plane_egress(self) -> None:
+        pod_spec = _pod_spec(self.cronjob)
+        container = pod_spec["containers"][0]
+        labels = (
+            self.cronjob["spec"]["jobTemplate"]["spec"]["template"]["metadata"][
+                "labels"
+            ]
+        )
+
+        self.assertEqual(
+            {
+                "app.kubernetes.io/name": labels["app.kubernetes.io/name"],
+                "app.kubernetes.io/instance": labels[
+                    "app.kubernetes.io/instance"
+                ],
+            },
+            {
+                "app.kubernetes.io/name": "agent-control-plane",
+                "app.kubernetes.io/instance": "agent-control-plane",
+            },
+        )
+        self.assertEqual(labels["app.kubernetes.io/component"], "postgres-sweep")
+        self.assertEqual(pod_spec["serviceAccountName"], "agent-control-plane")
+        self.assertFalse(pod_spec["automountServiceAccountToken"])
+        self.assertEqual(pod_spec["restartPolicy"], "Never")
+        self.assertEqual(
+            pod_spec["securityContext"],
+            {
+                "runAsNonRoot": True,
+                "runAsUser": 65532,
+                "runAsGroup": 65532,
+                "fsGroup": 65532,
+                "seccompProfile": {"type": "RuntimeDefault"},
+            },
+        )
+        self.assertEqual(
+            container["securityContext"],
+            {
+                "allowPrivilegeEscalation": False,
+                "readOnlyRootFilesystem": True,
+                "runAsNonRoot": True,
+                "capabilities": {"drop": ["ALL"]},
+            },
+        )
+        self.assertEqual(
+            container["volumeMounts"],
+            [{"name": "tmp", "mountPath": "/tmp"}],
+        )
+        self.assertEqual(pod_spec["volumes"], [{"name": "tmp", "emptyDir": {}}])
+
+    def test_raw_cronjob_is_the_only_production_sweep_owner(self) -> None:
+        self.assertFalse(self.values["postgresSweep"]["enabled"])
+        runtime_sources = [
+            source
+            for source in self.application["spec"]["sources"]
+            if source.get("path") == "apps/agent-control-plane-runtime-controls"
+        ]
+        self.assertEqual(len(runtime_sources), 1)
+        self.assertEqual(runtime_sources[0]["targetRevision"], "main")
+
+    def test_retention_and_connection_decisions_are_documented(self) -> None:
+        self.assertIn("single transient", self.readme)
+        self.assertIn("terminal-row retention decision is 30 days", self.readme)
+        self.assertIn("archives", self.readme)
+        self.assertIn("permanent `agent_runs` and `run_events`", self.readme)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = YAML_PARSER.load(path.read_text())
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def _pod_spec(cronjob: dict[str, Any]) -> dict[str, Any]:
+    return cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Schedules the existing `mandate-postgres-sweep` maintenance command in production so admission leases that expire before worker claim no longer leave permanently queued jobs.

- adds a GarzAICluster-owned `agent-control-plane-postgres-sweep` CronJob to the existing control-plane runtime-controls Argo source;
- runs every ten minutes with `concurrencyPolicy: Forbid`, a five-minute `startingDeadlineSeconds`, bounded histories, one retry, and a ten-minute active deadline;
- uses the current pinned control-plane image, `agent-control-plane-secrets`, `regcred`, and the existing control-plane ServiceAccount while disabling token automount;
- explicitly runs queued-lease, approval-expiry, and archive sweeps in batches of 100;
- caps the maintenance Postgres pool at zero minimum and one maximum connection;
- keeps the reusable chart's `postgresSweep.enabled=false` so only the raw production CronJob owns the schedule.

## Root Cause

The fail-closed queued-lease reaper already exists in agent-platform, but production had no scheduled invocation after the prior CronJob was suspended for connection pressure. Jobs admitted against a stale release tuple could therefore outlive their approximately 60-second claim lease indefinitely and repeatedly log digest mismatches.

## Retention and Security Decision

Production terminal-row retention is explicitly accepted at 30 days. The command archives eligible terminal control-job and dependent rows transactionally before deleting live copies, skips jobs with non-terminal callbacks, and does not prune permanent `agent_runs` or `run_events` audit history.

The one-connection pool ceiling, zero minimum, ten-minute cadence, `Forbid` concurrency, and active deadline bound database pressure. The pod runs non-root with a read-only root filesystem, drops all capabilities, mounts only an empty `/tmp`, inherits the control-plane NetworkPolicy through matching selector labels, and receives no Kubernetes API token.

## Validation

- focused CronJob contract: 6 passed;
- full Python contract suite on Python 3.11: 119 passed;
- grant-ownership generation and control-plane release-pin checks passed;
- registry overlay render matched its committed golden with kustomize v5.4.3;
- exact Helm v3.14.0 lint/render matrix passed for all repository charts;
- pinned agent-platform chart lint/render passed against production values;
- kubeconform v0.6.7 strict validation passed for the new CronJob, pinned control-plane render, and all CI chart renders;
- no-`:latest` and `git diff --check` passed.

Local parity gap: Prometheus validation could not run because Docker is not installed in this environment; that unchanged hosted job must pass on this exact head. `kubectl` is also unavailable locally, so no live cluster verification or deployment was performed.

## Production Effect and Verification

After merge and an authorized Argo sync, the next scheduled run should fail-close queued jobs whose claim leases have expired, expire stale approval waits, and archive eligible 30+ day terminal rows. Verification should inspect the Job counters/logs, confirm the expected audit event and callback for a deliberately unclaimable expired job, and confirm a legitimately claimable in-flight job remains untouched.

Emergency rollback is to suspend the CronJob and revert/remove the raw manifest through GitOps. This PR does not perform an Argo sync, create a live Job, or mutate production data.

Linear: CES-608
