### PR TITLE
Retry Poetry Cloudflare proxy with strict TLS

### DIFF
--- a/helm/poetry/README.md
+++ b/helm/poetry/README.md
@@ -1,15 +1,15 @@
 # Poetry chart rollout stages
 
-`values.yaml` enables the public DNS-only TLS stage: the runtime, signed
-Cloudflare Access origin validation, and Ingress are enabled while Cloudflare
-proxying remains disabled. `values-ci.yaml` exercises the same public Ingress
-with isolated Access identifiers in CI and must not be added to the Argo CD
-Application.
+`values.yaml` enables the final public launch stage: the runtime, signed
+Cloudflare Access origin validation, Ingress, and Cloudflare proxying are all
+enabled. `values-ci.yaml` exercises the same public Ingress with isolated Access
+identifiers in CI and must not be added to the Argo CD Application.
 
-During this stage, unauthenticated `/admin/` requests are rejected by the Django
-origin with `403` even when sent directly to the public load balancer. Do not
-create staff or superuser accounts until both this raw-origin denial and the
-later Cloudflare edge challenge have been proven.
+During this stage, public routes remain unauthenticated, `/admin/` is challenged
+by Cloudflare Access, and direct load-balancer requests to `/admin/` are still
+rejected by the Django origin with `403`. Do not create staff or superuser
+accounts until the edge policy accepts only `cesar@cegarza.com` through one-time
+PIN authentication and the raw-origin denial has been re-proven.
 
 Activate in reviewed stages:
 
@@ -34,7 +34,9 @@ Activate in reviewed stages:
    `cloudflareProxied: "false"`. Prove that a raw load-balancer request with
    `Host: poetry.cegarza.com` still receives `403` for `/admin/`, then complete
    nginx routing and the initial Let's Encrypt HTTP-01 issuance.
-5. Switch Cloudflare proxying on. Confirm public routes remain unauthenticated,
+5. Deploy a hostname-scoped Cloudflare Configuration Rule that sets Full
+   (strict) origin TLS for `poetry.cegarza.com`, then switch Cloudflare proxying
+   on. Confirm public routes remain unauthenticated without redirect loops,
    `/admin/` challenges at the edge, an authenticated request reaches Wagtail,
    and a direct origin request is still denied.
 

--- a/helm/poetry/values.yaml
+++ b/helm/poetry/values.yaml
@@ -124,7 +124,7 @@ ingress:
   host: poetry.cegarza.com
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  cloudflareProxied: "false"
+  cloudflareProxied: "true"
   tls:
     enabled: true
     clusterIssuer: letsencrypt-prod

--- a/scripts/check_poetry_substrate.py
+++ b/scripts/check_poetry_substrate.py
@@ -119,7 +119,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
     assert values["enabled"] is True
     assert values["replicaCount"] == 1
     assert values["ingress"]["enabled"] is True
-    assert values["ingress"]["cloudflareProxied"] == "false"
+    assert values["ingress"]["cloudflareProxied"] == "true"
     assert values["application"]["cloudflareAccess"] == {
         "enabled": True,
         "teamDomain": "https://rapid-bird-dbce.cloudflareaccess.com",
@@ -192,7 +192,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         runtime_ingress_annotations[
             "external-dns.alpha.kubernetes.io/cloudflare-proxied"
         ]
-        == "false"
+        == "true"
     )
     assert (
         runtime_ingress_annotations["cert-manager.io/cluster-issuer"]
@@ -287,7 +287,7 @@ def check(default_render: Path, enabled_render: Path) -> None:
         }
     ]
     annotations = ingress["metadata"]["annotations"]
-    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "false"
+    assert annotations["external-dns.alpha.kubernetes.io/cloudflare-proxied"] == "true"
     assert annotations["cert-manager.io/cluster-issuer"] == "letsencrypt-prod"
     assert annotations["nginx.ingress.kubernetes.io/ssl-redirect"] == "true"
     assert "nginx.ingress.kubernetes.io/whitelist-source-range" not in annotations


### PR DESCRIPTION
## Summary

- retry the Poetry Cloudflare proxy transition after deploying a hostname-scoped Full (strict) origin-TLS Configuration Rule
- keep signed Cloudflare Access validation active at the Django origin
- document Full (strict) as a required precondition before proxying

## Previous attempt and correction

The first proxy attempt produced a deterministic same-URL `308` loop because Cloudflare connected to the HTTPS-enforcing nginx origin over HTTP. It was immediately rolled back in #434, restoring the proven DNS-only state.

The Cloudflare dashboard now has a deployed Configuration Rule matching only `poetry.cegarza.com` and setting origin SSL/TLS mode to Full (strict). The DNS record remains unproxied until this reviewed GitOps change.

Current rollback baseline `d6ed10828d93335f25a242c040e884b76c7e90f9` is Synced/Healthy: public routes return `200` with zero redirects, `/admin/` returns `403`, the certificate is Ready, DNS points to `152.42.155.167`, the existing pod has zero restarts, and the Ghost apex is unchanged.

## Rendered scope

The sole rendered Kubernetes change is:

`Ingress/poetry` annotation `external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"` -> `"true"`.

ConfigMap, Service, Deployment, PreSync Job, complete pod template, immutable image, and configuration checksum `2b3b44feb9f7f5f43b33a7c6ea26e72a86490b48d627538b592ccd67036446d6` remain identical. This retry cannot roll the application pod.

## Verification

- Python 3.11 locked dependency sync
- 162 unit/contract tests
- grant ownership and release-pin checks
- Ruff 0.15.14 lint and format
- Helm 3.14.0 lint plus default and CI renders
- Poetry semantic checker and all six fail-closed Access render cases
- kubeconform 0.6.7 strict: Poetry 10/10 valid
- no-latest scan
- structural comparison: only the proxy annotation changes

## Post-merge gates

- Argo CD is Synced/Healthy at the exact merge revision without a pod change
- external-dns updates only Poetry to Cloudflare anycast
- public routes return `200` without redirect loops or `52x` responses
- `/admin`, `/admin/`, and `/admin/login/` challenge through the supplied Access application
- direct load-balancer `/admin/` remains `403`
- the certificate remains Ready and Ghost remains unchanged

Rollback is the already-proven one-value transition back to DNS-only. Revert immediately on any loop, public Access challenge, `52x`, missing admin challenge, raw-origin admin exposure, pod rollout, or Ghost mutation.
