### PR TITLE
Enable Poetry Access validation before public ingress

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,11 +272,13 @@ jobs:
           }
           expect_failure "teamDomain is required" \
             --set enabled=true \
-            --set application.cloudflareAccess.enabled=true
+            --set application.cloudflareAccess.enabled=true \
+            --set application.cloudflareAccess.teamDomain=
           expect_failure "audience is required" \
             --set enabled=true \
             --set application.cloudflareAccess.enabled=true \
-            --set application.cloudflareAccess.teamDomain=https://poetry-ci.cloudflareaccess.com
+            --set application.cloudflareAccess.teamDomain=https://poetry-ci.cloudflareaccess.com \
+            --set application.cloudflareAccess.audience=
           expect_failure "allowedEmail is required" \
             --set enabled=true \
             --set application.cloudflareAccess.enabled=true \

--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,14 +1,15 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the public, DNS-only TLS stage: `enabled` and
-`ingress.enabled` are true while Cloudflare proxying and Access validation remain
-false. `values-ci.yaml` exists only to exercise the later Access-enabled variant
-in CI and must not be added to the Argo CD Application.
+`values.yaml` enables the private Access-validation stage: the runtime and signed
+Cloudflare Access origin validation are enabled while ingress and Cloudflare
+proxying remain disabled. `values-ci.yaml` exercises the later public Ingress
+with isolated Access identifiers in CI and must not be added to the Argo CD
+Application.
 
-During this bounded certificate-issuance stage, `/admin/` is reachable through
-nginx with Wagtail authentication and Axes lockout only. Do not create staff or
-superuser accounts until Cloudflare Access and the signed origin validator are
-active.
+During this stage, in-cluster unauthenticated `/admin/` requests must be rejected
+by the Django origin with `403` before any public Ingress exists. Do not create
+staff or superuser accounts until both the later raw-origin denial and the
+Cloudflare edge challenge have been proven.
 
 Activate in reviewed stages:
 
@@ -21,17 +22,18 @@ Activate in reviewed stages:
    and verify the Service plus `/healthz` and `/readyz` from inside the cluster.
    While Access is disabled the chart explicitly sets
    `CLOUDFLARE_ACCESS_REQUIRED=false` for this ingress-free staging phase.
-3. Set `ingress.enabled: true` with `cloudflareProxied: "false"`. Complete nginx
-   routing and the initial Let's Encrypt HTTP-01 issuance before proxying the
-   hostname.
-4. Configure and verify Cloudflare Access for `/admin` and `/admin/*`. Copy the
-   application's exact team domain and audience tag into
-   `application.cloudflareAccess`, enable the origin validator, and prove that
-   a raw load-balancer request with `Host: poetry.cegarza.com` receives `403` for
-   `/admin/`. The validator checks the Access-signed RS256 JWT, issuer, audience,
-   and exact `cesar@cegarza.com` identity; the normal Wagtail login remains the
-   second authentication step. The ConfigMap checksum in the pod template makes
-   sure this same GitOps revision restarts the Deployment with validation active.
+3. Configure Cloudflare Access for `/admin` and `/admin/*`, then enable
+   `application.cloudflareAccess` with the application's exact team domain and
+   audience tag while keeping `ingress.enabled: false`. The validator checks the
+   Access-signed RS256 JWT, issuer, audience, and exact `cesar@cegarza.com`
+   identity; the normal Wagtail login remains the second authentication step.
+   The ConfigMap checksum makes sure this GitOps revision restarts the Deployment
+   with validation active. Prove the new pod is Ready and an in-cluster request
+   to `/admin/` without a signed assertion receives `403` before continuing.
+4. In a separate reviewed revision, set `ingress.enabled: true` with
+   `cloudflareProxied: "false"`. Prove that a raw load-balancer request with
+   `Host: poetry.cegarza.com` still receives `403` for `/admin/`, then complete
+   nginx routing and the initial Let's Encrypt HTTP-01 issuance.
 5. Switch Cloudflare proxying on. Confirm public routes remain unauthenticated,
    `/admin/` challenges at the edge, an authenticated request reaches Wagtail,
    and a direct origin request is still denied.

