### PR TITLE
Allow external-dns to manage cegarza.com

### DIFF
--- a/infra/external-dns/deployment.yaml
+++ b/infra/external-dns/deployment.yaml
@@ -33,6 +33,7 @@ spec:
             # Add one domain filter per public zone/TLD that this cluster should manage.
             - --domain-filter=splat.top
             - --domain-filter=garz.ai
+            - --domain-filter=cegarza.com
             - --provider=cloudflare
             - --policy=sync
             - --registry=txt


### PR DESCRIPTION
## Scope

Adds exactly one ExternalDNS argument:

`--domain-filter=cegarza.com`

Sources, Cloudflare provider, `policy=sync`, TXT registry, owner `splattop-prod`, `_externaldns.` prefix, nginx class, and existing `splat.top` / `garz.ai` filters remain unchanged.

No Poetry Ingress exists in this revision, so no Poetry DNS record is expected.

## Provider baseline and dry run

- Full normalized cegarza.com provider snapshot: 12 records.
- Ghost apex: exactly one DNS-only `A 206.189.205.35`.
- No Poetry record and no `_externaldns.*` ownership record.
- Snapshot SHA-256: `9a0b36812ae45cd641adb040276b5d74460f22fdf456d1ffc5a01f63ad36454f`.
- Exact digest-pinned ExternalDNS `--dry-run --once` used all three filters and reported zero changes / `All records are already up to date`.
- Dry-run log SHA-256: `00395057bda98cd8a1c0e5caeba06c0ea123da576b540f107260b8622e5dbcb4`.
- Existing token visibility is limited to `splat.top`, `garz.ai`, and `cegarza.com`; token values were not read.

## Verification

- Two independent security/release reviews: CLEAN.
- Diff is exactly one insertion.
- Python 3.11.13: ownership, release-pin, and 162/162 tests passed.
- Helm 3.14.0: seven lints and fourteen renders passed.
- kubeconform 0.6.7: full matrix 128 valid / 4 expected skips / 0 invalid; changed raw Deployment 1/1.
- Poetry semantic and six negative renders passed.
- Registry overlay, Prometheus config/15 rules, exact ExternalDNS args assertion, no-latest scan, and diff check passed.

CI gap: the broad config workflow runs for this path, but it does not directly validate `infra/external-dns`; the raw Deployment schema and exact-argument checks are review evidence.

## Post-merge gates

- Require Argo external-dns Synced/Healthy at the exact merge revision and rollout 1/1.
- Confirm running args contain exactly the three domain filters with policy/owner/prefix unchanged.
- Wait at least two one-minute reconciliation intervals with no change/error logs.
- Require exact normalized 12-record snapshot equality.
- Reconfirm Ghost apex `206.189.205.35`, HTTPS 200, and Poetry still unpublished.