### PR TITLE
CES-577: allow apply executor to reach Core

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -204,6 +204,13 @@ networkPolicy:
             app.kubernetes.io/instance: agent-workloads
       - namespaceSelector:
           matchLabels:
+            kubernetes.io/metadata.name: agent-workloads
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: opencode-apply-executor
+            app.kubernetes.io/instance: agent-workloads
+      - namespaceSelector:
+          matchLabels:
             kubernetes.io/metadata.name: monitoring
         podSelector:
           matchLabels:

--- a/tests/test_control_plane_release_pin.py
+++ b/tests/test_control_plane_release_pin.py
@@ -27,6 +27,23 @@ class ControlPlaneReleasePinTests(unittest.TestCase):
 
         self.assertIn("targetRevision and image tag match", result)
 
+    def test_control_plane_ingress_allows_both_split_opencode_workers(self) -> None:
+        values = YAML_PARSER.load(
+            (REPO_ROOT / "apps" / "agent-control-plane" / "values.yaml").read_text()
+        )
+        sources = values["networkPolicy"]["ingress"]["sources"]
+        workload_sources = {
+            source["podSelector"]["matchLabels"].get("app.kubernetes.io/name")
+            for source in sources
+            if source.get("namespaceSelector", {})
+            .get("matchLabels", {})
+            .get("kubernetes.io/metadata.name")
+            == "agent-workloads"
+        }
+
+        self.assertIn("opencode-proposer", workload_sources)
+        self.assertIn("opencode-apply-executor", workload_sources)
+
     def test_control_plane_release_pin_check_runs_in_python_contracts_ci(self) -> None:
         workflow = YAML_PARSER.load(
             (REPO_ROOT / ".github" / "workflows" / "ci.yaml").read_text()


### PR DESCRIPTION
## Summary

The CES-577 split-topology canary found that the new `opencode.apply_executor` pod was healthy but every Core claim timed out. The workload's own egress policy allowed Core, but the Core NetworkPolicy ingress list included `opencode-proposer` and omitted `opencode-apply-executor`.

This hotfix:

- adds the apply-executor pod selector to Core's `agent-workloads` ingress sources;
- preserves the executor's control-plane-only egress boundary;
- adds a regression assertion requiring both split OpenCode workers in production Core ingress.

## Verification

- Python 3.11 contract suite: 136/136 passed
- focused control-plane tests: 4/4 passed
- grant ownership map check: passed
- control-plane release-pin check: passed
- registry-overlay render check: passed
- Helm 3.14.0 production control-plane render: includes `agent-workloads`, `opencode-proposer`, and `opencode-apply-executor`
- kubeconform 0.6.7 strict: 15 valid, 0 invalid/errors, 1 expected CRD skip
- `git diff --check`: passed

## Production evidence

Before this change, proposer IP `10.244.0.185` returned repeated `POST /v1/worker/jobs:claim 200`, while apply-executor IP `10.244.0.251` never reached Core and logged bounded claim timeouts. Live Core NetworkPolicy ingress confirmed the missing selector.

After merge, sync only the `agent-control-plane` app, verify the apply worker begins returning authenticated claim calls, then continue the real propose → approval → apply canary against `mandate-sandbox`.

Linear: CES-577