### PR TITLE
CES-538/CES-572: preserve explicit Helm source selection

### DIFF
--- a/argocd/applications/agent-control-plane-registry-overlay.yaml
+++ b/argocd/applications/agent-control-plane-registry-overlay.yaml
@@ -17,9 +17,11 @@ spec:
     targetRevision: main
     path: apps/agent-control-plane-registry-overlay
     # This path intentionally retains kustomization.yaml for local render
-    # equivalence. Select Helm explicitly so Argo does not auto-detect the
-    # Kustomize input and silently omit templates/restart-hook.yaml.
-    helm: {}
+    # equivalence. Select Helm with a non-empty field that survives Kubernetes
+    # CRD normalization so Argo cannot auto-detect the Kustomize input and
+    # silently omit templates/restart-hook.yaml.
+    helm:
+      releaseName: agent-control-plane-registry-overlay
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-control-plane

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -137,7 +137,7 @@ def _assert_single_helm_application_source(repo_root: Path) -> None:
         "repoURL": "https://github.com/cesaregarza/GarzAICluster",
         "targetRevision": "main",
         "path": str(REGISTRY_OVERLAY_DIR),
-        "helm": {},
+        "helm": {"releaseName": "agent-control-plane-registry-overlay"},
     }
     if spec.get("source") != expected:
         raise RegistryOverlayRenderError(

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -372,7 +372,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
                 "repoURL": "https://github.com/cesaregarza/GarzAICluster",
                 "targetRevision": "main",
                 "path": "apps/agent-control-plane-registry-overlay",
-                "helm": {},
+                "helm": {"releaseName": "agent-control-plane-registry-overlay"},
             },
         )
 


### PR DESCRIPTION
## Outcome

Replace the empty Helm selector from #436 with a non-empty, behavior-preserving source configuration:

```yaml
helm:
  releaseName: agent-control-plane-registry-overlay
```

## Why this follow-up is required

The merged `helm: {}` object was pruned when the root Application reconciled the child Application. The live object therefore still had no `spec.source.helm`, and a hard refresh continued to report `sourceType: Kustomize`.

A non-empty `releaseName` survives Kubernetes/CRD normalization, forces Argo's Helm source selection, and matches the chart's existing release identity.

## Regression contract

The complete render gate and unit test now require the exact non-empty Helm source configuration, so replacing it with a prunable empty object or omitting it fails CI.

## Validation

- Python 3.11.13: 162/162 tests passed;
- Helm 3.14.0 + Kustomize 5.4.3 complete Application render passed;
- ConfigMap/RBAC/generated PostSync Job shape and Helm/Kustomize/golden equivalence passed;
- `git diff --check` passed.

The exhaustive chart/schema/Poetry/Prometheus parity from #436 remains unchanged; all hosted checks must pass again on this exact head.

## Deployment gate

After merge, reconcile only the overlay Application from root, hard-refresh and require `sourceType: Helm`, then run a full non-selective overlay sync and verify the generated PostSync Job and five-consumer sequence.

Follow-up to #436. Linear: CES-538, CES-572