### PR TITLE
CES-555: harden grant ownership regeneration

### DIFF
--- a/docs/grant-ownership-source.yaml
+++ b/docs/grant-ownership-source.yaml
@@ -8,6 +8,10 @@ deployment_owned_capability_keys:
 - model_bounds
 preserve_existing_capability_keys:
 - approval_mode
+spend_limit_keys:
+- max_cost_usd
+spend_limit_preserving_mapping_keys:
+- broker_bounds
 influence_key: influence
 session_authority_budget_preserved_keys:
 - influence

--- a/docs/grant-ownership.md
+++ b/docs/grant-ownership.md
@@ -17,6 +17,8 @@ normal publish, re-pin, and re-mint flow.
 - Source: `cesaregarza/agent-workloads/scripts/apply_garzaicluster_release_artifacts.py`
 - Deployment-owned capability roots: `artifacts`, `disclosure`, `model_bounds`
 - Preserved existing capability roots: `approval_mode`
+- Spend-limit-preserving mapping roots: `broker_bounds`
+- Preserved spend-limit subkeys: `max_cost_usd`
 - Session authority preserved subkeys: `session_authority_budget.influence`, `session_authority_budget.max_operations`
 
 ## Consumers
@@ -82,7 +84,7 @@ control-plane restart and do not require re-minting.
 | `agent_workloads.opencode_task` | `task_contract` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `artifacts` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.readonly_query` | `broker` | `workload_release` | `digest_moves_repin_remint` |
-| `agent_workloads.readonly_query` | `broker_bounds` | `workload_release` | `digest_moves_repin_remint` |
+| `agent_workloads.readonly_query` | `broker_bounds` | `mixed` | `control_plane_restart` |
 | `agent_workloads.readonly_query` | `description` | `workload_release` | `digest_moves_repin_remint` |
 | `agent_workloads.readonly_query` | `model_bounds` | `deployment_overlay` | `control_plane_restart` |
 | `agent_workloads.readonly_query` | `output_gate` | `workload_release` | `digest_moves_repin_remint` |

--- a/docs/grant-ownership.yaml
+++ b/docs/grant-ownership.yaml
@@ -8,6 +8,10 @@ generated_from:
   - model_bounds
   preserve_existing_capability_keys:
   - approval_mode
+  spend_limit_keys:
+  - max_cost_usd
+  spend_limit_preserving_mapping_keys:
+  - broker_bounds
   session_authority_budget_preserved_keys:
   - influence
   - max_operations
@@ -16,7 +20,7 @@ consumers:
 - mandate doctor deployment-layout checks
 policy_overlay:
   owner: deployment_overlay
-  file: apps/agent-control-plane-registry-overlay/configmap.yaml
+  file: apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml
   embedded_file: policy.prod.yaml
   deploy_consequence: control_plane_restart
   remint_required: false
@@ -32,7 +36,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/db-workspace-probe/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=data.workspace_probe].capabilities.agent_workloads.db_probe
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=data.workspace_probe].capabilities.agent_workloads.db_probe
     keys:
       description:
         owner: workload_release
@@ -58,7 +62,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/db-workspace-probe/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=data.workspace_probe].capabilities.agent_workloads.readonly_query
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=data.workspace_probe].capabilities.agent_workloads.readonly_query
     keys:
       artifacts:
         owner: deployment_overlay
@@ -73,11 +77,14 @@ capabilities:
         digest_moves: true
         source: workload agent.yaml
       broker_bounds:
-        owner: workload_release
-        deploy_consequence: digest_moves_repin_remint
-        remint_required: true
-        digest_moves: true
-        source: workload agent.yaml
+        owner: mixed
+        deploy_consequence: control_plane_restart
+        remint_required: false
+        digest_moves: false
+        deployment_owned_subkeys:
+        - max_cost_usd
+        release_owned_subkeys: '*'
+        source: SPEND_LIMIT_PRESERVING_MAPPING_KEYS/SPEND_LIMIT_KEYS
       description:
         owner: workload_release
         deploy_consequence: digest_moves_repin_remint
@@ -124,7 +131,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/opencode-proposer/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=opencode.proposer].capabilities.agent_workloads.opencode_orchestrate
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=opencode.proposer].capabilities.agent_workloads.opencode_orchestrate
     keys:
       artifacts:
         owner: deployment_overlay
@@ -208,7 +215,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/opencode-proposer/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=opencode.proposer].capabilities.agent_workloads.opencode_propose
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=opencode.proposer].capabilities.agent_workloads.opencode_propose
     keys:
       artifacts:
         owner: deployment_overlay
@@ -280,7 +287,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/opencode-proposer/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=opencode.proposer].capabilities.agent_workloads.opencode_task
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=opencode.proposer].capabilities.agent_workloads.opencode_task
     keys:
       artifacts:
         owner: deployment_overlay
@@ -358,7 +365,7 @@ capabilities:
       repo: agent-workloads
       repo_url: https://github.com/cesaregarza/agent-workloads
       path: agents/opencode-apply-executor/agent.yaml
-    config_path: apps/agent-control-plane-registry-overlay/configmap.yaml:data.workload_imports.yaml.imports[id=opencode.apply_executor].capabilities.agent_workloads.opencode_apply
+    config_path: apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml:imports[id=opencode.apply_executor].capabilities.agent_workloads.opencode_apply
     keys:
       approval_mode:
         owner: deployment_overlay

--- a/scripts/grant_ownership.py
+++ b/scripts/grant_ownership.py
@@ -20,6 +20,19 @@ OWNERSHIP_SOURCE_PATH = Path("docs/grant-ownership-source.yaml")
 OWNERSHIP_MAP_PATH = Path("docs/grant-ownership.yaml")
 OWNERSHIP_DOC_PATH = Path("docs/grant-ownership.md")
 APPLIER_PATH = Path("scripts/apply_garzaicluster_release_artifacts.py")
+APPLIER_CONTRACT_CONSTANT_NAMES = frozenset(
+    {
+        "DEPLOYMENT_OWNED_CAPABILITY_KEYS",
+        "PRESERVE_EXISTING_CAPABILITY_KEYS",
+        "SPEND_LIMIT_KEYS",
+        "SPEND_LIMIT_PRESERVING_MAPPING_KEYS",
+        "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
+        "INFLUENCE_KEY",
+    }
+)
+APPLIER_COLLECTION_CONSTANT_NAMES = APPLIER_CONTRACT_CONSTANT_NAMES.difference(
+    {"INFLUENCE_KEY"}
+)
 
 YAML_SAFE = YAML(typ="safe")
 YAML_RT = YAML()
@@ -45,6 +58,8 @@ class GrantEditError(RuntimeError):
 class ApplierContract:
     deployment_owned_capability_keys: tuple[str, ...]
     preserve_existing_capability_keys: tuple[str, ...]
+    spend_limit_keys: tuple[str, ...]
+    spend_limit_preserving_mapping_keys: tuple[str, ...]
     influence_key: str
     session_authority_budget_preserved_keys: tuple[str, ...]
 
@@ -66,23 +81,34 @@ def find_agent_workloads_repo(
     repo_root: Path = REPO_ROOT,
     explicit: Path | None = None,
 ) -> Path:
-    candidates: list[Path] = []
     if explicit is not None:
-        candidates.append(explicit)
+        candidate = explicit.resolve()
+        if (candidate / APPLIER_PATH).is_file():
+            return candidate
+        raise GrantOwnershipError(
+            "explicit agent-workloads checkout does not contain the expected "
+            f"applier {APPLIER_PATH}: {candidate}"
+        )
+
     env_path = os.environ.get("AGENT_WORKLOADS_REPO")
     if env_path:
-        candidates.append(Path(env_path))
-    candidates.extend(
-        [
-            repo_root / ".ci" / "agent-workloads",
-            repo_root.parent / "agent-workloads",
-        ]
-    )
+        candidate = Path(env_path).resolve()
+        if (candidate / APPLIER_PATH).is_file():
+            return candidate
+        raise GrantOwnershipError(
+            "AGENT_WORKLOADS_REPO does not contain the expected "
+            f"applier {APPLIER_PATH}: {candidate}"
+        )
+
+    candidates = [
+        repo_root / ".ci" / "agent-workloads",
+        repo_root.parent / "agent-workloads",
+    ]
 
     for candidate in candidates:
         applier = candidate / APPLIER_PATH
-        if applier.exists():
-            return candidate
+        if applier.is_file():
+            return candidate.resolve()
 
     searched = ", ".join(str(path) for path in candidates)
     raise GrantOwnershipError(
@@ -107,39 +133,22 @@ def load_applier_contract(
     source_path = repo_root / OWNERSHIP_SOURCE_PATH
     if source_path.exists():
         source = _load_yaml(source_path)
-        preserved_keys = tuple(
-            sorted(
-                str(key)
-                for key in source.get("session_authority_budget_preserved_keys")
-                or [_required_str(source.get("influence_key"), "influence_key")]
-            )
-        )
-        influence_key = _required_str(
-            source.get("influence_key") or "influence",
-            "influence_key",
-        )
-        if influence_key not in preserved_keys:
-            preserved_keys = tuple(sorted((*preserved_keys, influence_key)))
-
-        return ApplierContract(
-            deployment_owned_capability_keys=tuple(
-                sorted(
-                    _required_list(
-                        source.get("deployment_owned_capability_keys"),
-                        "deployment_owned_capability_keys",
-                    )
-                )
+        return _validated_applier_contract(
+            deployment_owned_capability_keys=source.get(
+                "deployment_owned_capability_keys"
             ),
-            preserve_existing_capability_keys=tuple(
-                sorted(
-                    _required_list(
-                        source.get("preserve_existing_capability_keys"),
-                        "preserve_existing_capability_keys",
-                    )
-                )
+            preserve_existing_capability_keys=source.get(
+                "preserve_existing_capability_keys"
             ),
-            influence_key=influence_key,
-            session_authority_budget_preserved_keys=preserved_keys,
+            spend_limit_keys=source.get("spend_limit_keys"),
+            spend_limit_preserving_mapping_keys=source.get(
+                "spend_limit_preserving_mapping_keys"
+            ),
+            influence_key=source.get("influence_key"),
+            session_authority_budget_preserved_keys=source.get(
+                "session_authority_budget_preserved_keys"
+            ),
+            label=str(source_path),
         )
 
     return extract_applier_contract(find_agent_workloads_repo(repo_root=repo_root))
@@ -147,45 +156,149 @@ def load_applier_contract(
 
 def extract_applier_contract(agent_workloads_repo: Path) -> ApplierContract:
     source_path = agent_workloads_repo / APPLIER_PATH
-    module = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    wanted = {
-        "DEPLOYMENT_OWNED_CAPABILITY_KEYS",
-        "PRESERVE_EXISTING_CAPABILITY_KEYS",
-        "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
-        "INFLUENCE_KEY",
-    }
-    values: dict[str, Any] = {}
-    for node in module.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        for target in node.targets:
-            if isinstance(target, ast.Name) and target.id in wanted:
-                values[target.id] = ast.literal_eval(node.value)
-
     try:
-        deployment_owned = tuple(sorted(values["DEPLOYMENT_OWNED_CAPABILITY_KEYS"]))
-        preserve_existing = tuple(sorted(values["PRESERVE_EXISTING_CAPABILITY_KEYS"]))
-        influence_key = str(values["INFLUENCE_KEY"])
-        preserved_keys = tuple(
-            sorted(
-                str(key)
-                for key in values.get(
-                    "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS",
-                    {influence_key},
-                )
-            )
+        module = ast.parse(
+            source_path.read_text(encoding="utf-8"),
+            filename=str(source_path),
         )
-    except KeyError as exc:
+    except (OSError, SyntaxError) as exc:
         raise GrantOwnershipError(
-            f"{source_path} is missing expected applier contract constant {exc.args[0]}"
+            f"cannot read the agent-workloads applier contract at {source_path}: {exc}"
         ) from exc
 
+    values: dict[str, Any] = {}
+    for node in module.body:
+        targets: list[ast.expr]
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        for target in targets:
+            if (
+                isinstance(target, ast.Name)
+                and target.id in APPLIER_CONTRACT_CONSTANT_NAMES
+            ):
+                try:
+                    value = ast.literal_eval(node.value)
+                except (TypeError, ValueError) as exc:
+                    raise GrantOwnershipError(
+                        f"{source_path} applier contract constant {target.id} "
+                        "must be a literal value"
+                    ) from exc
+                if target.id in APPLIER_COLLECTION_CONSTANT_NAMES:
+                    _reject_duplicate_collection_literals(
+                        node.value,
+                        source_path=source_path,
+                        constant_name=target.id,
+                    )
+                values[target.id] = value
+
+    missing = sorted(APPLIER_CONTRACT_CONSTANT_NAMES.difference(values))
+    if missing:
+        raise GrantOwnershipError(
+            f"{source_path} is missing expected applier contract constant(s): "
+            + ", ".join(missing)
+        )
+
+    return _validated_applier_contract(
+        deployment_owned_capability_keys=values[
+            "DEPLOYMENT_OWNED_CAPABILITY_KEYS"
+        ],
+        preserve_existing_capability_keys=values[
+            "PRESERVE_EXISTING_CAPABILITY_KEYS"
+        ],
+        spend_limit_keys=values["SPEND_LIMIT_KEYS"],
+        spend_limit_preserving_mapping_keys=values[
+            "SPEND_LIMIT_PRESERVING_MAPPING_KEYS"
+        ],
+        influence_key=values["INFLUENCE_KEY"],
+        session_authority_budget_preserved_keys=values[
+            "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS"
+        ],
+        label=str(source_path),
+    )
+
+
+def _validated_applier_contract(
+    *,
+    deployment_owned_capability_keys: Any,
+    preserve_existing_capability_keys: Any,
+    spend_limit_keys: Any,
+    spend_limit_preserving_mapping_keys: Any,
+    influence_key: Any,
+    session_authority_budget_preserved_keys: Any,
+    label: str,
+) -> ApplierContract:
+    deployment_owned = _nonempty_string_collection(
+        deployment_owned_capability_keys,
+        f"{label} deployment-owned capability keys",
+    )
+    preserve_existing = _nonempty_string_collection(
+        preserve_existing_capability_keys,
+        f"{label} preserve-existing capability keys",
+    )
+    preserved_spend_limits = _nonempty_string_collection(
+        spend_limit_keys,
+        f"{label} spend-limit keys",
+    )
+    spend_limit_mappings = _nonempty_string_collection(
+        spend_limit_preserving_mapping_keys,
+        f"{label} spend-limit-preserving mapping keys",
+    )
+    influence = _required_str(influence_key, f"{label} influence key")
+    preserved_keys = _nonempty_string_collection(
+        session_authority_budget_preserved_keys,
+        f"{label} session-authority preserved keys",
+    )
+    if influence not in preserved_keys:
+        raise GrantOwnershipError(
+            f"{label} session-authority preserved keys must include influence key "
+            f"{influence!r}"
+        )
     return ApplierContract(
         deployment_owned_capability_keys=deployment_owned,
         preserve_existing_capability_keys=preserve_existing,
-        influence_key=influence_key,
+        spend_limit_keys=preserved_spend_limits,
+        spend_limit_preserving_mapping_keys=spend_limit_mappings,
+        influence_key=influence,
         session_authority_budget_preserved_keys=preserved_keys,
     )
+
+
+def _nonempty_string_collection(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple | set | frozenset) or not value:
+        raise GrantOwnershipError(
+            f"{label} must be a non-empty collection of non-empty strings"
+        )
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise GrantOwnershipError(
+                f"{label} must be a non-empty collection of non-empty strings"
+            )
+        items.append(item)
+    if len(set(items)) != len(items):
+        raise GrantOwnershipError(f"{label} must not contain duplicate keys")
+    return tuple(sorted(items))
+
+
+def _reject_duplicate_collection_literals(
+    node: ast.expr | None,
+    *,
+    source_path: Path,
+    constant_name: str,
+) -> None:
+    if not isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return
+    literal_items = [ast.literal_eval(element) for element in node.elts]
+    for index, item in enumerate(literal_items):
+        if item in literal_items[:index]:
+            raise GrantOwnershipError(
+                f"{source_path} applier contract constant {constant_name} "
+                "must not contain duplicate literal values"
+            )
 
 
 def build_ownership_map(
@@ -202,6 +315,11 @@ def build_ownership_map(
         _required_str(data.get("workload_imports.yaml"), "data.workload_imports.yaml")
     )
     imports = _required_list(workload_imports.get("imports"), "workload imports")
+    workload_imports_reference = _registry_overlay_value_reference(
+        repo_root,
+        "workload_imports.yaml",
+    )
+    policy_path = registry_overlay_value_path(repo_root, "policy.prod.yaml")
 
     capabilities: dict[str, Any] = {}
     for entry in imports:
@@ -232,8 +350,7 @@ def build_ownership_map(
                     "path": expected_source.get("path"),
                 },
                 "config_path": (
-                    "apps/agent-control-plane-registry-overlay/configmap.yaml:"
-                    f"data.workload_imports.yaml.imports[id={agent_id}]"
+                    f"{workload_imports_reference}imports[id={agent_id}]"
                     f".capabilities.{capability_id}"
                 ),
                 "keys": keys,
@@ -250,6 +367,10 @@ def build_ownership_map(
             "preserve_existing_capability_keys": list(
                 contract.preserve_existing_capability_keys
             ),
+            "spend_limit_keys": list(contract.spend_limit_keys),
+            "spend_limit_preserving_mapping_keys": list(
+                contract.spend_limit_preserving_mapping_keys
+            ),
             "session_authority_budget_preserved_keys": list(
                 contract.session_authority_budget_preserved_keys
             ),
@@ -260,7 +381,7 @@ def build_ownership_map(
         ],
         "policy_overlay": {
             "owner": DEPLOYMENT_OWNER,
-            "file": str(CONFIGMAP_PATH),
+            "file": str(policy_path),
             "embedded_file": "policy.prod.yaml",
             "deploy_consequence": CONTROL_PLANE_RESTART,
             "remint_required": False,
@@ -299,6 +420,13 @@ def render_ownership_markdown(ownership: dict[str, Any]) -> str:
         + ", ".join(f"`{key}`" for key in generated_from["deployment_owned_capability_keys"]),
         "- Preserved existing capability roots: "
         + ", ".join(f"`{key}`" for key in generated_from["preserve_existing_capability_keys"]),
+        "- Spend-limit-preserving mapping roots: "
+        + ", ".join(
+            f"`{key}`"
+            for key in generated_from["spend_limit_preserving_mapping_keys"]
+        ),
+        "- Preserved spend-limit subkeys: "
+        + ", ".join(f"`{key}`" for key in generated_from["spend_limit_keys"]),
         "- Session authority preserved subkeys: "
         + ", ".join(
             f"`session_authority_budget.{key}`"
@@ -345,37 +473,23 @@ def write_ownership_outputs(
     repo_root: Path = REPO_ROOT,
     agent_workloads_repo: Path | None = None,
 ) -> None:
-    contract = load_applier_contract(
+    exact_agent_workloads_repo = find_agent_workloads_repo(
         repo_root=repo_root,
-        agent_workloads_repo=agent_workloads_repo,
+        explicit=agent_workloads_repo,
     )
-    _write_yaml(
-        repo_root / OWNERSHIP_SOURCE_PATH,
-        {
-            "schema_version": "grant-ownership-source.v1",
-            "generated_from": {
-                "repo": "cesaregarza/agent-workloads",
-                "path": str(APPLIER_PATH),
-            },
-            "deployment_owned_capability_keys": list(
-                contract.deployment_owned_capability_keys
-            ),
-            "preserve_existing_capability_keys": list(
-                contract.preserve_existing_capability_keys
-            ),
-            "influence_key": contract.influence_key,
-            "session_authority_budget_preserved_keys": list(
-                contract.session_authority_budget_preserved_keys
-            ),
-        },
-    )
+    contract = extract_applier_contract(exact_agent_workloads_repo)
     ownership = build_ownership_map(
         repo_root=repo_root,
-        agent_workloads_repo=None,
+        agent_workloads_repo=exact_agent_workloads_repo,
     )
-    _write_yaml(repo_root / OWNERSHIP_MAP_PATH, ownership)
+    source_yaml = _dump_yaml(_ownership_source(contract))
+    ownership_yaml = _dump_yaml(ownership)
+    ownership_markdown = render_ownership_markdown(ownership)
+
+    (repo_root / OWNERSHIP_SOURCE_PATH).write_text(source_yaml, encoding="utf-8")
+    (repo_root / OWNERSHIP_MAP_PATH).write_text(ownership_yaml, encoding="utf-8")
     (repo_root / OWNERSHIP_DOC_PATH).write_text(
-        render_ownership_markdown(ownership),
+        ownership_markdown,
         encoding="utf-8",
     )
 
@@ -385,6 +499,17 @@ def check_ownership_outputs(
     repo_root: Path = REPO_ROOT,
     agent_workloads_repo: Path | None = None,
 ) -> None:
+    contract = load_applier_contract(
+        repo_root=repo_root,
+        agent_workloads_repo=agent_workloads_repo,
+    )
+    expected_source = _dump_yaml(_ownership_source(contract))
+    actual_source = (repo_root / OWNERSHIP_SOURCE_PATH).read_text(encoding="utf-8")
+    if actual_source != expected_source:
+        raise GrantOwnershipError(
+            f"{OWNERSHIP_SOURCE_PATH} is stale; run scripts/generate_grant_ownership.py"
+        )
+
     ownership = build_ownership_map(
         repo_root=repo_root,
         agent_workloads_repo=agent_workloads_repo,
@@ -402,6 +527,30 @@ def check_ownership_outputs(
         raise GrantOwnershipError(
             f"{OWNERSHIP_DOC_PATH} is stale; run scripts/generate_grant_ownership.py"
         )
+
+
+def _ownership_source(contract: ApplierContract) -> dict[str, Any]:
+    return {
+        "schema_version": "grant-ownership-source.v1",
+        "generated_from": {
+            "repo": "cesaregarza/agent-workloads",
+            "path": str(APPLIER_PATH),
+        },
+        "deployment_owned_capability_keys": list(
+            contract.deployment_owned_capability_keys
+        ),
+        "preserve_existing_capability_keys": list(
+            contract.preserve_existing_capability_keys
+        ),
+        "spend_limit_keys": list(contract.spend_limit_keys),
+        "spend_limit_preserving_mapping_keys": list(
+            contract.spend_limit_preserving_mapping_keys
+        ),
+        "influence_key": contract.influence_key,
+        "session_authority_budget_preserved_keys": list(
+            contract.session_authority_budget_preserved_keys
+        ),
+    }
 
 
 def apply_grant_edit(
@@ -460,8 +609,8 @@ def apply_grant_edit(
         new_value=new_value,
         deploy_consequence=key_info["deploy_consequence"],
         config_path=(
-            "apps/agent-control-plane-registry-overlay/configmap.yaml:"
-            f"data.workload_imports.yaml.imports[id={import_entry['id']}]"
+            f"{_registry_overlay_value_reference(repo_root, 'workload_imports.yaml')}"
+            f"imports[id={import_entry['id']}]"
             f".capabilities.{capability_id}.{key_path}"
         ),
         owner=key_info["owner"],
@@ -567,6 +716,18 @@ def _ownership_for_key(key: str, contract: ApplierContract) -> dict[str, Any]:
             "remint_required": False,
             "digest_moves": False,
             "source": "PRESERVE_EXISTING_CAPABILITY_KEYS",
+        }
+    if key in contract.spend_limit_preserving_mapping_keys:
+        return {
+            "owner": MIXED_OWNER,
+            "deploy_consequence": CONTROL_PLANE_RESTART,
+            "remint_required": False,
+            "digest_moves": False,
+            "deployment_owned_subkeys": list(contract.spend_limit_keys),
+            "release_owned_subkeys": "*",
+            "source": (
+                "SPEND_LIMIT_PRESERVING_MAPPING_KEYS/SPEND_LIMIT_KEYS"
+            ),
         }
     if key == "session_authority_budget":
         return {
@@ -748,6 +909,13 @@ def registry_overlay_value_path(repo_root: Path, key: str) -> Path:
     if source_path is None:
         raise GrantOwnershipError(f"registry overlay ConfigMap key not found: {key}")
     return source_path.relative_to(repo_root)
+
+
+def _registry_overlay_value_reference(repo_root: Path, key: str) -> str:
+    path = registry_overlay_value_path(repo_root, key)
+    if path == CONFIGMAP_PATH:
+        return f"{path}:data.{key}."
+    return f"{path}:"
 
 
 def registry_overlay_source_paths(repo_root: Path) -> dict[str, Path]:

--- a/tests/test_agent_control_plane_registry_compat.py
+++ b/tests/test_agent_control_plane_registry_compat.py
@@ -222,7 +222,7 @@ class AgentControlPlaneRegistryCompatTests(unittest.TestCase):
 
             self.assertNotEqual(result.returncode, 0)
             self.assertIn(
-                "worker_service model call lease must declare exactly one allowed profile",
+                "worker_service model call bounds must declare exactly one allowed profile",
                 result.stderr,
             )
 
@@ -384,14 +384,14 @@ def _fake_agent_platform_repo(tmp: Path) -> tuple[Path, str, str]:
                             import_entry.get("capabilities") or {}
                         ).items():
                             profiles = (
-                                (capability.get("model_lease") or {}).get(
+                                (capability.get("model_bounds") or {}).get(
                                     "allowed_profiles"
                                 )
                                 or []
                             )
                             if len(profiles) != 1:
                                 raise RegistryError(
-                                    "worker_service model call lease must declare "
+                                    "worker_service model call bounds must declare "
                                     f"exactly one allowed profile: {capability_id}"
                                 )
                     return cls()
@@ -497,7 +497,7 @@ def _write_overlay_configmap(
                 "image_digest": "sha256:" + "b" * 64,
                 "capabilities": {
                     "agent_workloads.opencode_propose": {
-                        "model_lease": {"allowed_profiles": allowed_profiles}
+                        "model_bounds": {"allowed_profiles": allowed_profiles}
                     }
                 },
             }

--- a/tests/test_grant_ownership.py
+++ b/tests/test_grant_ownership.py
@@ -9,16 +9,19 @@ from typing import Any
 from ruamel.yaml import YAML
 
 from scripts.grant_ownership import (
+    APPLIER_PATH,
     OWNERSHIP_DOC_PATH,
     OWNERSHIP_MAP_PATH,
     OWNERSHIP_SOURCE_PATH,
     REGISTRY_OVERLAY_DIR,
     GrantEditError,
+    GrantOwnershipError,
     apply_grant_edit,
     build_ownership_map,
     check_ownership_outputs,
     load_registry_overlay_data,
     render_ownership_markdown,
+    write_ownership_outputs,
     write_registry_overlay_values,
 )
 
@@ -30,6 +33,24 @@ YAML_PARSER = YAML(typ="safe")
 class GrantOwnershipTests(unittest.TestCase):
     def test_generated_ownership_map_is_current(self) -> None:
         check_ownership_outputs(repo_root=REPO_ROOT)
+
+    def test_generated_ownership_map_points_to_split_registry_sources(self) -> None:
+        ownership = YAML_PARSER.load((REPO_ROOT / OWNERSHIP_MAP_PATH).read_text())
+
+        self.assertEqual(
+            ownership["policy_overlay"]["file"],
+            "apps/agent-control-plane-registry-overlay/registry/policy.prod.yaml",
+        )
+        workload_imports_prefix = (
+            "apps/agent-control-plane-registry-overlay/registry/"
+            "workload_imports.yaml:"
+        )
+        for capability in ownership["capabilities"].values():
+            self.assertTrue(
+                capability["config_path"].startswith(workload_imports_prefix),
+                capability["config_path"],
+            )
+            self.assertNotIn("configmap.yaml", capability["config_path"])
 
     def test_ci_checks_generated_grant_ownership_without_private_repo_checkout(
         self,
@@ -74,6 +95,331 @@ class GrantOwnershipTests(unittest.TestCase):
             render_ownership_markdown(changed),
         )
 
+    def test_explicit_agent_workloads_checkout_never_falls_back(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        _fake_agent_workloads(base / "agent-workloads")
+        explicit = base / "requested-agent-workloads"
+        explicit.mkdir()
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "explicit agent-workloads checkout does not contain the expected applier",
+        ):
+            build_ownership_map(
+                repo_root=base / "config",
+                agent_workloads_repo=explicit,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_constant_name_drift(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_constant_name="DEPLOYMENT_OWNED_CAPABILITY_ROOTS",
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "missing expected applier contract constant.*"
+            "DEPLOYMENT_OWNED_CAPABILITY_KEYS",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_string_key_collection(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys="model_bounds",
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "deployment-owned capability keys must be a non-empty collection",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_duplicate_set_literal(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys_literal="{'model_bounds', 'model_bounds'}",
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "DEPLOYMENT_OWNED_CAPABILITY_KEYS must not contain duplicate literal values",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_malformed_literal(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys_literal="{'model_bounds', dynamic_key}",
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "DEPLOYMENT_OWNED_CAPABILITY_KEYS must be a literal value",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_non_string_key(self) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys=(1,),
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "deployment-owned capability keys must be a non-empty collection",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_requires_preserved_influence_key(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            session_authority_budget_preserved_keys=("max_operations",),
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "session-authority preserved keys must include influence key 'influence'",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_agent_workloads_checkout_rejects_non_string_influence_key(
+        self,
+    ) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            influence_key=1,
+        )
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "non-empty string expected: .* influence key",
+        ):
+            build_ownership_map(
+                repo_root=REPO_ROOT,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_fallback_ownership_source_rejects_non_string_key(self) -> None:
+        root = _fixture_repo()
+        source_path = root / OWNERSHIP_SOURCE_PATH
+        source = YAML_PARSER.load(source_path.read_text())
+        source["deployment_owned_capability_keys"] = [1]
+        _write_yaml(source_path, source)
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "deployment-owned capability keys must be a non-empty collection",
+        ):
+            build_ownership_map(repo_root=root)
+
+    def test_fallback_ownership_source_rejects_string_preserved_keys(self) -> None:
+        root = _fixture_repo()
+        source_path = root / OWNERSHIP_SOURCE_PATH
+        source = YAML_PARSER.load(source_path.read_text())
+        source["session_authority_budget_preserved_keys"] = "influence"
+        _write_yaml(source_path, source)
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "session-authority preserved keys must be a non-empty collection",
+        ):
+            build_ownership_map(repo_root=root)
+
+    def test_fallback_ownership_source_requires_preserved_influence_key(self) -> None:
+        root = _fixture_repo()
+        source_path = root / OWNERSHIP_SOURCE_PATH
+        source = YAML_PARSER.load(source_path.read_text())
+        source["session_authority_budget_preserved_keys"] = ["max_operations"]
+        _write_yaml(source_path, source)
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "session-authority preserved keys must include influence key 'influence'",
+        ):
+            build_ownership_map(repo_root=root)
+
+    def test_explicit_agent_workloads_checkout_regenerates_all_outputs(self) -> None:
+        root = _fixture_repo()
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys=(
+                "artifacts",
+                "custom_deployment_key",
+                "disclosure",
+                "model_bounds",
+            ),
+        )
+
+        write_ownership_outputs(
+            repo_root=root,
+            agent_workloads_repo=agent_workloads,
+        )
+
+        source = YAML_PARSER.load((root / OWNERSHIP_SOURCE_PATH).read_text())
+        ownership = YAML_PARSER.load((root / OWNERSHIP_MAP_PATH).read_text())
+        markdown = (root / OWNERSHIP_DOC_PATH).read_text()
+        self.assertIn(
+            "custom_deployment_key",
+            source["deployment_owned_capability_keys"],
+        )
+        self.assertIn(
+            "custom_deployment_key",
+            ownership["generated_from"]["deployment_owned_capability_keys"],
+        )
+        self.assertIn("`custom_deployment_key`", markdown)
+        check_ownership_outputs(
+            repo_root=root,
+            agent_workloads_repo=agent_workloads,
+        )
+
+    def test_spend_limit_mapping_is_mixed_ownership(self) -> None:
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+        )
+
+        ownership = build_ownership_map(
+            repo_root=REPO_ROOT,
+            agent_workloads_repo=agent_workloads,
+        )
+
+        broker_bounds = ownership["capabilities"][
+            "agent_workloads.readonly_query"
+        ]["keys"]["broker_bounds"]
+        self.assertEqual(broker_bounds["owner"], "mixed")
+        self.assertEqual(
+            broker_bounds["deployment_owned_subkeys"],
+            ["max_cost_usd"],
+        )
+        self.assertEqual(
+            broker_bounds["source"],
+            "SPEND_LIMIT_PRESERVING_MAPPING_KEYS/SPEND_LIMIT_KEYS",
+        )
+
+    def test_generation_validation_failure_preserves_all_outputs(self) -> None:
+        root = _fixture_repo()
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+            deployment_owned_capability_keys=(
+                "artifacts",
+                "custom_deployment_key",
+                "disclosure",
+                "model_bounds",
+            ),
+        )
+        output_paths = [
+            root / OWNERSHIP_SOURCE_PATH,
+            root / OWNERSHIP_MAP_PATH,
+            root / OWNERSHIP_DOC_PATH,
+        ]
+        before = {path: path.read_bytes() for path in output_paths}
+        (root / REGISTRY_OVERLAY_DIR / "registry/workload_imports.yaml").unlink()
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "registry overlay ConfigMap source file not found",
+        ):
+            write_ownership_outputs(
+                repo_root=root,
+                agent_workloads_repo=agent_workloads,
+            )
+
+        self.assertEqual(
+            {path: path.read_bytes() for path in output_paths},
+            before,
+        )
+
+    def test_explicit_check_rejects_stale_ownership_source(self) -> None:
+        root = _fixture_repo()
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+        )
+        write_ownership_outputs(
+            repo_root=root,
+            agent_workloads_repo=agent_workloads,
+        )
+        source_path = root / OWNERSHIP_SOURCE_PATH
+        source = YAML_PARSER.load(source_path.read_text())
+        source["deployment_owned_capability_keys"].remove("model_bounds")
+        _write_yaml(source_path, source)
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "docs/grant-ownership-source.yaml is stale",
+        ):
+            check_ownership_outputs(
+                repo_root=root,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_check_rejects_stale_ownership_map(self) -> None:
+        root = _fixture_repo()
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+        )
+        write_ownership_outputs(
+            repo_root=root,
+            agent_workloads_repo=agent_workloads,
+        )
+        (root / OWNERSHIP_MAP_PATH).write_text("stale: true\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "docs/grant-ownership.yaml is stale",
+        ):
+            check_ownership_outputs(
+                repo_root=root,
+                agent_workloads_repo=agent_workloads,
+            )
+
+    def test_explicit_check_rejects_stale_ownership_markdown(self) -> None:
+        root = _fixture_repo()
+        agent_workloads = _fake_agent_workloads(
+            Path(tempfile.mkdtemp()) / "agent-workloads",
+        )
+        write_ownership_outputs(
+            repo_root=root,
+            agent_workloads_repo=agent_workloads,
+        )
+        (root / OWNERSHIP_DOC_PATH).write_text("stale\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(
+            GrantOwnershipError,
+            "docs/grant-ownership.md is stale",
+        ):
+            check_ownership_outputs(
+                repo_root=root,
+                agent_workloads_repo=agent_workloads,
+            )
+
     def test_set_grant_unsets_deployment_owned_model_bounds_key(self) -> None:
         root = _fixture_repo()
         _inject_model_completion_tokens(root, 4000)
@@ -91,6 +437,13 @@ class GrantOwnershipTests(unittest.TestCase):
         self.assertNotIn("max_completion_tokens", capability["model_bounds"])
         self.assertEqual(result.action, "unset")
         self.assertEqual(result.old_value, 4000)
+        self.assertTrue(
+            result.config_path.startswith(
+                "apps/agent-control-plane-registry-overlay/registry/"
+                "workload_imports.yaml:"
+            ),
+            result.config_path,
+        )
         body = pr_body.read_text()
         self.assertIn("overlay-only: CP restart required, no re-mint", body)
         self.assertIn("No workload manifest, image, or code digest moves.", body)
@@ -116,6 +469,25 @@ class GrantOwnershipTests(unittest.TestCase):
         body = pr_body.read_text()
         self.assertIn("overlay-only: CP restart required, no re-mint", body)
         self.assertIn("No workload manifest, image, or code digest moves.", body)
+
+    def test_set_grant_allows_preserved_broker_spend_limit_edit(self) -> None:
+        root = _fixture_repo()
+
+        result = apply_grant_edit(
+            repo_root=root,
+            capability_id="agent_workloads.readonly_query",
+            key_path="broker_bounds.max_cost_usd",
+            raw_value="7.5",
+        )
+
+        capability = _capability(root, "agent_workloads.readonly_query")
+        self.assertEqual(capability["broker_bounds"]["max_cost_usd"], 7.5)
+        self.assertEqual(result.owner, "deployment_overlay")
+        self.assertFalse(
+            YAML_PARSER.load((root / OWNERSHIP_MAP_PATH).read_text())["capabilities"][
+                "agent_workloads.readonly_query"
+            ]["keys"]["broker_bounds"]["remint_required"]
+        )
 
     def test_set_grant_refuses_release_owned_output_schema(self) -> None:
         root = _fixture_repo()
@@ -144,6 +516,54 @@ def _fixture_repo() -> Path:
         target = root / path
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, target)
+    return root
+
+
+def _fake_agent_workloads(
+    root: Path,
+    *,
+    deployment_owned_capability_keys: Any = (
+        "artifacts",
+        "disclosure",
+        "model_bounds",
+    ),
+    deployment_owned_capability_keys_literal: str | None = None,
+    deployment_constant_name: str = "DEPLOYMENT_OWNED_CAPABILITY_KEYS",
+    preserve_existing_capability_keys: Any = ("approval_mode",),
+    spend_limit_keys: Any = ("max_cost_usd",),
+    spend_limit_preserving_mapping_keys: Any = ("broker_bounds",),
+    influence_key: Any = "influence",
+    session_authority_budget_preserved_keys: Any = (
+        "influence",
+        "max_operations",
+    ),
+) -> Path:
+    applier_path = root / APPLIER_PATH
+    applier_path.parent.mkdir(parents=True)
+    deployment_literal = (
+        deployment_owned_capability_keys_literal
+        if deployment_owned_capability_keys_literal is not None
+        else repr(deployment_owned_capability_keys)
+    )
+    applier_path.write_text(
+        "\n".join(
+            [
+                f"{deployment_constant_name} = {deployment_literal}",
+                (
+                    "PRESERVE_EXISTING_CAPABILITY_KEYS = "
+                    f"{preserve_existing_capability_keys!r}"
+                ),
+                f"SPEND_LIMIT_KEYS = {spend_limit_keys!r}",
+                "SPEND_LIMIT_PRESERVING_MAPPING_KEYS = "
+                f"{spend_limit_preserving_mapping_keys!r}",
+                f"INFLUENCE_KEY = {influence_key!r}",
+                "SESSION_AUTHORITY_BUDGET_PRESERVED_KEYS = "
+                f"{session_authority_budget_preserved_keys!r}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
     return root
 
 


### PR DESCRIPTION
## Outcome

- Make grant-ownership generation derive its contract from an explicit, exact agent-workloads checkout.
- Require and validate all six ownership-affecting applier constants, including spend-limit mapping ownership.
- Regenerate and check the committed source snapshot, YAML map, and Markdown together.
- Point generated ownership paths at the split registry sources.

## Root cause

The deployment generator modeled only part of the release applier's ownership contract. A vocabulary or merge-policy change could therefore leave the committed source snapshot and generated ownership artifacts internally consistent while disagreeing with the live applier.

## Security boundary

This closes a clobber-on-repin authority gap. In particular, `broker_bounds.max_cost_usd` is now recorded as deployment-owned while the remaining `broker_bounds` fields remain release-owned.

This PR does not publish an agent-workloads release, re-pin a workload, mint or rotate credentials, merge, deploy, sync Argo CD, or mutate production.

## Independent review fixes

- Added the previously omitted `SPEND_LIMIT_KEYS` and `SPEND_LIMIT_PRESERVING_MAPPING_KEYS` contract roots.
- Precompute and validate all three ownership outputs before the first write, so late validation failure leaves committed outputs unchanged.
- Detect duplicate set literals at the AST level before Python collapses them.
- Added malformed-literal, duplicate, stale source/map/Markdown, mixed spend-limit ownership, exact-checkout, and no-partial-output regressions.

## Validation

- Python 3.11 full suite: 155 passed
- Focused ownership/registry suite: 35 passed
- Exact current agent-workloads checkout generation and `--check`: passed
- Real Python 3.13 production-path `regenerate_and_validate_grant_ownership_outputs`: passed
- kustomize v5.4.3 registry overlay render: passed
- control-plane release-pin check: passed
- `git diff --check`: passed
- Signed commit: `4001775e972503a4c2da602d112ac2b2792473c8`

## Dependency and rollout

The stronger transactional agent-workloads integration is already merged in cesaregarza/agent-workloads#102. Its stale local predecessor was intentionally not published because it was non-atomic. This PR supplies the remaining GarzAICluster guard and generated contract correction.

No production registry, Helm values, image pin, identity tuple, or rendered ConfigMap changes are included.

Refs CES-555.