### PR TITLE
Activate the private Poetry runtime

### DIFF
--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,8 +1,9 @@
 # Poetry chart rollout stages
 
-`values.yaml` is intentionally inert: both `enabled` and `ingress.enabled` are
-false. `values-ci.yaml` exists only to exercise every template in CI and must not
-be added to the Argo CD Application.
+`values.yaml` enables the private, ingress-free runtime: `enabled` is true while
+`ingress.enabled` remains false. `values-ci.yaml` exists only to exercise the
+later public-launch Access and Ingress variant in CI and must not be added to the
+Argo CD Application.
 
 Activate in reviewed stages:
 

--- a/helm/poetry/templates/_helpers.tpl
+++ b/helm/poetry/templates/_helpers.tpl
@@ -57,6 +57,32 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{/* Secret-only environment sources for PreSync hooks. */}}
+{{- define "poetry.secretEnvFrom" -}}
+{{- range .Values.application.secretRefs }}
+- secretRef:
+    name: {{ . }}
+{{- end }}
+{{- end }}
+
+{{/* Non-secret runtime configuration for PreSync hooks. */}}
+{{- define "poetry.runtimeEnv" -}}
+{{- range $key, $value := .Values.application.configData }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+- name: CLOUDFLARE_ACCESS_REQUIRED
+  value: {{ ternary "true" "false" .Values.application.cloudflareAccess.enabled | quote }}
+{{- if .Values.application.cloudflareAccess.enabled }}
+- name: CLOUDFLARE_ACCESS_TEAM_DOMAIN
+  value: {{ .Values.application.cloudflareAccess.teamDomain | quote }}
+- name: CLOUDFLARE_ACCESS_AUD
+  value: {{ .Values.application.cloudflareAccess.audience | quote }}
+- name: CLOUDFLARE_ACCESS_ALLOWED_EMAIL
+  value: {{ .Values.application.cloudflareAccess.allowedEmail | quote }}
+{{- end }}
+{{- end }}
+
 {{/* Shared image pull secrets. */}}
 {{- define "poetry.imagePullSecrets" -}}
 {{- with .Values.imagePullSecrets }}

--- a/helm/poetry/templates/migrations-job.yaml
+++ b/helm/poetry/templates/migrations-job.yaml
@@ -34,8 +34,10 @@ spec:
             - -c
           args:
             - {{ .Values.migrations.command | quote }}
+          env:
+            {{- include "poetry.runtimeEnv" . | nindent 12 }}
           envFrom:
-            {{- include "poetry.envFrom" . | nindent 12 }}
+            {{- include "poetry.secretEnvFrom" . | nindent 12 }}
           resources:
             {{- toYaml .Values.migrations.resources | nindent 12 }}
           securityContext:

--- a/helm/poetry/values-ci.yaml
+++ b/helm/poetry/values-ci.yaml
@@ -1,4 +1,4 @@
-# Render all resources in CI without changing the disabled production default.
+# Render the public-launch Access and Ingress variant in CI.
 enabled: true
 
 application:

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -1,6 +1,6 @@
-# The application is introduced inertly. A later, reviewed activation change must
-# provision encrypted secrets, pin a published image, and set enabled to true.
-enabled: false
+# Runtime activation follows the live encrypted-secret and immutable-image gates.
+# Public ingress remains a separate, explicitly reviewed launch step.
+enabled: true
 
 replicaCount: 1
 

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Semantic CI assertions for the inert Poetry GitOps substrate."""
+"""Semantic CI assertions for the staged Poetry GitOps release."""
 
 from __future__ import annotations
 
@@ -116,7 +116,7 @@ def _assert_encrypted_secret(
 
 def check(default_render: Path, enabled_render: Path) -> None:
     values = _load_one(REPO_ROOT / "helm" / "poetry" / "values.yaml")
-    assert values["enabled"] is False
+    assert values["enabled"] is True
     assert values["replicaCount"] == 1
     assert values["ingress"]["enabled"] is False
     assert values["ingress"]["cloudflareProxied"] == "false"
@@ -128,7 +128,38 @@ def check(default_render: Path, enabled_render: Path) -> None:
     }
     assert re.fullmatch(r"sha-[a-f0-9]{40}", values["image"]["tag"])
 
-    assert _load_all(default_render) == [], "disabled values must render no resources"
+    runtime_docs = _load_all(default_render)
+    assert [document["kind"] for document in runtime_docs] == [
+        "ConfigMap",
+        "Service",
+        "Deployment",
+        "Job",
+    ]
+    assert all(document["kind"] != "Ingress" for document in runtime_docs)
+    assert all(document["kind"] != "PersistentVolumeClaim" for document in runtime_docs)
+    _assert_no_key(runtime_docs, "persistentVolumeClaim")
+    runtime_config = _find(runtime_docs, "ConfigMap", "poetry-config")
+    assert runtime_config["data"]["CLOUDFLARE_ACCESS_REQUIRED"] == "false"
+    runtime_service = _find(runtime_docs, "Service", "poetry")
+    assert runtime_service["spec"]["type"] == "ClusterIP"
+    runtime_deployment = _find(runtime_docs, "Deployment", "poetry")
+    assert (
+        runtime_deployment["spec"]["template"]["spec"]["containers"][0]["image"]
+        == f"{values['image']['repository']}:{values['image']['tag']}"
+    )
+    runtime_job = _find(runtime_docs, "Job", "poetry-migrate")
+    runtime_job_container = runtime_job["spec"]["template"]["spec"]["containers"][0]
+    assert {item["name"]: item["value"] for item in runtime_job_container["env"]} == {
+        **values["application"]["configData"],
+        "CLOUDFLARE_ACCESS_REQUIRED": "false",
+    }
+    assert all(
+        "configMapRef" not in source for source in runtime_job_container["envFrom"]
+    )
+    assert [
+        source["secretRef"]["name"] for source in runtime_job_container["envFrom"]
+    ] == EXPECTED_SECRETS
+
     docs = _load_all(enabled_render)
     assert [document["kind"] for document in docs] == [
         "ConfigMap",
@@ -191,6 +222,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert job_pod_spec["imagePullSecrets"] == [{"name": "regcred"}]
     job_container = job_pod_spec["containers"][0]
     assert IMAGE_PATTERN.fullmatch(job_container["image"])
+    assert all("configMapRef" not in source for source in job_container["envFrom"])
     assert [
         source["secretRef"]["name"]
         for source in job_container["envFrom"]


### PR DESCRIPTION
## Scope

Activates the Poetry chart with the already-live encrypted Secrets and immutable image while keeping every public edge component disabled:

- one non-root replica
- ClusterIP Service only
- PreSync migration/bootstrap Job
- no Ingress, public DNS, Cloudflare proxying, Access mode, PVC, or external IP

Pinned image: `registry.digitalocean.com/sendouq/poetry:sha-43ccbf5780e241f04c8c98398a636d8ca12a50cc`

Registry manifest digest: `sha256:26f52c2687f5f7d3ee2a04a656afc501e36fb2ace5b64b767bdef7949efa2439`

## PreSync ordering correction

Independent review found that the original PreSync Job referenced the Sync-phase `poetry-config` ConfigMap, which does not exist on first activation and would deadlock reconciliation. This slice removes that dependency: the Job now receives non-secret runtime configuration directly, explicitly sets `CLOUDFLARE_ACCESS_REQUIRED=false`, and references only the three already-live application Secrets. The Deployment continues to use the ConfigMap.

## Verification

- Two independent activation/security reviews: CLEAN after the ordering correction.
- Python 3.11.13: ownership, release-pin, and 162/162 tests passed.
- Helm 3.14.0: full seven-chart lint/render matrix passed.
- Default Poetry render: ConfigMap, ClusterIP Service, Deployment, PreSync Job.
- CI public variant: the same four resources plus Ingress.
- Semantic checker and all six fail-closed Access/proxy cases passed.
- kubeconform 0.6.7 strict: private 4/4, public variant 5/5; full matrix passed.
- no-latest, Ruff 0.15.14 lint/format, and `git diff --check` passed.

## Post-merge gates

- Watch the PreSync Job and capture its completion before hook cleanup.
- Require Argo Synced/Healthy at the exact merge revision.
- Require one Ready replica running the expected immutable image.
- Require a populated Service EndpointSlice and successful in-cluster `/healthz` and `/readyz` requests with the production Host/proto headers.
- Confirm no Ingress exists.