### PR TITLE
Publish Poetry through unproxied TLS ingress

### DIFF
--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,15 +1,15 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the private Access-validation stage: the runtime and signed
-Cloudflare Access origin validation are enabled while ingress and Cloudflare
-proxying remain disabled. `values-ci.yaml` exercises the later public Ingress
+`values.yaml` enables the public DNS-only TLS stage: the runtime, signed
+Cloudflare Access origin validation, and Ingress are enabled while Cloudflare
+proxying remains disabled. `values-ci.yaml` exercises the same public Ingress
 with isolated Access identifiers in CI and must not be added to the Argo CD
 Application.
 
-During this stage, in-cluster unauthenticated `/admin/` requests must be rejected
-by the Django origin with `403` before any public Ingress exists. Do not create
-staff or superuser accounts until both the later raw-origin denial and the
-Cloudflare edge challenge have been proven.
+During this stage, unauthenticated `/admin/` requests are rejected by the Django
+origin with `403` even when sent directly to the public load balancer. Do not
+create staff or superuser accounts until both this raw-origin denial and the
+later Cloudflare edge challenge have been proven.
 
 Activate in reviewed stages:
 

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -119,7 +119,7 @@ probes:
     failureThreshold: 3
 
 ingress:
-  enabled: false
+  enabled: true
   className: nginx
   host: poetry.cegarza.com
   annotations:

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -118,7 +118,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     values = _load_one(REPO_ROOT / "helm" / "poetry" / "values.yaml")
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
-    assert values["ingress"]["enabled"] is False
+    assert values["ingress"]["enabled"] is True
     assert values["ingress"]["cloudflareProxied"] == "false"
     assert values["application"]["cloudflareAccess"] == {
         "enabled": True,
@@ -136,8 +136,8 @@ def check(default_render: Path, enabled_render: Path) -> None:
         "Service",
         "Deployment",
         "Job",
+        "Ingress",
     ]
-    assert all(document["kind"] != "Ingress" for document in runtime_docs)
     assert all(document["kind"] != "PersistentVolumeClaim" for document in runtime_docs)
     _assert_no_key(runtime_docs, "persistentVolumeClaim")
     runtime_config = _find(runtime_docs, "ConfigMap", "poetry-config")
@@ -177,6 +177,36 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert [
         source["secretRef"]["name"] for source in runtime_job_container["envFrom"]
     ] == EXPECTED_SECRETS
+    runtime_ingress = _find(runtime_docs, "Ingress", "poetry")
+    runtime_ingress_spec = runtime_ingress["spec"]
+    assert runtime_ingress_spec["ingressClassName"] == "nginx"
+    assert runtime_ingress_spec["rules"][0]["host"] == "poetry.cegarza.com"
+    assert runtime_ingress_spec["tls"] == [
+        {
+            "hosts": ["poetry.cegarza.com"],
+            "secretName": "poetry-cegarza-com-tls",
+        }
+    ]
+    runtime_ingress_annotations = runtime_ingress["metadata"]["annotations"]
+    assert (
+        runtime_ingress_annotations[
+            "external-dns.alpha.kubernetes.io/cloudflare-proxied"
+        ]
+        == "false"
+    )
+    assert (
+        runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
+        == "letsencrypt-prod"
+    )
+    assert (
+        runtime_ingress_annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+        == "true"
+    )
+    assert (
+        "nginx.ingress.kubernetes.io/whitelist-source-range"
+        not in runtime_ingress_annotations
+    )
+
     docs = _load_all(enabled_render)
     assert [document["kind"] for document in docs] == [
         "ConfigMap",


### PR DESCRIPTION
## Summary

- publish the already Access-protected Poetry service through the shared nginx ingress
- request the initial letsencrypt-prod certificate for poetry.cegarza.com
- keep external-dns Cloudflare proxying disabled for raw-origin and ACME verification
- strengthen semantic CI so production must render the exact host, class, TLS secret, issuer, and unproxied annotation

## Safety and rollout ordering

This PR is intentionally separate from Access activation. The Access-only revision `4c12d932f5aa66e550d8b38aead27d2d6fdd702b` is already Synced/Healthy in Argo CD. Its replacement pod is Ready with signed Access validation required, the old Access-disabled ReplicaSet is at zero, an unauthenticated in-cluster request to `/admin/` returns `403`, and `/healthz` plus `/readyz` return `200`.

The rendered delta from that exact revision adds only `Ingress/poetry`. ConfigMap, Service, Deployment, PreSync migration Job, full pod template, immutable image, and configuration checksum remain identical, so this change does not roll or alter the application pod.

Expected ingress load balancer: `152.42.155.167`. Cloudflare proxying remains explicitly `false` until a later, separate PR.

## Verification

- Python 3.11 locked dependency sync
- 162 unit/contract tests
- grant ownership and release-pin checks
- Ruff 0.15.14 lint and format
- Helm 3.14.0 lint plus default and CI renders
- Poetry semantic checker
- all six fail-closed Access render cases
- kubeconform 0.6.7 strict: Poetry 10/10 valid; full chart matrix 133 resources, 129 valid and 4 expected skips
- no-latest scan
- independent CI-parity review: PASS

## Post-merge gates

- Argo CD is Synced/Healthy at the exact merge revision and the migration hook succeeds
- the Deployment retains the same ReplicaSet and pod
- the Ingress receives `152.42.155.167`
- external-dns creates only the Poetry A record and ownership TXT with proxying disabled
- the certificate becomes Ready through nginx HTTP-01
- public pages and health endpoints pass with trusted HTTPS
- raw-origin `/admin/` remains `403`
- the existing `cegarza.com` Ghost apex remains on `206.189.205.35` and healthy

Rollback is an immutable GitOps revert of this Ingress-only revision; database and Spaces media are retained.
