### PR TITLE
Proxy Poetry through Cloudflare

### DIFF
--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,15 +1,15 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the public DNS-only TLS stage: the runtime, signed
-Cloudflare Access origin validation, and Ingress are enabled while Cloudflare
-proxying remains disabled. `values-ci.yaml` exercises the same public Ingress
-with isolated Access identifiers in CI and must not be added to the Argo CD
-Application.
+`values.yaml` enables the final public launch stage: the runtime, signed
+Cloudflare Access origin validation, Ingress, and Cloudflare proxying are all
+enabled. `values-ci.yaml` exercises the same public Ingress with isolated Access
+identifiers in CI and must not be added to the Argo CD Application.
 
-During this stage, unauthenticated `/admin/` requests are rejected by the Django
-origin with `403` even when sent directly to the public load balancer. Do not
-create staff or superuser accounts until both this raw-origin denial and the
-later Cloudflare edge challenge have been proven.
+During this stage, public routes remain unauthenticated, `/admin/` is challenged
+by Cloudflare Access, and direct load-balancer requests to `/admin/` are still
+rejected by the Django origin with `403`. Do not create staff or superuser
+accounts until the edge policy accepts only `cesar@cegarza.com` through one-time
+PIN authentication and the raw-origin denial has been re-proven.
 
 Activate in reviewed stages:
 

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -124,7 +124,7 @@ ingress:
   host: poetry.cegarza.com
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  cloudflareProxied: "false"
+  cloudflareProxied: "true"
   tls:
     enabled: true
     clusterIssuer: letsencrypt-prod

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -119,7 +119,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
     assert values["ingress"]["enabled"] is True
-    assert values["ingress"]["cloudflareProxied"] == "false"
+    assert values["ingress"]["cloudflareProxied"] == "true"
     assert values["application"]["cloudflareAccess"] == {
         "enabled": True,
         "teamDomain": "https://rapid-bird-dbce.cloudflareaccess.com",
@@ -192,7 +192,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         runtime_ingress_annotations[
             "external-dns.alpha.kubernetes.io/cloudflare-proxied"
         ]
-        == "false"
+        == "true"
     )
     assert (
         runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
@@ -287,7 +287,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         }
     ]
     annotations = ingress["metadata"]["annotations"]
-    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "false"
+    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "true"
     assert annotations["cert-manager.io/cluster-issuer"] == "letsencrypt-prod"
     assert annotations["nginx.ingress.kubernetes.io/ssl-redirect"] == "true"
     assert "nginx.ingress.kubernetes.io/whitelist-source-range" not in annotations


### PR DESCRIPTION
## Summary

- switch Poetry's external-dns Cloudflare proxy annotation from `false` to `true`
- preserve signed Access validation at the Django origin
- advance rollout documentation and semantic CI to the final public-launch state

## Proven prerequisite state

The unproxied ingress revision `46937a5f40b3bf56cd9c81f0cc080f3e6fb0aba8` is already Synced/Healthy in Argo CD. Its PreSync migration hook succeeded and the application retained the existing Ready ReplicaSet and pod.

Live acceptance before this PR:

- `poetry.cegarza.com` resolves directly to `152.42.155.167`
- both external-dns ownership TXT records exist with owner `splattop-prod`
- `poetry-cegarza-com-tls` is Ready from `letsencrypt-prod`
- Home, Poems, Collections, About, feed, sitemap, robots, health, and readiness return `200` over trusted HTTPS
- normal and forced raw-origin `/admin/` return `403` without an Access assertion
- the intentional empty states and same-origin theme assets are live
- `cegarza.com` remains on `206.189.205.35` and its Ghost site returns `200`

## Rendered scope

The only rendered Kubernetes change is:

`Ingress/poetry` annotation `external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"` -> `"true"`.

ConfigMap, Service, Deployment, PreSync Job, complete pod template, immutable image, and configuration checksum `2b3b44feb9f7f5f43b33a7c6ea26e72a86490b48d627538b592ccd67036446d6` remain identical. This PR does not roll or alter the application pod.

## Verification

- Python 3.11 locked dependency sync
- 162 unit/contract tests
- grant ownership and release-pin checks
- Ruff 0.15.14 lint and format
- Helm 3.14.0 lint plus default and CI renders
- Poetry semantic checker and all six fail-closed Access render cases
- kubeconform 0.6.7 strict: Poetry 10/10 valid; full chart matrix 133 resources, 129 valid and 4 expected skips
- no-latest scan

## Post-merge gates

- Argo CD is Synced/Healthy at the exact merge revision
- external-dns reports the proxied record update without touching the Ghost apex
- public routes remain unauthenticated and healthy at the Cloudflare edge
- unauthenticated `/admin/` receives the Cloudflare Access challenge for the supplied application audience
- direct load-balancer `/admin/` remains `403`
- the exact-email one-time-PIN policy is verified interactively before creating a Wagtail superuser

Rollback is a one-value GitOps revert to the proven unproxied state; origin Access validation remains active throughout.
