### PR TITLE
Add disabled Poetry deployment substrate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,6 +190,10 @@ jobs:
             path: helm/skyquiet-server
             release: skyquiet-server
             prod_values: helm/skyquiet-server/values.yaml
+          - name: poetry
+            path: helm/poetry
+            release: poetry
+            prod_values: helm/poetry/values-ci.yaml
           - name: agent-workloads
             path: helm/agent-workloads
             release: agent-workloads
@@ -221,6 +225,61 @@ jobs:
           mkdir -p rendered
           helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" > "rendered/${{ matrix.chart.name }}-default.yaml"
           helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" -f "${{ matrix.chart.prod_values }}" > "rendered/${{ matrix.chart.name }}-prod.yaml"
+
+      - name: Install uv for Poetry semantic checks
+        if: matrix.chart.name == 'poetry'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python for Poetry semantic checks
+        if: matrix.chart.name == 'poetry'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry semantic-check dependencies
+        if: matrix.chart.name == 'poetry'
+        run: uv sync
+
+      - name: Run Poetry semantic checks
+        if: matrix.chart.name == 'poetry'
+        run: >-
+          uv run python scripts/check_poetry_substrate.py
+          --default-render rendered/poetry-default.yaml
+          --enabled-render rendered/poetry-prod.yaml
+
+      - name: Verify Poetry Access configuration fails closed
+        if: matrix.chart.name == 'poetry'
+        run: |
+          set -euo pipefail
+          chart=helm/poetry
+          expect_failure() {
+            expected=$1
+            shift
+            if helm template poetry "$chart" "$@" >/dev/null 2>rendered/poetry-negative.err; then
+              echo "Expected Helm render to fail: $expected" >&2
+              exit 1
+            fi
+            grep -F "$expected" rendered/poetry-negative.err >/dev/null
+          }
+          expect_failure "teamDomain is required" \
+            --set enabled=true \
+            --set application.cloudflareAccess.enabled=true
+          expect_failure "audience is required" \
+            --set enabled=true \
+            --set application.cloudflareAccess.enabled=true \
+            --set application.cloudflareAccess.teamDomain=https://poetry-ci.cloudflareaccess.com
+          expect_failure "allowedEmail is required" \
+            --set enabled=true \
+            --set application.cloudflareAccess.enabled=true \
+            --set application.cloudflareAccess.teamDomain=https://poetry-ci.cloudflareaccess.com \
+            --set application.cloudflareAccess.audience=0123456789abcdef0123456789abcdef \
+            --set application.cloudflareAccess.allowedEmail=
+          expect_failure "must be an https://" \
+            -f helm/poetry/values-ci.yaml \
+            --set application.cloudflareAccess.teamDomain=http://bad.example.com
+          expect_failure "must remain cesar@cegarza.com" \
+            -f helm/poetry/values-ci.yaml \
+            --set application.cloudflareAccess.allowedEmail=attacker@example.com
 
       - name: Run kubeconform
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,6 +280,10 @@ jobs:
           expect_failure "must remain cesar@cegarza.com" \
             -f helm/poetry/values-ci.yaml \
             --set application.cloudflareAccess.allowedEmail=attacker@example.com
+          expect_failure "proxying requires application.cloudflareAccess.enabled=true" \
+            -f helm/poetry/values-ci.yaml \
+            --set-string ingress.cloudflareProxied=true \
+            --set application.cloudflareAccess.enabled=false
 
       - name: Run kubeconform
         run: |

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -28,6 +28,9 @@ creation_rules:
   - path_regex: ^secrets/spotify-hot-100/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+  - path_regex: ^secrets/poetry/.*\.enc\.yaml$
+    encrypted_regex: '^(data|stringData)$'
+    age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
   - path_regex: ^secrets/skyquiet-server/.*\.enc\.yaml$
     encrypted_regex: '^(data|stringData)$'
     age: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt

--- a/argocd/applications/poetry-secrets.yaml
+++ b/argocd/applications/poetry-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: poetry-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/GarzAICluster
+    targetRevision: main
+    path: secrets/poetry
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: poetry
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 5

--- a/argocd/applications/poetry.yaml
+++ b/argocd/applications/poetry.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: poetry
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: splattop
+  source:
+    repoURL: https://github.com/cesaregarza/GarzAICluster
+    targetRevision: main
+    path: helm/poetry
+    helm:
+      releaseName: poetry
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: poetry
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+  revisionHistoryLimit: 10

