### PR TITLE
CES-611: allow declared OpenCode runtimes

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -3,6 +3,10 @@ defaults:
   max_runtime_seconds_per_job: 60
   max_runtime_seconds_per_capability:
     agent_workloads.readonly_query: 180
+    agent_workloads.opencode_propose: 900
+    agent_workloads.opencode_task: 900
+    agent_workloads.opencode_orchestrate: 900
+    agent_workloads.opencode_apply: 300
   aggregate_budget:
     platform_daily_usd: 250.0
     per_capability_daily_usd_default: 100.0

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -260,6 +260,10 @@ data:
       max_runtime_seconds_per_job: 60
       max_runtime_seconds_per_capability:
         agent_workloads.readonly_query: 180
+        agent_workloads.opencode_propose: 900
+        agent_workloads.opencode_task: 900
+        agent_workloads.opencode_orchestrate: 900
+        agent_workloads.opencode_apply: 300
       aggregate_budget:
         platform_daily_usd: 250.0
         per_capability_daily_usd_default: 100.0

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -577,7 +577,13 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(policy["defaults"]["max_runtime_seconds_per_job"], 60)
         self.assertEqual(
             policy["defaults"]["max_runtime_seconds_per_capability"],
-            {"agent_workloads.readonly_query": 180},
+            {
+                "agent_workloads.readonly_query": 180,
+                "agent_workloads.opencode_propose": 900,
+                "agent_workloads.opencode_task": 900,
+                "agent_workloads.opencode_orchestrate": 900,
+                "agent_workloads.opencode_apply": 300,
+            },
         )
         self.assertEqual(
             policy["defaults"]["aggregate_budget"]["per_capability_daily_usd"][


### PR DESCRIPTION
## What changed

- add production policy runtime overrides for `opencode_propose`, `opencode_task`, and `opencode_orchestrate` at 900 seconds
- add the `opencode_apply` override at 300 seconds
- regenerate the registry-overlay ConfigMap golden and strengthen the policy contract test

## Why

The global 60-second default currently applies to every OpenCode capability, despite the imported workloads declaring 900 seconds for proposer work and 300 seconds for apply. A real Hermes `opencode_propose` is therefore rejected before submission and blocks the CES-577 governed-handoff canary.

This keeps the 60-second global default and all existing per-capability cost budgets unchanged; it only aligns the four OpenCode runtime ceilings with their declared workload runtimes.

## Validation

- Python 3.11 contract suite: 136/136 passed
- kustomize v5.4.3 registry-overlay render matches the committed golden
- Helm v3.14.0 lint/render across all five CI matrix entries
- kubeconform v0.6.7 strict validation clean
- production Prometheus config/rules validation clean
- `no-latest` guard clean
- `git diff --check` clean

Hosted OIDC/broker-backed registry compatibility and identity-drift gates are left to the exact-head GitHub Actions run.