### PR TITLE
CES-614: Keep OpenCode apply on no-model admission path

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
@@ -11,7 +11,7 @@ defaults:
     platform_daily_usd: 250.0
     per_capability_daily_usd_default: 100.0
     per_capability_daily_usd:
-      agent_workloads.opencode_apply: 10.0
+      agent_workloads.opencode_apply: 50.0
       agent_workloads.opencode_propose: 10.0
 
 bindings:

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -346,10 +346,6 @@ imports:
       artifacts:
         allowed: true
         broker_required: false
-      model_bounds:
-        required: true
-        max_cost_usd: 0.25
-        max_influence: principal
       disclosure_summary:
         summary: OpenCode apply releases local apply metadata for the governed delivery
           arc.

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -43,7 +43,6 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_apply` | `disclosure` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `disclosure_summary` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `limitations` | `workload_release` | `digest_moves_repin_remint` |
-| `agent_workloads.opencode_apply` | `model_bounds` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.opencode_apply` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `output_schema` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.opencode_apply` | `result_contract` | `workload_release` | `digest_moves_repin_remint` |

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -396,12 +396,6 @@ capabilities:
         remint_required: true
         digest_moves: true
         source: workload agent.yaml
-      model_bounds:
-        owner: deployment_overlay
-        deploy_consequence: control_plane_restart
-        remint_required: false
-        digest_moves: false
-        source: DEPLOYMENT_OWNED_CAPABILITY_KEYS
       output_gate:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -268,7 +268,7 @@ data:
         platform_daily_usd: 250.0
         per_capability_daily_usd_default: 100.0
         per_capability_daily_usd:
-          agent_workloads.opencode_apply: 10.0
+          agent_workloads.opencode_apply: 50.0
           agent_workloads.opencode_propose: 10.0
 
     bindings:
@@ -705,10 +705,6 @@ data:
           artifacts:
             allowed: true
             broker_required: false
-          model_bounds:
-            required: true
-            max_cost_usd: 0.25
-            max_influence: principal
           disclosure_summary:
             summary: OpenCode apply releases local apply metadata for the governed delivery
               arc.

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -458,9 +458,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             capability["artifacts"],
             {"allowed": True, "broker_required": False},
         )
-        self.assertNotIn("allowed_tier", capability["model_bounds"])
-        self.assertNotIn("allowed_profiles", capability["model_bounds"])
-        self.assertEqual(capability["model_bounds"]["max_cost_usd"], 0.25)
+        self.assertNotIn("model_bounds", capability)
         self.assertEqual(
             capability["disclosure"]["artifact_classes_allowed"],
             ["opencode_apply_result"],
@@ -598,7 +596,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             policy["defaults"]["aggregate_budget"]["per_capability_daily_usd"][
                 "agent_workloads.opencode_apply"
             ],
-            10.0,
+            50.0,
         )
 
         evals = YAML_PARSER.load(self.data["evals.yaml"])


### PR DESCRIPTION
## What changed

- remove `model_bounds` entirely from `agent_workloads.opencode_apply`
- raise only apply's daily aggregate cap from `$10` to `$50`; keep propose at `$10`
- regenerate the registry overlay golden and grant-ownership outputs
- update the overlay contract test to require that apply has no `model_bounds`

## Why

PR #420 fixed the original 429 budget rejection, but live verification exposed a new `403 model tier not allowed by policy`.

`opencode_apply` is a deterministic no-model worker. Any `model_bounds.required: true` makes admission treat the worker as a brokered model call. Without a real model tier, that path resolves to `None` and policy rejects it. Removing `model_bounds` preserves apply's true `no_model` scope.

Apply therefore inherits the global `$10` per-job reservation. A `$50` daily capability cap keeps `$10 <= $50`, preventing the original 429 while allowing roughly five reserved attempts per day.

## Deployment impact

Policy-overlay-only change. After merge, sync `agent-control-plane-registry-overlay`, restart the boot-cached control API (scale `0 -> 1`), and submit a real `opencode_apply` canary. No workload identity re-mint is required.

## Validation

- full unit suite: 136 passed
- CI-pinned kustomize v5.4.3 registry overlay render gate: passed
- deployed-registry compatibility against pinned agent-platform `11df8fcd999c0d08067f9fc753ab1d12da056140`: passed
- `git diff --check`: passed

Follow-up to merged PR #420.

Linear: CES-614