### PR TITLE
CES-352 Phase 1 CP re-pin: sha-419b0c005a5c

### DIFF
--- a/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
+++ b/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: postgres-sweep
-              image: registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c
+              image: registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c
               imagePullPolicy: IfNotPresent
               command:
                 - mandate-postgres-sweep

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-11df8fcd999c
+  tag: sha-419b0c005a5c
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 11df8fcd999c0d08067f9fc753ab1d12da056140
+      targetRevision: 419b0c005a5c8f30700ef5ec8b3a7cddd8ec0cda
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-11df8fcd999c
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Scope

Control-plane image + Application `targetRevision` bump to ap main `419b0c00` (CES-352 Phase 1: stage the API RWO topology label).

- `apps/agent-control-plane/values.yaml`: `image.tag sha-11df8fcd999c -> sha-419b0c005a5c`
- `argocd/applications/agent-control-plane.yaml`: `targetRevision -> 419b0c005a5c8f30700ef5ec8b3a7cddd8ec0cda`
- fixture syncs: `docs/runbooks/postgres-restore.md` (x2) + `apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml` image refs

## Why it's clean

The train `11df8fcd..419b0c00` is **only** `helm/mandate/templates/deployment.yaml` (+6, the label) + its tests. So:
- **No migrations** (`audit/schema/` untouched).
- **No broker-adapter changes** -> provider digest pins **unchanged** (fingerprints are byte-identical per the CES-352 topology analysis).
- **No identity re-mint** (not a worker_service change).

## Deploy effect

Adds the inert `mandate.dev/codex-auth-consumer: "true"` label to the **API** pod template (nothing selects on it yet in Phase 1). The API rolls with the new label; its existing required affinity to the gateway node keeps the relabel RWO-safe. DOCR: tag `sha-419b0c005a5c`, manifest `sha256:e214d2784b2b6239a338765bc03c2c463aa62bb0b8475ae16613e82f6150eeb4`.

## Post-deploy gate (CES-352 Phase 1)

Prove >=1 Ready API pod carries the label and every scheduled labeled API pod is on one hostname -> then the Phase 2 source PR can open.