--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,9 +1,14 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the private, ingress-free runtime: `enabled` is true while
-`ingress.enabled` remains false. `values-ci.yaml` exists only to exercise the
-later public-launch Access and Ingress variant in CI and must not be added to the
-Argo CD Application.
+`values.yaml` enables the public, DNS-only TLS stage: `enabled` and
+`ingress.enabled` are true while Cloudflare proxying and Access validation remain
+false. `values-ci.yaml` exists only to exercise the later Access-enabled variant
+in CI and must not be added to the Argo CD Application.
+
+During this bounded certificate-issuance stage, `/admin/` is reachable through
+nginx with Wagtail authentication and Axes lockout only. Do not create staff or
+superuser accounts until Cloudflare Access and the signed origin validator are
+active.
 
 Activate in reviewed stages:
 

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -40,13 +40,13 @@ application:
     AWS_S3_ENDPOINT_URL: https://nyc3.digitaloceanspaces.com
     AWS_S3_CUSTOM_DOMAIN: cegarza-poetry-media.nyc3.cdn.digitaloceanspaces.com
     TMPDIR: /tmp
-  # Disabled until the Cloudflare Access application exists. When enabled, the
-  # Django origin validates the signed Access JWT on /admin and /admin/* so a
-  # direct request to the load-balancer cannot bypass the edge policy.
+  # The Django origin validates the signed Access JWT on /admin and /admin/* so
+  # a direct request to the load-balancer cannot bypass the edge policy. Keep
+  # this enabled before the public Ingress is created or Cloudflare is proxied.
   cloudflareAccess:
-    enabled: false
-    teamDomain: ""
-    audience: ""
+    enabled: true
+    teamDomain: https://rapid-bird-dbce.cloudflareaccess.com
+    audience: aaeced7b6693e5b64f4a03c8704989bc89de070986793107baf1b03a9ce589db
     allowedEmail: cesar@cegarza.com
 
 service:
@@ -119,7 +119,7 @@ probes:
     failureThreshold: 3
 
 ingress:
-  enabled: true
+  enabled: false
   className: nginx
   host: poetry.cegarza.com
   annotations:

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -119,7 +119,7 @@ probes:
     failureThreshold: 3
 
 ingress:
-  enabled: false
+  enabled: true
   className: nginx
   host: poetry.cegarza.com
   annotations:

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -118,7 +118,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     values = _load_one(REPO_ROOT / "helm" / "poetry" / "values.yaml")
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
-    assert values["ingress"]["enabled"] is False
+    assert values["ingress"]["enabled"] is True
     assert values["ingress"]["cloudflareProxied"] == "false"
     assert values["application"]["cloudflareAccess"] == {
         "enabled": False,
@@ -134,12 +134,17 @@ def check(default_render: Path, enabled_render: Path) -> None:
         "Service",
         "Deployment",
         "Job",
+        "Ingress",
     ]
-    assert all(document["kind"] != "Ingress" for document in runtime_docs)
     assert all(document["kind"] != "PersistentVolumeClaim" for document in runtime_docs)
     _assert_no_key(runtime_docs, "persistentVolumeClaim")
     runtime_config = _find(runtime_docs, "ConfigMap", "poetry-config")
     assert runtime_config["data"]["CLOUDFLARE_ACCESS_REQUIRED"] == "false"
+    assert not {
+        key
+        for key in runtime_config["data"]
+        if key.startswith("CLOUDFLARE_ACCESS_") and key != "CLOUDFLARE_ACCESS_REQUIRED"
+    }
     runtime_service = _find(runtime_docs, "Service", "poetry")
     assert runtime_service["spec"]["type"] == "ClusterIP"
     runtime_deployment = _find(runtime_docs, "Deployment", "poetry")
@@ -159,6 +164,35 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert [
         source["secretRef"]["name"] for source in runtime_job_container["envFrom"]
     ] == EXPECTED_SECRETS
