### PR TITLE
Add encrypted Poetry runtime secrets

### DIFF
--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -14,6 +14,21 @@ from ruamel.yaml import YAML
 REPO_ROOT = Path(__file__).resolve().parents[1]
 YAML_PARSER = YAML(typ="safe")
 EXPECTED_SECRETS = ["poetry-database", "poetry-django", "poetry-media"]
+AGE_RECIPIENT = "age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt"
+EXPECTED_SECRET_FILES = {
+    "database.enc.yaml": ("poetry-database", "Opaque", {"DATABASE_URL"}),
+    "django.enc.yaml": ("poetry-django", "Opaque", {"DJANGO_SECRET_KEY"}),
+    "media.enc.yaml": (
+        "poetry-media",
+        "Opaque",
+        {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"},
+    ),
+    "regcred.enc.yaml": (
+        "regcred",
+        "kubernetes.io/dockerconfigjson",
+        {".dockerconfigjson"},
+    ),
+}
 EXPECTED_HEADERS = {
     "Host": "poetry.cegarza.com",
     "X-Forwarded-Proto": "https",
@@ -41,7 +56,10 @@ def _load_all(path: Path) -> list[dict[str, Any]]:
 
 def _find(docs: Iterable[dict[str, Any]], kind: str, name: str) -> dict[str, Any]:
     for document in docs:
-        if document.get("kind") == kind and document.get("metadata", {}).get("name") == name:
+        if (
+            document.get("kind") == kind
+            and document.get("metadata", {}).get("name") == name
+        ):
             return document
     raise AssertionError(f"missing {kind}/{name}")
 
@@ -57,14 +75,14 @@ def _assert_no_key(value: Any, forbidden_key: str) -> None:
             _assert_no_key(nested, forbidden_key)
 
 
-def _assert_application(
-    path: Path, *, name: str, wave: str, source_path: str
-) -> None:
+def _assert_application(path: Path, *, name: str, wave: str, source_path: str) -> None:
     application = _load_one(path)
     assert application["kind"] == "Application"
     assert application["metadata"]["name"] == name
     assert application["metadata"]["namespace"] == "argocd"
-    assert application["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == wave
+    assert (
+        application["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == wave
+    )
     assert application["spec"]["source"]["path"] == source_path
     assert application["spec"]["destination"] == {
         "server": "https://kubernetes.default.svc",
@@ -75,6 +93,25 @@ def _assert_application(
         "selfHeal": True,
     }
     assert "CreateNamespace=true" in application["spec"]["syncPolicy"]["syncOptions"]
+
+
+def _assert_encrypted_secret(
+    path: Path, *, name: str, secret_type: str, data_keys: set[str]
+) -> None:
+    secret = _load_one(path)
+    assert secret["apiVersion"] == "v1"
+    assert secret["kind"] == "Secret"
+    assert secret["metadata"] == {"name": name, "namespace": "poetry"}
+    assert secret["type"] == secret_type
+    assert "data" not in secret
+    assert set(secret["stringData"]) == data_keys
+    assert all(
+        isinstance(value, str) and value.startswith("ENC[AES256_GCM,")
+        for value in secret["stringData"].values()
+    )
+    sops = secret["sops"]
+    assert sops["encrypted_regex"] == "^(data|stringData)$"
+    assert {entry["recipient"] for entry in sops["age"]} == {AGE_RECIPIENT}
 
 
 def check(default_render: Path, enabled_render: Path) -> None:
@@ -184,9 +221,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     poetry_application = _load_one(
         REPO_ROOT / "argocd" / "applications" / "poetry.yaml"
     )
-    assert poetry_application["spec"]["source"]["helm"]["valueFiles"] == [
-        "values.yaml"
-    ]
+    assert poetry_application["spec"]["source"]["helm"]["valueFiles"] == ["values.yaml"]
     _assert_application(
         REPO_ROOT / "argocd" / "applications" / "poetry-secrets.yaml",
         name="poetry-secrets",
@@ -203,6 +238,19 @@ def check(default_render: Path, enabled_render: Path) -> None:
     )
     assert secret_kustomization["namespace"] == "poetry"
     assert secret_kustomization["resources"] == []
+    assert secret_kustomization["generators"] == ["ksops.yaml"]
+    secret_ksops = _load_one(REPO_ROOT / "secrets" / "poetry" / "ksops.yaml")
+    assert secret_ksops["apiVersion"] == "viaduct.ai/v1"
+    assert secret_ksops["kind"] == "ksops"
+    assert secret_ksops["metadata"]["name"] == "poetry-secrets"
+    assert secret_ksops["files"] == list(EXPECTED_SECRET_FILES)
+    for filename, (name, secret_type, data_keys) in EXPECTED_SECRET_FILES.items():
+        _assert_encrypted_secret(
+            REPO_ROOT / "secrets" / "poetry" / filename,
+            name=name,
+            secret_type=secret_type,
+            data_keys=data_keys,
+        )
 
     rollout_notes = (REPO_ROOT / "helm" / "poetry" / "README.md").read_text(
         encoding="utf-8"

--- a/secrets/poetry/README.md
+++ b/secrets/poetry/README.md
@@ -1,15 +1,14 @@
 # Poetry secret activation
 
-This directory is intentionally inert. Before setting `helm/poetry/values.yaml`
-`enabled: true`, create and SOPS-encrypt the following Kubernetes Secrets with
-the repository age recipient, list the encrypted files in `ksops.yaml`, and
-enable the generator in `kustomization.yaml`:
+This directory contains the SOPS-encrypted runtime Secrets required before
+setting `helm/poetry/values.yaml` `enabled: true`:
 
 - `poetry-database`: `DATABASE_URL`
 - `poetry-django`: `DJANGO_SECRET_KEY`
 - `poetry-media`: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
-- `regcred` (`kubernetes.io/dockerconfigjson`): `.dockerconfigjson`
+- `regcred` (`kubernetes.io/dockerconfigjson`): namespace-local, read-only
+  `.dockerconfigjson`
 
-Do not commit unencrypted Secret manifests or placeholder credentials. Validate
-the completed directory with the Argo CD KSOPS/kustomize build before enabling
-the chart.
+Only ciphertext belongs here. Validate the directory with the Argo CD
+KSOPS/kustomize build and confirm the `poetry-secrets` Application is Synced and
+Healthy before enabling the chart.

--- a/secrets/poetry/database.enc.yaml
+++ b/secrets/poetry/database.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: poetry-database
+    namespace: poetry
+type: Opaque
+stringData:
+    DATABASE_URL: ENC[AES256_GCM,data:GbTsTbDhJq1BpXzgI5iHU4rPs+xRuFrV4FhGG97uJMkVCfTwHboerbVE3+iOlqYrKnaiQuiRnGTYt3QhbM95ZCRgWOv3OtM8rTk7zOWEH9D8UR5JIDkYqlQnXLqYzZlhUSmg8OZPNegSepyV7ZlLVCJoxOHiaPRmxlqNbZ4ehmsS78cMF9/+/IcWp4Yv/9DOAUv0sSVb3fNPd+VSjQ==,iv:SWWfP4mgSk8o8wcazus7jHZOn78cviKuplaRYdWZzbo=,tag:kUulpcdq5pO6SNgCNxNgrg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDTWJiZVBqRHd5QmZycGc0
+            V0hsU3JmclMrTFBhVGoyanhjN2x4d1NlUEI4Ck1BTGJyNm1KVityMXVmOXpmOXpE
+            dHR1SHgzZmdINFVNekNEa1pDbDNTTVUKLS0tIGtlcjAwNTc4WTUzU0F0Mk1EeEVp
+            dHcrWHpIVUdYQ09yQW45MHlrVWVlNm8K89FAtu1Qjl+8I4ElSGSC9HpBQLpUBo99
+            +/gn7LWvRoMkuDAdRFlvPN762FKryFGfIo7S/PEroQXcr4hz1cIfeA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-22T00:50:54Z"
+    mac: ENC[AES256_GCM,data:V7r9OaBgptWwe6epXeh4lqmHYKVTqOWrvppLtGpZOWmwtHMQGkLTYG0nYCRBzjWt5B/p9h3LHlvEPaS1GxINveOGmSpZcMzloUhvlowfoyyvXv2ngVsULfl1jS4kf7qH8XBlb82ucoYvsY2IgSpEb2VHRtN5/FHlFl979RONAK8=,iv:QZ6NdYe3yJVX+Ffza7nIYSkNcvIXySApjjixYrGzamg=,tag:j0YnCe7miLlk/VQJ0Dubog==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/poetry/django.enc.yaml
+++ b/secrets/poetry/django.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: poetry-django
+    namespace: poetry
+type: Opaque
+stringData:
+    DJANGO_SECRET_KEY: ENC[AES256_GCM,data:ftoZNxOCdPrDxGr26JhSZ5KGdJoFFyQosuXcz/7BzEhbn/7DzrDPIH/5fNPl5QaPczNeeJooHKvAiu/3TcCvug/SOV0ig48WH7XZVMp8eJTMmH1GBFg=,iv:cmgm0cY+SleTJbjOgvrdS7jkS6z+nHzBisJ3fXFgRiI=,tag:8cKsMFAWTGvV0JNZfWgMRQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFdFRBUXFWT0JnRDdhUWY3
+            cjlvMWEzOGREUHVBSTMxRm1qcy84a1AvbkZFCllGZTJjSHFTeUVjZnlzS2FtV3cr
+            OEZtclE1aHFKNkJXSzh0YkN1NnFtc1kKLS0tIE9MWTBUZ2lWdmhxN09NUHJGbkQv
+            RW41cXBpd3dzdEdFNFpHaVBGQUpkU3MK932oojFcs7auZ6JO8AgcDiyw0nqw/Gvm
+            Og5nT4HX8ZT46Nd0ioA5LcvEqdpmva4fH8H1Bl23zal0kyXYaYZfDg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-22T00:50:54Z"
+    mac: ENC[AES256_GCM,data:yL1dQ16UPD4MjVlv0uLzP/h/hgpEDKeI/4bk98Ip+RBzxz3Sl6L9TDpkX6tbxPtCb+27xd27iuodPv/OU8qO1vWiRnpkGKI24YSY9bdex2Sy4j167K+0g9RZoFeT712TngXMdl8N2om4DfA+eoV5Ab6mejva/qnxTA3JEG5P7WI=,iv:LKS+TFaS2bWsvNDY0yYAgkax5BC0NyvugD/mzgAUAEE=,tag:iiiLGD+dPCIwkdEEZQwbOw==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/poetry/ksops.yaml
+++ b/secrets/poetry/ksops.yaml
@@ -2,6 +2,8 @@ apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:
   name: poetry-secrets
-# Add only SOPS-encrypted manifests here, then enable this generator from
-# kustomization.yaml in the same reviewed change.
-files: []
+files:
+  - database.enc.yaml
+  - django.enc.yaml
+  - media.enc.yaml
+  - regcred.enc.yaml

--- a/secrets/poetry/kustomization.yaml
+++ b/secrets/poetry/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: poetry
-# Intentionally empty until the activation slice adds SOPS-encrypted Secret
-# manifests to ksops.yaml and enables the generator below.
 resources: []
-# generators:
-#   - ksops.yaml
+generators:
+  - ksops.yaml

--- a/secrets/poetry/media.enc.yaml
+++ b/secrets/poetry/media.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: poetry-media
+    namespace: poetry
+type: Opaque
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:JSxejybglygH5WXfIAeSWCSHujA=,iv:vYrlAgG054Sqmd+XB9CRdRun/EXiOJ3N1Zv0kB1sd7w=,tag:PZy2a7oRizxqpKS58bvdXg==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:TB468G7zzC6vy/kHpkij3unN1Dk23TAn/ewCfJflqCSG4qBROGXZWAVORA==,iv:ZRq3Ua0pwJmJY09zWbg63EKIxyP+DXBrMCxG4HAeyrs=,tag:E927IspOhQEpEmkBp4BK1w==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2RjdEQlhVRWZXT0llUVdS
+            enJTU1Nob1VlK1NNZ21UWXF1MTRGUWxSLzBBCmUxR0NpQUlGKzVVWFlEblBoVklP
+            b1B0b1RTcEhZV0VkQkRlemVlQXBsRk0KLS0tIEFIUmdJb1B6UUNBZitXSitKZmZW
+            dklBVEV1dS85ZEFEVDRCZXpQeVZtdjAKE4OauriFfOp+AfBZwlvAhm00PExUGlJr
+            zzEwJfZ1nJq4S59lwH9F9LOKO0TNjMqBWHKLd99vZWS4i3qSdV4DrQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-22T00:50:54Z"
+    mac: ENC[AES256_GCM,data:KNQL4A7Z6NFxjEHP4MCJvYsPlHq8Xel52W22v/loylBhnsLGzVlrDqUF0yiCw8ERTRjQ5HyX7Ghg9XDULBuZ3Fwm/FLdEFEhpvmclvalXjET6owwFypcUeBcOiory9Dglx5MrJjJQguVZ/MTOI67EoL4QFvKuIZzIdB3CRl3dK0=,iv:V/PO2Z93uS1sUdRtgmIqS5JmCSJEY35bBtPr/O3yGVU=,tag:K2L2z5o0nKUkZSglQYX/UQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/poetry/regcred.enc.yaml
+++ b/secrets/poetry/regcred.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: regcred
+    namespace: poetry
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:4G3cbRvc5z9UCSiiJvzZVE/ljgGtTLvu16w5xcIqJ0oaS/hD+vT1oDLC0OHCxmThgNDyCF2Fv2Z+oGC4C+qSP3JSCxZ54iT0q0uk6kxd8TdbDfMXR6GnI/uHACylB69EYAqmQ3y+olxwegpdS3ODQoRT73JSWP4CRY1xYcj5K1IQCCBMFWzQimEhWcr0qu6XTmE3hNb08/xjKM+8HqCVg5W66ZDKd08CbS+lp9IHsAlgIFgus4K3,iv:ScmSrAhJFdJq4yfUrrBzDMIZCP/60JxVxQZUJ9ba94s=,tag:dzfiviiZxFBnpvmLj2WRpw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16yxsawhpecdrhas2q3z246q3tjq8889m552lqhjcgf8jnt7naszqqgz8vt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFR0VVaDVaQlk2YXlNRDhl
+            TGZOMm8vMmZkd05qZjNlRE5zNGhNN05MYWpRCkdBWDE1M0dLOEptQXNqc1crQnMr
+            QnFPS1A3VlFLelpqY1F3QUdybTduZjQKLS0tIENPcVRqUzFDeG5ZRlV3NGFQNU9V
+            SG4wZHg3bGdMNUJoRkdLalZlOGJHdUkKn2nUvg7uQDXJbIcFzb1s0fRORbyDPHjC
+            kY9NbXN572bE4LyqMhsoVJVtKrjmZVhQLsBwSI/pjtWkJlzd3aTPhw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-22T00:50:54Z"
+    mac: ENC[AES256_GCM,data:A8YNVCWEFm0Nbo435qfZ+/FXOpZhwNTmmIZ1fHmxugF7YMaVagBwZGDJ1hkI9uUpmMkwWrG6oVGL+XsWtU7eH8wCS4HgYOOWlemGdCtNcplJJR/RwBRawdTDISpeYxW5p6njl7j1Y8jA1CGk//WzztThD5wiEq3QJzz0MNS6sD0=,iv:kBpdUz5O0gFzV6/4fPdSRC+/dgeUEdPkuKm3V4vBULI=,tag:pnlvEIorTeRlPnjHwh5v7Q==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1


### PR DESCRIPTION
## Scope

Adds only the four SOPS/age-encrypted runtime Secrets required by the disabled Poetry substrate and wires the existing `poetry-secrets` KSOPS generator:

- `poetry-database`
- `poetry-django`
- `poetry-media`
- namespace-local read-only `regcred`

This PR does **not** enable the Poetry chart, create a Deployment/Service/Ingress, or change DNS. The disabled chart continues to render zero resources. Merging does apply the four Secrets through the existing auto-synced `poetry-secrets` Argo Application.

## Provider scope

- The Spaces runtime key is scoped exactly to `cegarza-poetry-media:readwrite`.
- The temporary account-wide bootstrap key was revoked before the runtime key was created.
- The registry Docker config was minted without `--read-write` and contains only `registry.digitalocean.com`.

## Verification

- Independent security review: CLEAN.
- Independent CI-parity review: CLEAN.
- Python 3.11.13 / uv 0.8.17: locked sync, ownership check, 162/162 tests, release-pin check.
- Helm 3.14.0: seven-chart lint/render matrix passed; Poetry disabled render 0 resources, enabled render 5.
- Poetry semantic checker and six fail-closed render tests passed.
- kubeconform 0.6.7 strict validation passed; Poetry 5/5.
- Plaintext gate including new files passed; `git diff --check` passed.

## Post-merge gate

The private age key is intentionally unavailable locally. Before any workload activation, require `poetry-secrets` to become Synced/Healthy at the merge revision and verify exactly the four expected namespace Secrets exist while the Poetry workload remains absent.

## Release train

Broker policy and inert substrate are already live. Merge this ciphertext-only slice before the Poetry source PR; then publish/pin the immutable image and activate the workload in a separate PR.