--- a/argocd/projects/splattop-project.yaml
+++ b/argocd/projects/splattop-project.yaml
@@ -30,6 +30,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: garz-ai
       server: https://kubernetes.default.svc
+    - namespace: poetry
+      server: https://kubernetes.default.svc
     - namespace: agent-control-plane
       server: https://kubernetes.default.svc
     - namespace: agent-workloads

--- a/helm/poetry/Chart.yaml
+++ b/helm/poetry/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: poetry
+description: Wagtail poetry site for poetry.cegarza.com
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -13,6 +13,8 @@ Activate in reviewed stages:
    `Synced` and `Healthy` before enabling the chart.
 2. Pin a published immutable image, set `enabled: true`, keep ingress disabled,
    and verify the Service plus `/healthz` and `/readyz` from inside the cluster.
+   While Access is disabled the chart explicitly sets
+   `CLOUDFLARE_ACCESS_REQUIRED=false` for this ingress-free staging phase.
 3. Set `ingress.enabled: true` with `cloudflareProxied: "false"`. Complete nginx
    routing and the initial Let's Encrypt HTTP-01 issuance before proxying the
    hostname.
@@ -29,7 +31,9 @@ Activate in reviewed stages:
    and a direct origin request is still denied.
 
 The chart refuses to render a proxied Ingress unless origin JWT validation is
-enabled in that same revision.
+enabled in that same revision. Enabling validation also derives
+`CLOUDFLARE_ACCESS_REQUIRED=true`; the pod will then fail startup rather than
+run a production admin origin without the issuer and audience.
 
 Do not use `nginx.ingress.kubernetes.io/whitelist-source-range` for this control
 unless the shared ingress controller is separately changed and verified to

--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,0 +1,35 @@
+# Poetry chart rollout stages
+
+`values.yaml` is intentionally inert: both `enabled` and `ingress.enabled` are
+false. `values-ci.yaml` exists only to exercise every template in CI and must not
+be added to the Argo CD Application.
+
+Activate in reviewed stages:
+
+1. Add the SOPS-encrypted database, Django, media, and registry Secrets. A root
+   sync wave orders the `poetry-secrets` Application at `-10` and `poetry` at
+   `+10`, but those waves order Application reconciliation only. They do not
+   prove the child secrets Application has finished. Verify `poetry-secrets` is
+   `Synced` and `Healthy` before enabling the chart.
+2. Pin a published immutable image, set `enabled: true`, keep ingress disabled,
+   and verify the Service plus `/healthz` and `/readyz` from inside the cluster.
+3. Set `ingress.enabled: true` with `cloudflareProxied: "false"`. Complete nginx
+   routing and the initial Let's Encrypt HTTP-01 issuance before proxying the
+   hostname.
+4. Configure and verify Cloudflare Access for `/admin` and `/admin/*`. Copy the
+   application's exact team domain and audience tag into
+   `application.cloudflareAccess`, enable the origin validator, and prove that
+   a raw load-balancer request with `Host: poetry.cegarza.com` receives `403` for
+   `/admin/`. The validator checks the Access-signed RS256 JWT, issuer, audience,
+   and exact `cesar@cegarza.com` identity; the normal Wagtail login remains the
+   second authentication step. The ConfigMap checksum in the pod template makes
+   sure this same GitOps revision restarts the Deployment with validation active.
+5. Switch Cloudflare proxying on. Confirm public routes remain unauthenticated,
+   `/admin/` challenges at the edge, an authenticated request reaches Wagtail,
+   and a direct origin request is still denied.
+
+Do not use `nginx.ingress.kubernetes.io/whitelist-source-range` for this control
+unless the shared ingress controller is separately changed and verified to
+preserve Cloudflare source IPs. The current controller does not provide that
+guarantee. Signed Access JWT validation is independent of source-IP handling and
+does not interfere with HTTP-01 certificate renewal.

--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -28,6 +28,9 @@ Activate in reviewed stages:
    `/admin/` challenges at the edge, an authenticated request reaches Wagtail,
    and a direct origin request is still denied.
 
+The chart refuses to render a proxied Ingress unless origin JWT validation is
+enabled in that same revision.
+
 Do not use `nginx.ingress.kubernetes.io/whitelist-source-range` for this control
 unless the shared ingress controller is separately changed and verified to
 preserve Cloudflare source IPs. The current controller does not provide that

