### PR TITLE
CES-538/CES-572: force Helm rendering for registry overlay

### DIFF
--- a/argocd/applications/agent-control-plane-registry-overlay.yaml
+++ b/argocd/applications/agent-control-plane-registry-overlay.yaml
@@ -16,6 +16,10 @@ spec:
     repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
     path: apps/agent-control-plane-registry-overlay
+    # This path intentionally retains kustomization.yaml for local render
+    # equivalence. Select Helm explicitly so Argo does not auto-detect the
+    # Kustomize input and silently omit templates/restart-hook.yaml.
+    helm: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-control-plane

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -137,6 +137,7 @@ def _assert_single_helm_application_source(repo_root: Path) -> None:
         "repoURL": "https://github.com/cesaregarza/GarzAICluster",
         "targetRevision": "main",
         "path": str(REGISTRY_OVERLAY_DIR),
+        "helm": {},
     }
     if spec.get("source") != expected:
         raise RegistryOverlayRenderError(

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -372,6 +372,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
                 "repoURL": "https://github.com/cesaregarza/GarzAICluster",
                 "targetRevision": "main",
                 "path": "apps/agent-control-plane-registry-overlay",
+                "helm": {},
             },
         )
 


### PR DESCRIPTION
## Outcome

Force the `agent-control-plane-registry-overlay` Argo Application to select Helm explicitly with `spec.source.helm: {}`.

## Root cause

The application path intentionally retains both `Chart.yaml` and `kustomization.yaml`: Helm is the production renderer, while Kustomize exists only for local ConfigMap equivalence. Without an explicit Helm selector, the live Argo controller auto-detected Kustomize, reported the application `Synced`/`Healthy`, and omitted `templates/restart-hook.yaml` from `syncResult`. A hard refresh reproduced the mis-detection.

## Changes

- add an explicit empty Helm source configuration to the Argo Application;
- make the complete-Application render gate require that exact source shape;
- strengthen the unit contract so removing the selector fails CI.

## Local CI parity

- Python 3.11.13: 162/162 tests passed;
- grant-ownership and control-plane release-pin checks passed;
- Helm 3.14.0 + Kustomize 5.4.3 complete Application render passed with ConfigMap/RBAC/generated PostSync Job and golden equivalence;
- seven chart lints and fourteen Helm renders passed;
- kubeconform 0.6.7 strict validation passed for all fourteen renders (128 valid, 4 expected CRD skips, 0 invalid/errors);
- Poetry semantic and six negative renders passed;
- Prometheus configuration and 15 rules passed;
- `no-latest` and `git diff --check` passed.

Hosted OIDC-backed registry compatibility, identity-drift, and provider-image gates remain required on this exact head.

## Deployment/verification

After merge, reconcile the root Argo Application, confirm the overlay source type becomes `Helm`, then run one authorized full overlay sync. CES-538/CES-572 pass only if `syncResult` includes a fresh generated PostSync Job and its logs prove sequential API → model gateway → callback adapter → git deliverer → local worker restart with old-pod drain.

Linear: CES-538, CES-572