### PR TITLE
Roll back Poetry Cloudflare proxy

### DIFF
--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,15 +1,15 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the final public launch stage: the runtime, signed
-Cloudflare Access origin validation, Ingress, and Cloudflare proxying are all
-enabled. `values-ci.yaml` exercises the same public Ingress with isolated Access
-identifiers in CI and must not be added to the Argo CD Application.
+`values.yaml` enables the public DNS-only TLS stage: the runtime, signed
+Cloudflare Access origin validation, and Ingress are enabled while Cloudflare
+proxying remains disabled. `values-ci.yaml` exercises the same public Ingress
+with isolated Access identifiers in CI and must not be added to the Argo CD
+Application.
 
-During this stage, public routes remain unauthenticated, `/admin/` is challenged
-by Cloudflare Access, and direct load-balancer requests to `/admin/` are still
-rejected by the Django origin with `403`. Do not create staff or superuser
-accounts until the edge policy accepts only `cesar@cegarza.com` through one-time
-PIN authentication and the raw-origin denial has been re-proven.
+During this stage, unauthenticated `/admin/` requests are rejected by the Django
+origin with `403` even when sent directly to the public load balancer. Do not
+create staff or superuser accounts until both this raw-origin denial and the
+later Cloudflare edge challenge have been proven.
 
 Activate in reviewed stages:
 

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -124,7 +124,7 @@ ingress:
   host: poetry.cegarza.com
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  cloudflareProxied: "true"
+  cloudflareProxied: "false"
   tls:
     enabled: true
     clusterIssuer: letsencrypt-prod

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -119,7 +119,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
     assert values["ingress"]["enabled"] is True
-    assert values["ingress"]["cloudflareProxied"] == "true"
+    assert values["ingress"]["cloudflareProxied"] == "false"
     assert values["application"]["cloudflareAccess"] == {
         "enabled": True,
         "teamDomain": "https://rapid-bird-dbce.cloudflareaccess.com",
@@ -192,7 +192,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         runtime_ingress_annotations[
             "external-dns.alpha.kubernetes.io/cloudflare-proxied"
         ]
-        == "true"
+        == "false"
     )
     assert (
         runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
@@ -287,7 +287,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         }
     ]
     annotations = ingress["metadata"]["annotations"]
-    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "true"
+    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "false"
     assert annotations["cert-manager.io/cluster-issuer"] == "letsencrypt-prod"
     assert annotations["nginx.ingress.kubernetes.io/ssl-redirect"] == "true"
     assert "nginx.ingress.kubernetes.io/whitelist-source-range" not in annotations


### PR DESCRIPTION
## Incident

Final edge acceptance after #433 exposed a deterministic HTTPS redirect loop:

- `https://poetry.cegarza.com/` returned Cloudflare `308`
- `Location: https://poetry.cegarza.com`
- following redirects exceeded the limit while returning to the same URL

This is consistent with Cloudflare forwarding to the TLS-enforcing nginx origin over HTTP (Flexible encryption mode). The release gate requires immediate rollback on any public-route redirect loop.

## Rollback

Restore `external-dns.alpha.kubernetes.io/cloudflare-proxied` from `"true"` to the proven `"false"` state and restore the matching rollout documentation/assertions.

The full candidate working tree was compared with the parent of #433 and exactly matches proven unproxied revision `46937a5f40b3bf56cd9c81f0cc080f3e6fb0aba8`. The only live runtime change is the Ingress annotation. Access validation, origin TLS, certificate, Deployment, pod, image, checksum, database, and media remain unchanged.

An immediate live annotation correction was applied while this GitOps rollback is reviewed; this PR makes that safe state authoritative.

## Verification

- full tree exactly matches `46937a5f40b3bf56cd9c81f0cc080f3e6fb0aba8`
- 162 unit/contract tests pass
- Ruff lint/format pass
- Helm 3.14.0 lint and both renders pass
- Poetry semantic checker passes

After merge, verify DNS returns to `152.42.155.167`, public HTTPS routes return `200`, raw `/admin/` remains `403`, the pod is unchanged, and the Ghost apex remains healthy.
