### PR TITLE
CES-614: Fix OpenCode apply budget admission

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -11,8 +11,8 @@ defaults:
     platform_daily_usd: 250.0
     per_capability_daily_usd_default: 100.0
     per_capability_daily_usd:
-      agent_workloads.opencode_apply: 1.0
-      agent_workloads.opencode_propose: 1.0
+      agent_workloads.opencode_apply: 10.0
+      agent_workloads.opencode_propose: 10.0
 
 bindings:
   - id: private-admin-controlled-capabilities

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -346,6 +346,13 @@ imports:
       artifacts:
         allowed: true
         broker_required: false
+      model_bounds:
+        required: true
+        allowed_tier: fast
+        allowed_profiles:
+        - openai.gpt-5.3-codex-spark
+        max_cost_usd: 0.25
+        max_influence: principal
       disclosure_summary:
         summary: OpenCode apply releases local apply metadata for the governed delivery
           arc.

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -150,6 +150,9 @@ imports:
         - internal sources and broker internals
       model_bounds:
         required: true
+        allowed_tier: fast
+        allowed_profiles:
+        - openai.gpt-5.3-codex-spark
         max_cost_usd: 0.25
         max_influence: principal
       limitations:
@@ -345,9 +348,6 @@ imports:
         broker_required: false
       model_bounds:
         required: true
-        allowed_tier: fast
-        allowed_profiles:
-        - openai.gpt-5.3-codex-spark
         max_cost_usd: 0.25
         max_influence: principal
       disclosure_summary:

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -150,9 +150,6 @@ imports:
         - internal sources and broker internals
       model_bounds:
         required: true
-        allowed_tier: fast
-        allowed_profiles:
-        - openai.gpt-5.3-codex-spark
         max_cost_usd: 0.25
         max_influence: principal
       limitations:

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -43,6 +43,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_apply` | `disclosure` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `limitations` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.opencode_apply` | `model_bounds` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -396,6 +396,12 @@ capabilities:
         remint_required: true
         digest_moves: true
         source: workload agent.yaml
+      model_bounds:
+        owner: deployment_overlay
+        deploy_consequence: control_plane_restart
+        remint_required: false
+        digest_moves: false
+        source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
       output_gate:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -509,6 +509,9 @@ data:
             - internal sources and broker internals
           model_bounds:
             required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
             max_influence: principal
           limitations:
@@ -704,9 +707,6 @@ data:
             broker_required: false
           model_bounds:
             required: true
-            allowed_tier: fast
-            allowed_profiles:
-            - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
             max_influence: principal
           disclosure_summary:

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -268,8 +268,8 @@ data:
         platform_daily_usd: 250.0
         per_capability_daily_usd_default: 100.0
         per_capability_daily_usd:
-          agent_workloads.opencode_apply: 1.0
-          agent_workloads.opencode_propose: 1.0
+          agent_workloads.opencode_apply: 10.0
+          agent_workloads.opencode_propose: 10.0
 
     bindings:
       - id: private-admin-controlled-capabilities
@@ -705,6 +705,13 @@ data:
           artifacts:
             allowed: true
             broker_required: false
+          model_bounds:
+            required: true
+            allowed_tier: fast
+            allowed_profiles:
+            - openai.gpt-5.3-codex-spark
+            max_cost_usd: 0.25
+            max_influence: principal
           disclosure_summary:
             summary: OpenCode apply releases local apply metadata for the governed delivery
               arc.

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -509,9 +509,6 @@ data:
             - internal sources and broker internals
           model_bounds:
             required: true
-            allowed_tier: fast
-            allowed_profiles:
-            - openai.gpt-5.3-codex-spark
             max_cost_usd: 0.25
             max_influence: principal
           limitations:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -458,6 +458,12 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             capability["artifacts"],
             {"allowed": True, "broker_required": False},
         )