+    runtime_ingress = _find(runtime_docs, "Ingress", "poetry")
+    runtime_ingress_spec = runtime_ingress["spec"]
+    assert runtime_ingress_spec["ingressClassName"] == "nginx"
+    assert runtime_ingress_spec["rules"][0]["host"] == "poetry.cegarza.com"
+    assert runtime_ingress_spec["tls"] == [
+        {
+            "hosts": ["poetry.cegarza.com"],
+            "secretName": "poetry-cegarza-com-tls",
+        }
+    ]
+    runtime_ingress_annotations = runtime_ingress["metadata"]["annotations"]
+    assert (
+        runtime_ingress_annotations[
+            "external-dns.alpha.kubernetes.io/cloudflare-proxied"
+        ]
+        == "false"
+    )
+    assert (
+        runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
+        == "letsencrypt-prod"
+    )
+    assert (
+        runtime_ingress_annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+        == "true"
+    )
+    assert (
+        "nginx.ingress.kubernetes.io/whitelist-source-range"
+        not in runtime_ingress_annotations
+    )
 
     docs = _load_all(enabled_render)
     assert [document["kind"] for document in docs] == [
@@ -242,6 +276,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     annotations = ingress["metadata"]["annotations"]
     assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "false"
     assert annotations["cert-manager.io/cluster-issuer"] == "letsencrypt-prod"
+    assert annotations["nginx.ingress.kubernetes.io/ssl-redirect"] == "true"
     assert "nginx.ingress.kubernetes.io/whitelist-source-range" not in annotations
 
     _assert_application(

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -118,12 +118,14 @@ def check(default_render: Path, enabled_render: Path) -> None:
     values = _load_one(REPO_ROOT / "helm" / "poetry" / "values.yaml")
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
-    assert values["ingress"]["enabled"] is True
+    assert values["ingress"]["enabled"] is False
     assert values["ingress"]["cloudflareProxied"] == "false"
     assert values["application"]["cloudflareAccess"] == {
-        "enabled": False,
-        "teamDomain": "",
-        "audience": "",
+        "enabled": True,
+        "teamDomain": "https://rapid-bird-dbce.cloudflareaccess.com",
+        "audience": (
+            "aaeced7b6693e5b64f4a03c8704989bc89de070986793107baf1b03a9ce589db"
+        ),
         "allowedEmail": "cesar@cegarza.com",
     }
     assert re.fullmatch(r"sha-[a-f0-9]{40}", values["image"]["tag"])
@@ -134,17 +136,21 @@ def check(default_render: Path, enabled_render: Path) -> None:
         "Service",
         "Deployment",
         "Job",
-        "Ingress",
     ]
+    assert all(document["kind"] != "Ingress" for document in runtime_docs)
     assert all(document["kind"] != "PersistentVolumeClaim" for document in runtime_docs)
     _assert_no_key(runtime_docs, "persistentVolumeClaim")
     runtime_config = _find(runtime_docs, "ConfigMap", "poetry-config")
-    assert runtime_config["data"]["CLOUDFLARE_ACCESS_REQUIRED"] == "false"
-    assert not {
-        key
-        for key in runtime_config["data"]
-        if key.startswith("CLOUDFLARE_ACCESS_") and key != "CLOUDFLARE_ACCESS_REQUIRED"
-    }
+    assert runtime_config["data"]["CLOUDFLARE_ACCESS_REQUIRED"] == "true"
+    assert runtime_config["data"]["CLOUDFLARE_ACCESS_TEAM_DOMAIN"] == (
+        "https://rapid-bird-dbce.cloudflareaccess.com"
+    )
+    assert runtime_config["data"]["CLOUDFLARE_ACCESS_AUD"] == (
+        "aaeced7b6693e5b64f4a03c8704989bc89de070986793107baf1b03a9ce589db"
+    )
+    assert runtime_config["data"]["CLOUDFLARE_ACCESS_ALLOWED_EMAIL"] == (
+        "cesar@cegarza.com"
+    )
     runtime_service = _find(runtime_docs, "Service", "poetry")
     assert runtime_service["spec"]["type"] == "ClusterIP"
     runtime_deployment = _find(runtime_docs, "Deployment", "poetry")
@@ -156,7 +162,14 @@ def check(default_render: Path, enabled_render: Path) -> None:
     runtime_job_container = runtime_job["spec"]["template"]["spec"]["containers"][0]
     assert {item["name"]: item["value"] for item in runtime_job_container["env"]} == {
         **values["application"]["configData"],
-        "CLOUDFLARE_ACCESS_REQUIRED": "false",
+        "CLOUDFLARE_ACCESS_REQUIRED": "true",
+        "CLOUDFLARE_ACCESS_TEAM_DOMAIN": values["application"]["cloudflareAccess"][
+            "teamDomain"
+        ],
+        "CLOUDFLARE_ACCESS_AUD": values["application"]["cloudflareAccess"]["audience"],
+        "CLOUDFLARE_ACCESS_ALLOWED_EMAIL": values["application"]["cloudflareAccess"][
+            "allowedEmail"
+        ],
     }
     assert all(
         "configMapRef" not in source for source in runtime_job_container["envFrom"]
@@ -164,36 +177,6 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert [
         source["secretRef"]["name"] for source in runtime_job_container["envFrom"]
     ] == EXPECTED_SECRETS
-    runtime_ingress = _find(runtime_docs, "Ingress", "poetry")
-    runtime_ingress_spec = runtime_ingress["spec"]
-    assert runtime_ingress_spec["ingressClassName"] == "nginx"
-    assert runtime_ingress_spec["rules"][0]["host"] == "poetry.cegarza.com"
-    assert runtime_ingress_spec["tls"] == [
-        {
-            "hosts": ["poetry.cegarza.com"],
-            "secretName": "poetry-cegarza-com-tls",
-        }
-    ]
-    runtime_ingress_annotations = runtime_ingress["metadata"]["annotations"]
-    assert (
-        runtime_ingress_annotations[
-            "external-dns.alpha.kubernetes.io/cloudflare-proxied"
-        ]
-        == "false"
-    )
-    assert (
-        runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
-        == "letsencrypt-prod"
-    )
-    assert (
-        runtime_ingress_annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
-        == "true"
-    )
-    assert (
-        "nginx.ingress.kubernetes.io/whitelist-source-range"
-        not in runtime_ingress_annotations
-    )
-
     docs = _load_all(enabled_render)
     assert [document["kind"] for document in docs] == [
         "ConfigMap",
@@ -328,7 +311,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         "Let's Encrypt HTTP-01 issuance",
         "Access-signed RS256 JWT",
         "does not interfere with HTTP-01 certificate renewal",
-        "same GitOps revision restarts the Deployment",
+        "GitOps revision restarts the Deployment",
         "refuses to render a proxied Ingress",
     ):
         assert required_text in rollout_notes


### PR DESCRIPTION
## Outcome

Enable signed Cloudflare Access JWT validation for Poetry while keeping the application private and ingress-free.

This is the first of two ordered launch slices:

1. **This PR:** roll out and prove origin validation with no public Ingress.
2. **Next PR:** enable the unproxied Ingress, issue TLS, and prove raw-origin admin denial before Cloudflare proxying.

## Production effect

- `application.cloudflareAccess.enabled: true`
- team domain: `https://rapid-bird-dbce.cloudflareaccess.com`
- application audience: `aaeced7b6693e5b64f4a03c8704989bc89de070986793107baf1b03a9ce589db`
- exact allowed email remains `cesar@cegarza.com`
- `ingress.enabled: false`
- Cloudflare proxying remains disabled
- immutable image remains `sha-43ccbf5780e241f04c8c98398a636d8ca12a50cc`
- ConfigMap checksum changes, forcing the one-replica Deployment to roll with validation enabled
- no DNS, Certificate, Ingress, secret, database, media, or image change

The team domain, AUD, and email are verifier identifiers, not bearer credentials.

## Security ordering

The production render contains only ConfigMap, ClusterIP Service, Deployment, and PreSync migration Job. There is no Ingress, so the existing Access-disabled pod cannot become publicly reachable while the replacement rolls. If migration or rollout fails, the application remains private and the ingress stage is blocked.

The next ingress PR is gated on:

- Argo CD Synced/Healthy at this exact revision
- the old ReplicaSet scaled to zero
- the new pod Ready with `CLOUDFLARE_ACCESS_REQUIRED=true`
- in-cluster `/admin/` without a JWT returns `403`
- `/healthz` and `/readyz` return `200`
- zero active staff and superusers
- no Poetry Ingress or DNS records

## Verification

Exact-head local CI parity:

- Python 3.11.13: 162/162 tests
- Helm 3.14.0 lint and default/CI renders
- production render: 4 resources, no Ingress
- CI render: 5 resources with isolated test Access identifiers
- Poetry semantic checker
- six fail-closed Access/proxy rejection cases
- kubeconform 0.6.7 strict: 9/9 valid
- full independent matrix: 7 lints, 14 renders, 128 valid resources plus 4 expected CRD skips, zero errors
- ownership, release-pin, immutable-image, `no-latest`, and Ruff checks

Independent CI review: PASS.
Independent security re-review: CLEAN after splitting Access activation from ingress exposure.

## Rollback

Do not enable the public Ingress unless this revision is fully proven. After ingress exists, disable/remove ingress before ever disabling origin validation.
