### PR TITLE
CES-611: add second private-admin canary policy binding

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -79,3 +79,23 @@ bindings:
         - agent_workloads.opencode_orchestrate
         - agent_workloads.opencode_task
         - audit.digest
+  - id: private-admin-second-canary-account
+    description: >-
+      Second non-admin trusted account on the private-admin surface for driving
+      the OpenCode propose/task/orchestrate canary (CES-611/CES-577). Read/query
+      + OpenCode propose/task/orchestrate only; no apply, ops, deploy, or probes.
+      Cannot approve admin-gated actions or act on other users' jobs.
+    surface_identifiers:
+      guild_id: "1523242748822425750"
+      channel_id: "1523242750043226234"
+    users:
+      admins: []
+      authorized:
+        - "457258175939346455"
+    capabilities:
+      allow:
+        - agent_workloads.opencode_propose
+        - agent_workloads.opencode_task
+        - agent_workloads.opencode_orchestrate
+        - agent_workloads.readonly_query
+        - audit.digest

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -336,6 +336,26 @@ data:
             - agent_workloads.opencode_orchestrate
             - agent_workloads.opencode_task
             - audit.digest
+      - id: private-admin-second-canary-account
+        description: >-
+          Second non-admin trusted account on the private-admin surface for driving
+          the OpenCode propose/task/orchestrate canary (CES-611/CES-577). Read/query
+          + OpenCode propose/task/orchestrate only; no apply, ops, deploy, or probes.
+          Cannot approve admin-gated actions or act on other users' jobs.
+        surface_identifiers:
+          guild_id: "1523242748822425750"
+          channel_id: "1523242750043226234"
+        users:
+          admins: []
+          authorized:
+            - "457258175939346455"
+        capabilities:
+          allow:
+            - agent_workloads.opencode_propose
+            - agent_workloads.opencode_task
+            - agent_workloads.opencode_orchestrate
+            - agent_workloads.readonly_query
+            - audit.digest
   workload_imports.yaml: |
     schema_version: workload-imports.v1
     imports:


### PR DESCRIPTION
## Summary

- Add `private-admin-second-canary-account` for Discord user `457258175939346455` on the existing private-admin guild/channel surface.
- Grant only OpenCode propose/task/orchestrate, read-only query, and audit digest capabilities for the CES-611/CES-577 canary.
- Regenerate the Kustomize-rendered registry overlay ConfigMap golden.

## Safety invariants

- `users.admins` is empty; this account cannot approve `admin_confirm` actions.
- The account is disjoint from every other binding user list, so it matches only this binding on the scoped surface.
- No `approval_overrides` are present; all allowed capabilities resolve to `approval_mode: none`.
- The exact allow list is fail-closed and excludes apply, ops, deploy, and probe capabilities.
- Policy config only: no source/code changes, no base/dev `agent-platform` policy edits, and no re-mint.

## Validation

- `uv run python scripts/check_agent_control_plane_registry_overlay_render.py --kustomize /tmp/codex-kustomize-v5.4.3/kustomize`
- Deployed-pin registry compatibility against agent-platform `11df8fcd999c0d08067f9fc753ab1d12da056140`
- `python3 -m pytest -q tests/test_agent_control_plane_registry_overlay.py` (15 passed)
- Scope audit: exactly two files changed, 40 additions, zero deletions

## Operator rollout

Operator-gated merge; do not auto-merge. After merge, sync `agent-control-plane-registry-overlay`, then restart `control-api` via scale `0 → 1` so it reloads the boot-cached overlay. No re-mint and no worker restart.