+        self.assertEqual(capability["model_bounds"]["allowed_tier"], "fast")
+        self.assertEqual(
+            capability["model_bounds"]["allowed_profiles"],
+            ["openai.gpt-5.3-codex-spark"],
+        )
+        self.assertEqual(capability["model_bounds"]["max_cost_usd"], 0.25)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_apply_result"],
@@ -589,13 +595,13 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             policy["defaults"]["aggregate_budget"]["per_capability_daily_usd"][
                 "agent_workloads.opencode_propose"
             ],
-            1.0,
+            10.0,
         )
         self.assertEqual(
             policy["defaults"]["aggregate_budget"]["per_capability_daily_usd"][
                 "agent_workloads.opencode_apply"
             ],
-            1.0,
+            10.0,
         )
 
         evals = YAML_PARSER.load(self.data["evals.yaml"])

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -384,11 +384,8 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(opencode["agent"]["network_access"], "broker_only")
 
         capability = opencode["capabilities"]["agent_workloads.opencode_propose"]
-        self.assertEqual(capability["model_bounds"]["allowed_tier"], "fast")
-        self.assertEqual(
-            capability["model_bounds"]["allowed_profiles"],
-            ["openai.gpt-5.3-codex-spark"],
-        )
+        self.assertNotIn("allowed_tier", capability["model_bounds"])
+        self.assertNotIn("allowed_profiles", capability["model_bounds"])
         self.assertEqual(capability["model_bounds"]["max_cost_usd"], 0.25)
         self.assertEqual(capability["session_authority_budget"]["max_operations"], 100)
         self.assertEqual(

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -384,8 +384,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         self.assertEqual(opencode["agent"]["network_access"], "broker_only")
 
         capability = opencode["capabilities"]["agent_workloads.opencode_propose"]
-        self.assertNotIn("allowed_tier", capability["model_bounds"])
-        self.assertNotIn("allowed_profiles", capability["model_bounds"])
+        self.assertEqual(capability["model_bounds"]["allowed_tier"], "fast")
+        self.assertEqual(
+            capability["model_bounds"]["allowed_profiles"],
+            ["openai.gpt-5.3-codex-spark"],
+        )
         self.assertEqual(capability["model_bounds"]["max_cost_usd"], 0.25)
         self.assertEqual(capability["session_authority_budget"]["max_operations"], 100)
         self.assertEqual(
@@ -455,11 +458,8 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             capability["artifacts"],
             {"allowed": True, "broker_required": False},
         )
-        self.assertEqual(capability["model_bounds"]["allowed_tier"], "fast")
-        self.assertEqual(
-            capability["model_bounds"]["allowed_profiles"],
-            ["openai.gpt-5.3-codex-spark"],
-        )
+        self.assertNotIn("allowed_tier", capability["model_bounds"])
+        self.assertNotIn("allowed_profiles", capability["model_bounds"])
         self.assertEqual(capability["model_bounds"]["max_cost_usd"], 0.25)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],


### PR DESCRIPTION
## What changed

- add a deployment-owned `model_bounds` override to `agent_workloads.opencode_apply` with `max_cost_usd: 0.25`, without constraining its resolved tier or profile
- raise the `opencode_propose` and `opencode_apply` daily aggregate caps from `$1` to `$10`
- regenerate the registry overlay golden fixture and grant-ownership documentation
- update overlay contract tests for the new limits

## Why

`opencode_apply` inherited the global `$10` per-job maximum while its daily capability cap was only `$1`. Admission reserves worst-case job cost, so every apply request was rejected with `429 aggregate budget exceeded` before a job could be created.

The explicit `$0.25` per-job bound makes apply admissible, while the `$10` daily caps leave enough room for repeated dogfood propose/apply attempts. Tier and profile are intentionally left unconstrained by the overlay so the apply executor retains its resolved model scope.

## Deployment impact

Policy-overlay-only change. Sync `agent-control-plane-registry-overlay`, then restart the boot-cached control API (scale `0 -> 1`). No workload identity re-mint is required.

## Validation

- `uv run python -m unittest discover -s tests` — 136 passed
- CI-pinned kustomize v5.4.3 registry overlay render gate — passed
- `git diff --check` — passed
- deployed-registry compatibility is verified by GitHub Actions because the exact check requires brokered contract material unavailable locally

Linear: CES-614