--- a/helm/poetry/templates/_helpers.tpl
+++ b/helm/poetry/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/* Expand the chart name. */}}
+{{- define "poetry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a fully qualified application name. */}}
+{{- define "poetry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "poetry.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "poetry.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels. */}}
+{{- define "poetry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "poetry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Image reference. Tags are commit pins; an optional digest takes precedence. */}}
+{{- define "poetry.image" -}}
+{{- $repository := required "image.repository is required" .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.image.digest) -}}
+{{- fail "image.digest must be a sha256 digest" -}}
+{{- end -}}
+{{- printf "%s@%s" $repository .Values.image.digest -}}
+{{- else -}}
+{{- $tag := required "image.tag is required when image.digest is empty" .Values.image.tag -}}
+{{- if not (regexMatch "^sha-[a-f0-9]{40}$" $tag) -}}
+{{- fail "image.tag must be an immutable sha-<40 lowercase hex> commit pin" -}}
+{{- end -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/* Shared environment sources. */}}
+{{- define "poetry.envFrom" -}}
+- configMapRef:
+    name: {{ .Values.application.configMapName }}
+{{- range .Values.application.secretRefs }}
+- secretRef:
+    name: {{ . }}
+{{- end }}
+{{- end }}
+
+{{/* Shared image pull secrets. */}}
+{{- define "poetry.imagePullSecrets" -}}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/poetry/templates/configmap.yaml
+++ b/helm/poetry/templates/configmap.yaml
@@ -23,6 +23,7 @@ data:
   {{- range $key, $value := .Values.application.configData }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  CLOUDFLARE_ACCESS_REQUIRED: {{ ternary "true" "false" .Values.application.cloudflareAccess.enabled | quote }}
   {{- if .Values.application.cloudflareAccess.enabled }}
   CLOUDFLARE_ACCESS_TEAM_DOMAIN: {{ .Values.application.cloudflareAccess.teamDomain | quote }}
   CLOUDFLARE_ACCESS_AUD: {{ .Values.application.cloudflareAccess.audience | quote }}

--- a/helm/poetry/templates/configmap.yaml
+++ b/helm/poetry/templates/configmap.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.enabled .Values.application.cloudflareAccess.enabled }}
+{{- $teamDomain := required "application.cloudflareAccess.teamDomain is required when Cloudflare Access validation is enabled" .Values.application.cloudflareAccess.teamDomain }}
+{{- $audience := required "application.cloudflareAccess.audience is required when Cloudflare Access validation is enabled" .Values.application.cloudflareAccess.audience }}
+{{- $allowedEmail := required "application.cloudflareAccess.allowedEmail is required when Cloudflare Access validation is enabled" .Values.application.cloudflareAccess.allowedEmail }}
+{{- if not (regexMatch "^https://[a-z0-9-]+\\.cloudflareaccess\\.com$" $teamDomain) }}
+{{- fail "application.cloudflareAccess.teamDomain must be an https://<team>.cloudflareaccess.com origin without a path" }}
+{{- end }}
+{{- if not (regexMatch "^[A-Za-z0-9_-]{20,}$" $audience) }}
+{{- fail "application.cloudflareAccess.audience must be a Cloudflare Access AUD tag" }}
+{{- end }}
+{{- if ne $allowedEmail "cesar@cegarza.com" }}
+{{- fail "application.cloudflareAccess.allowedEmail must remain cesar@cegarza.com" }}
+{{- end }}
+{{- end }}
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.application.configMapName }}
+  labels:
+    {{- include "poetry.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.application.configData }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if .Values.application.cloudflareAccess.enabled }}
+  CLOUDFLARE_ACCESS_TEAM_DOMAIN: {{ .Values.application.cloudflareAccess.teamDomain | quote }}
+  CLOUDFLARE_ACCESS_AUD: {{ .Values.application.cloudflareAccess.audience | quote }}
+  CLOUDFLARE_ACCESS_ALLOWED_EMAIL: {{ .Values.application.cloudflareAccess.allowedEmail | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/poetry/templates/deployment.yaml
+++ b/helm/poetry/templates/deployment.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "poetry.fullname" . }}
+  labels:
+    {{- include "poetry.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  progressDeadlineSeconds: {{ .Values.deployment.progressDeadlineSeconds }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "poetry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "poetry.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "poetry.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ include "poetry.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: {{ .Values.application.workingDirectory }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - {{ .Values.application.command | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            {{- include "poetry.envFrom" . | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+              httpHeaders:
+                {{- toYaml .Values.probes.httpHeaders | nindent 16 }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+              httpHeaders:
+                {{- toYaml .Values.probes.httpHeaders | nindent 16 }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+              httpHeaders:
+                {{- toYaml .Values.probes.httpHeaders | nindent 16 }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmp.sizeLimit }}
+{{- end }}

--- a/helm/poetry/templates/ingress.yaml
+++ b/helm/poetry/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.enabled .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "poetry.fullname" . }}
+  labels:
+    {{- include "poetry.labels" . | nindent 4 }}
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ .Values.ingress.cloudflareProxied | quote }}
+    {{- if .Values.ingress.tls.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "poetry.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/helm/poetry/templates/ingress.yaml
+++ b/helm/poetry/templates/ingress.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.enabled .Values.ingress.enabled (eq .Values.ingress.cloudflareProxied "true") (not .Values.application.cloudflareAccess.enabled) }}
+{{- fail "Cloudflare proxying requires application.cloudflareAccess.enabled=true for origin JWT validation" }}
+{{- end }}
 {{- if and .Values.enabled .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/helm/poetry/templates/migrations-job.yaml
+++ b/helm/poetry/templates/migrations-job.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.enabled .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "poetry.fullname" . }}-migrate
+  labels:
+    {{- include "poetry.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrations
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "poetry.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrations
+    spec:
+      {{- include "poetry.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: {{ include "poetry.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: {{ .Values.application.workingDirectory }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - {{ .Values.migrations.command | quote }}
+          envFrom:
+            {{- include "poetry.envFrom" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmp.sizeLimit }}
+{{- end }}

--- a/helm/poetry/templates/service.yaml
+++ b/helm/poetry/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "poetry.fullname" . }}
+  labels:
+    {{- include "poetry.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "poetry.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/helm/poetry/values-ci.yaml
+++ b/helm/poetry/values-ci.yaml
@@ -1,0 +1,12 @@
+# Render all resources in CI without changing the disabled production default.
+enabled: true
+
+application:
+  cloudflareAccess:
+    enabled: true
+    teamDomain: https://poetry-ci.cloudflareaccess.com
+    audience: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    allowedEmail: cesar@cegarza.com
+
+ingress:
+  enabled: true

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -1,0 +1,139 @@
+# The application is introduced inertly. A later, reviewed activation change must
+# provision encrypted secrets, pin a published image, and set enabled to true.
+enabled: false
+
+replicaCount: 1
+
+image:
+  repository: registry.digitalocean.com/sendouq/poetry
+  # Bot-owned path. The source repository updates this exact key after publishing.
+  tag: sha-0000000000000000000000000000000000000000
+  # Optional digest pin. When set, it takes precedence over tag.
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets:
+  - regcred
+
+nameOverride: ""
+fullnameOverride: ""
+
+application:
+  workingDirectory: /app
+  command: >-
+    exec gunicorn poetry_site.wsgi:application --bind 0.0.0.0:8000 --workers 2
+    --timeout 120 --access-logfile - --error-logfile -
+  configMapName: poetry-config
+  secretRefs:
+    - poetry-database
+    - poetry-django
+    - poetry-media
+  configData:
+    DJANGO_DEBUG: "false"
+    DJANGO_ALLOWED_HOSTS: poetry.cegarza.com
+    DJANGO_CSRF_TRUSTED_ORIGINS: https://poetry.cegarza.com
+    WAGTAILADMIN_BASE_URL: https://poetry.cegarza.com
+    SITE_HOSTNAME: poetry.cegarza.com
+    DATABASE_SSL_REQUIRE: "true"
+    AWS_STORAGE_BUCKET_NAME: cegarza-poetry-media
+    AWS_S3_REGION_NAME: nyc3
+    AWS_S3_ENDPOINT_URL: https://nyc3.digitaloceanspaces.com
+    AWS_S3_CUSTOM_DOMAIN: cegarza-poetry-media.nyc3.cdn.digitaloceanspaces.com
+    TMPDIR: /tmp
+  # Disabled until the Cloudflare Access application exists. When enabled, the
+  # Django origin validates the signed Access JWT on /admin and /admin/* so a
+  # direct request to the load-balancer cannot bypass the edge policy.
+  cloudflareAccess:
+    enabled: false
+    teamDomain: ""
+    audience: ""
+    allowedEmail: cesar@cegarza.com
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+
+deployment:
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 600
+  terminationGracePeriodSeconds: 30
+
+migrations:
+  enabled: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  command: >-
+    python manage.py migrate --noinput && python manage.py bootstrap_site --hostname
+    poetry.cegarza.com
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+podSecurityContext:
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+  capabilities:
+    drop:
+      - ALL
+
+tmp:
+  sizeLimit: 128Mi
+
+probes:
+  httpHeaders:
+    - name: Host
+      value: poetry.cegarza.com
+    - name: X-Forwarded-Proto
+      value: https
+  startup:
+    path: /healthz
+    periodSeconds: 2
+    timeoutSeconds: 2
+    failureThreshold: 30
+  liveness:
+    path: /healthz
+    periodSeconds: 30
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    path: /readyz
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+ingress:
+  enabled: false
+  className: nginx
+  host: poetry.cegarza.com
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  cloudflareProxied: "false"
+  tls:
+    enabled: true
+    clusterIssuer: letsencrypt-prod
+    secretName: poetry-cegarza-com-tls
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Semantic CI assertions for the inert Poetry GitOps substrate."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+EXPECTED_SECRETS = ["poetry-database", "poetry-django", "poetry-media"]
+EXPECTED_HEADERS = {
+    "Host": "poetry.cegarza.com",
+    "X-Forwarded-Proto": "https",
+}
+IMAGE_PATTERN = re.compile(
+    r"^registry\.digitalocean\.com/sendouq/poetry(?:"
+    r":sha-[a-f0-9]{40}|@sha256:[a-f0-9]{64})$"
+)
+
+
+def _load_one(path: Path) -> dict[str, Any]:
+    loaded = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"expected a YAML mapping in {path}")
+    return loaded
+
+
+def _load_all(path: Path) -> list[dict[str, Any]]:
+    return [
+        document
+        for document in YAML_PARSER.load_all(path.read_text(encoding="utf-8"))
+        if isinstance(document, dict) and document
+    ]
+
+
+def _find(docs: Iterable[dict[str, Any]], kind: str, name: str) -> dict[str, Any]:
+    for document in docs:
+        if document.get("kind") == kind and document.get("metadata", {}).get("name") == name:
+            return document
+    raise AssertionError(f"missing {kind}/{name}")
+
+
+def _assert_no_key(value: Any, forbidden_key: str) -> None:
+    if isinstance(value, dict):
+        if forbidden_key in value:
+            raise AssertionError(f"render contains forbidden key {forbidden_key!r}")
+        for nested in value.values():
+            _assert_no_key(nested, forbidden_key)
+    elif isinstance(value, list):
+        for nested in value:
+            _assert_no_key(nested, forbidden_key)
+
+
+def _assert_application(
+    path: Path, *, name: str, wave: str, source_path: str
+) -> None:
+    application = _load_one(path)
+    assert application["kind"] == "Application"
+    assert application["metadata"]["name"] == name
+    assert application["metadata"]["namespace"] == "argocd"
+    assert application["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == wave
+    assert application["spec"]["source"]["path"] == source_path
+    assert application["spec"]["destination"] == {
+        "server": "https://kubernetes.default.svc",
+        "namespace": "poetry",
+    }
+    assert application["spec"]["syncPolicy"]["automated"] == {
+        "prune": True,
+        "selfHeal": True,
+    }
+    assert "CreateNamespace=true" in application["spec"]["syncPolicy"]["syncOptions"]
+
+
+def check(default_render: Path, enabled_render: Path) -> None:
+    values = _load_one(REPO_ROOT / "helm" / "poetry" / "values.yaml")
+    assert values["enabled"] is False
+    assert values["replicaCount"] == 1
+    assert values["ingress"]["enabled"] is False
+    assert values["ingress"]["cloudflareProxied"] == "false"
+    assert values["application"]["cloudflareAccess"] == {
+        "enabled": False,
+        "teamDomain": "",
+        "audience": "",
+        "allowedEmail": "cesar@cegarza.com",
+    }
+    assert re.fullmatch(r"sha-[a-f0-9]{40}", values["image"]["tag"])
+
+    assert _load_all(default_render) == [], "disabled values must render no resources"
+    docs = _load_all(enabled_render)
+    assert [document["kind"] for document in docs] == [
+        "ConfigMap",
+        "Service",
+        "Deployment",
+        "Job",
+        "Ingress",
+    ]
+    assert all(document["kind"] != "PersistentVolumeClaim" for document in docs)
+    _assert_no_key(docs, "persistentVolumeClaim")
+
+    deployment = _find(docs, "Deployment", "poetry")
+    assert deployment["spec"]["replicas"] == 1
+    config_checksum = deployment["spec"]["template"]["metadata"]["annotations"][
+        "checksum/config"
+    ]
+    assert re.fullmatch(r"[a-f0-9]{64}", config_checksum)
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["imagePullSecrets"] == [{"name": "regcred"}]
+    assert pod_spec["automountServiceAccountToken"] is False
+    assert pod_spec["volumes"] == [{"name": "tmp", "emptyDir": {"sizeLimit": "128Mi"}}]
+    container = pod_spec["containers"][0]
+    assert IMAGE_PATTERN.fullmatch(container["image"])
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    assert container["volumeMounts"] == [{"name": "tmp", "mountPath": "/tmp"}]
+    assert [
+        source["secretRef"]["name"]
+        for source in container["envFrom"]
+        if "secretRef" in source
+    ] == EXPECTED_SECRETS
+
+    config_map = _find(docs, "ConfigMap", "poetry-config")
+    assert config_map["data"]["CLOUDFLARE_ACCESS_TEAM_DOMAIN"] == (
+        "https://poetry-ci.cloudflareaccess.com"
+    )
+    assert config_map["data"]["CLOUDFLARE_ACCESS_AUD"] == (
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    )
+    assert config_map["data"]["CLOUDFLARE_ACCESS_ALLOWED_EMAIL"] == (
+        "cesar@cegarza.com"
+    )
+
+    for probe_name, expected_path in (
+        ("startupProbe", "/healthz"),
+        ("livenessProbe", "/healthz"),
+        ("readinessProbe", "/readyz"),
+    ):
+        http_get = container[probe_name]["httpGet"]
+        assert http_get["path"] == expected_path
+        assert http_get["port"] == "http"
+        rendered_headers = {
+            header["name"]: header["value"] for header in http_get["httpHeaders"]
+        }
+        assert rendered_headers == EXPECTED_HEADERS
+
+    job = _find(docs, "Job", "poetry-migrate")
+    assert job["metadata"]["annotations"]["argocd.argoproj.io/hook"] == "PreSync"
+    job_pod_spec = job["spec"]["template"]["spec"]
+    assert job_pod_spec["imagePullSecrets"] == [{"name": "regcred"}]
+    job_container = job_pod_spec["containers"][0]
+    assert IMAGE_PATTERN.fullmatch(job_container["image"])
+    assert [
+        source["secretRef"]["name"]
+        for source in job_container["envFrom"]
+        if "secretRef" in source
+    ] == EXPECTED_SECRETS
+
+    ingress = _find(docs, "Ingress", "poetry")
+    ingress_spec = ingress["spec"]
+    assert ingress_spec["ingressClassName"] == "nginx"
+    assert ingress_spec["rules"][0]["host"] == "poetry.cegarza.com"
+    assert ingress_spec["tls"] == [
+        {
+            "hosts": ["poetry.cegarza.com"],
+            "secretName": "poetry-cegarza-com-tls",
+        }
+    ]
+    annotations = ingress["metadata"]["annotations"]
+    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "false"
+    assert annotations["cert-manager.io/cluster-issuer"] == "letsencrypt-prod"
+    assert "nginx.ingress.kubernetes.io/whitelist-source-range" not in annotations
+
+    _assert_application(
+        REPO_ROOT / "argocd" / "applications" / "poetry.yaml",
+        name="poetry",
+        wave="10",
+        source_path="helm/poetry",
+    )
+    poetry_application = _load_one(
+        REPO_ROOT / "argocd" / "applications" / "poetry.yaml"
+    )
+    assert poetry_application["spec"]["source"]["helm"]["valueFiles"] == [
+        "values.yaml"
+    ]
+    _assert_application(
+        REPO_ROOT / "argocd" / "applications" / "poetry-secrets.yaml",
+        name="poetry-secrets",
+        wave="-10",
+        source_path="secrets/poetry",
+    )
+    project = _load_one(REPO_ROOT / "argocd" / "projects" / "splattop-project.yaml")
+    assert {
+        "namespace": "poetry",
+        "server": "https://kubernetes.default.svc",
+    } in project["spec"]["destinations"]
+    secret_kustomization = _load_one(
+        REPO_ROOT / "secrets" / "poetry" / "kustomization.yaml"
+    )
+    assert secret_kustomization["namespace"] == "poetry"
+    assert secret_kustomization["resources"] == []
+
+    rollout_notes = (REPO_ROOT / "helm" / "poetry" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    for required_text in (
+        "waves order Application reconciliation only",
+        "Synced` and `Healthy",
+        "Let's Encrypt HTTP-01 issuance",
+        "Access-signed RS256 JWT",
+        "does not interfere with HTTP-01 certificate renewal",
+        "same GitOps revision restarts the Deployment",
+    ):
+        assert required_text in rollout_notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--default-render", type=Path, required=True)
+    parser.add_argument("--enabled-render", type=Path, required=True)
+    args = parser.parse_args()
+    check(args.default_render, args.enabled_render)
+    print("poetry substrate semantic checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -124,6 +124,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     ] == EXPECTED_SECRETS
 
     config_map = _find(docs, "ConfigMap", "poetry-config")
+    assert config_map["data"]["CLOUDFLARE_ACCESS_REQUIRED"] == "true"
     assert config_map["data"]["CLOUDFLARE_ACCESS_TEAM_DOMAIN"] == (
         "https://poetry-ci.cloudflareaccess.com"
     )

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -213,6 +213,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         "Access-signed RS256 JWT",
         "does not interfere with HTTP-01 certificate renewal",
         "same GitOps revision restarts the Deployment",
+        "refuses to render a proxied Ingress",
     ):
         assert required_text in rollout_notes
 

--- a/secrets/poetry/README.md
+++ b/secrets/poetry/README.md
@@ -1,0 +1,15 @@
+# Poetry secret activation
+
+This directory is intentionally inert. Before setting `helm/poetry/values.yaml`
+`enabled: true`, create and SOPS-encrypt the following Kubernetes Secrets with
+the repository age recipient, list the encrypted files in `ksops.yaml`, and
+enable the generator in `kustomization.yaml`:
+
+- `poetry-database`: `DATABASE_URL`
+- `poetry-django`: `DJANGO_SECRET_KEY`
+- `poetry-media`: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- `regcred` (`kubernetes.io/dockerconfigjson`): `.dockerconfigjson`
+
+Do not commit unencrypted Secret manifests or placeholder credentials. Validate
+the completed directory with the Argo CD KSOPS/kustomize build before enabling
+the chart.

--- a/secrets/poetry/ksops.yaml
+++ b/secrets/poetry/ksops.yaml
@@ -1,0 +1,7 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: poetry-secrets
+# Add only SOPS-encrypted manifests here, then enable this generator from
+# kustomization.yaml in the same reviewed change.
+files: []

--- a/secrets/poetry/kustomization.yaml
+++ b/secrets/poetry/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: poetry
+# Intentionally empty until the activation slice adds SOPS-encrypted Secret
+# manifests to ksops.yaml and enables the generator below.
+resources: []
+# generators:
+#   - ksops.yaml


### PR DESCRIPTION
## Summary

- add a dedicated `poetry` Argo destination and disabled-by-default Helm chart
- add inert `-10` secrets and `+10` workload Applications
- enforce immutable image references, one non-root replica, read-only root filesystem, explicit `/tmp`, no PVC or service-account token, and PreSync migrations
- add nginx/Let's Encrypt ingress staging with Cloudflare proxying off by default
- add fail-closed, disabled signed Cloudflare Access JWT origin-validation configuration for `/admin`
- add SOPS/KSOPS scaffolding without any plaintext or ciphertext Secret values

## Verification

- Helm lint; disabled render is empty
- enabled CI render: ConfigMap, Service, Deployment, PreSync Job, Ingress
- strict kubeconform: 5/5 valid
- semantic assertions for namespace, waves, immutable image, Secrets, probes/headers, no PVC, ingress/TLS/proxy state, Access config, and config rollout checksum
- five fail-closed Cloudflare Access configuration cases
- Kustomize/KSOPS inert scaffold
- repository suite: 136 passed before final Access-only template revision
- independent security review: no blocking findings after two remediation rounds

This PR is intentionally merge-safe and inert. Activation requires separately reviewed SOPS ciphertext Secrets, a real `sha-<commit>` image pin, internal Service/health verification, TLS issuance, Cloudflare Access plus origin JWT proof, and only then proxying.
