### PR TITLE
CES-352 Phase 2 CP re-pin: sha-5efddce68417

### DIFF
--- a/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
+++ b/apps/agent-control-plane-runtime-controls/postgres-sweep-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: postgres-sweep
-              image: registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c
+              image: registry.digitalocean.com/sendouq/agent-platform:sha-5efddce68417
               imagePullPolicy: IfNotPresent
               command:
                 - mandate-postgres-sweep

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -19,7 +19,7 @@ metrics:
 
 image:
   repository: registry.digitalocean.com/sendouq/agent-platform
-  tag: sha-419b0c005a5c
+  tag: sha-5efddce68417
   pullPolicy: IfNotPresent
 
 secretKeys:

--- a/argocd/applications/agent-control-plane.yaml
+++ b/argocd/applications/agent-control-plane.yaml
@@ -11,7 +11,7 @@ spec:
   project: splattop
   sources:
     - repoURL: git@github.com:cesaregarza/agent-platform.git
-      targetRevision: 419b0c005a5c8f30700ef5ec8b3a7cddd8ec0cda
+      targetRevision: 5efddce6841756aa8f5b4f770cc9a64c17bcd68e
       path: helm/mandate
       helm:
         releaseName: agent-control-plane

--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -36,7 +36,7 @@ DigitalOcean context:
 | Values overlay | `apps/agent-control-plane/values.yaml` |
 | Chart source | `argocd/applications/agent-control-plane.yaml` |
 | Public hostname | `agent-control-plane.garz.ai` |
-| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c` |
+| Current image | `registry.digitalocean.com/sendouq/agent-platform:sha-5efddce68417` |
 
 DigitalOcean managed PostgreSQL documents automatic backups and point-in-time
 restore by forking a new database cluster. Restores must create a new cluster;
@@ -177,7 +177,7 @@ spec:
         - name: regcred
       containers:
         - name: schema-check
-          image: registry.digitalocean.com/sendouq/agent-platform:sha-419b0c005a5c
+          image: registry.digitalocean.com/sendouq/agent-platform:sha-5efddce68417
           envFrom:
             - secretRef:
                 name: agent-control-plane-secrets


### PR DESCRIPTION
## Scope

Control-plane image + Application `targetRevision` bump to ap main `5efddce6` (CES-352 Phase 2: enforce safe shared-RWO topology).

- `apps/agent-control-plane/values.yaml`: `image.tag sha-419b0c005a5c -> sha-5efddce68417`
- `argocd/applications/agent-control-plane.yaml`: `targetRevision -> 5efddce6841756aa8f5b4f770cc9a64c17bcd68e`
- fixture syncs: `docs/runbooks/postgres-restore.md` (x2) + `postgres-sweep-cronjob.yaml`

## Why it's clean

Phase 2 is a chart-only topology change (label/affinity/strategy/PDB/schema/tests). **No env/volume/args edits -> provider digest pins unchanged**, no migration, no identity re-mint. Gate: ap#364 clean on all 4 deploy-critical dimensions, full CI green. DOCR: tag `sha-5efddce68417`, manifest `sha256:33bc34c88e8d504501daddf45ee7ccdac52703e1b1bf0135c4dd7287bc0b6e23`.

## Deploy effect (the risky live step — separate operator go)

Switches BOTH API + model-gateway to required shared-label hostname affinity and the **model-gateway to `Recreate`**. Anchored on the already-labeled Phase 1 API pod (Ready on 38ntso). Gateway Recreate = brief request outage (old pod stops before new starts); API stays RollingUpdate. This is what makes the shared-RWO topology safe and **lifts the GaiC#423 deploy-hold** once live.