### PR TITLE
CES-572: fix non-root kubectl in registry restart hook

### DIFF
--- a/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
@@ -31,6 +31,12 @@ spec:
           # CES-108/CES-538: the control plane boot-caches the registry
           # snapshot; an overlay sync without a rollout leaves stale authority.
           image: alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
+          # The image defaults HOME to /root, but this container runs as UID
+          # 65534. Give kubectl an accessible home so it falls back to the
+          # projected in-cluster ServiceAccount configuration.
+          env:
+            - name: HOME
+              value: /tmp
           command:
             - /bin/sh
             - -ec
@@ -246,3 +252,9 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -278,6 +278,33 @@ def _assert_complete_application_resources(documents: list[dict[str, Any]]) -> N
         raise RegistryOverlayRenderError(
             "generated PostSync Job must retain failed logs for one bounded day"
         )
+    pod_spec = (hook_spec.get("template") or {}).get("spec")
+    if not isinstance(pod_spec, dict):
+        raise RegistryOverlayRenderError("generated PostSync Job Pod spec is missing")
+    containers = pod_spec.get("containers")
+    if not isinstance(containers, list) or len(containers) != 1:
+        raise RegistryOverlayRenderError(
+            "generated PostSync Job must contain exactly one container"
+        )
+    restart_container = containers[0]
+    expected_env = [{"name": "HOME", "value": "/tmp"}]
+    if restart_container.get("env") != expected_env:
+        raise RegistryOverlayRenderError(
+            "generated PostSync Job must give non-root kubectl an accessible HOME:\n"
+            + _json_diff(expected_env, restart_container.get("env"))
+        )
+    expected_mounts = [{"name": "tmp", "mountPath": "/tmp"}]
+    if restart_container.get("volumeMounts") != expected_mounts:
+        raise RegistryOverlayRenderError(
+            "generated PostSync Job writable-home mount drifted:\n"
+            + _json_diff(expected_mounts, restart_container.get("volumeMounts"))
+        )
+    expected_volumes = [{"name": "tmp", "emptyDir": {}}]
+    if pod_spec.get("volumes") != expected_volumes:
+        raise RegistryOverlayRenderError(
+            "generated PostSync Job writable-home volume drifted:\n"
+            + _json_diff(expected_volumes, pod_spec.get("volumes"))
+        )
 
     role = next(document for document in documents if document.get("kind") == "Role")
     expected_rules = [

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -333,9 +333,19 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             1500,
         )
 
-        restart_script = self.registry_overlay_restart_hook["spec"]["template"]["spec"][
-            "containers"
-        ][0]["command"][-1]
+        pod_spec = self.registry_overlay_restart_hook["spec"]["template"]["spec"]
+        restart_container = pod_spec["containers"][0]
+        self.assertEqual(
+            restart_container["env"],
+            [{"name": "HOME", "value": "/tmp"}],
+        )
+        self.assertEqual(
+            restart_container["volumeMounts"],
+            [{"name": "tmp", "mountPath": "/tmp"}],
+        )
+        self.assertEqual(pod_spec["volumes"], [{"name": "tmp", "emptyDir": {}}])
+
+        restart_script = restart_container["command"][-1]
         self.assertEqual(
             restart_script.split('deployments="', 1)[1].split('"', 1)[0].split(),
             REGISTRY_OVERLAY_RESTART_ORDER,


### PR DESCRIPTION
## Outcome

Make the generated registry-overlay PostSync Job's pinned `alpine/k8s` container usable under its existing non-root/read-only security context.

- set `HOME=/tmp`;
- mount a dedicated `emptyDir` at `/tmp`;
- require the writable non-root home in both the complete render gate and unit contract.

## Live root cause

The first correct Helm-rendered sync at `e158459` created fresh Job `registry-overlay-restart-e158459-postsync-1784704991`, proving CES-538's omission fix. The Job failed closed during the first API capture before restarting any consumer:

```text
The connection to the server localhost:8080 was refused
[registry-overlay-restart] deployment=agent-control-plane phase=capture result=failed reason=api-error
```

The pinned image bakes `HOME=/root`, while the container runs as UID 65534 with a read-only root filesystem. Kubectl could not use its default home and fell back to localhost instead of the projected in-cluster ServiceAccount configuration.

## Safety

The fix does not broaden RBAC, change restart targets/order/deadlines, retry the failed Job, mutate credentials, or change registry data. The failed live Job restarted zero consumers and remains retained for diagnosis.

## Validation

- Python 3.11.13: 162/162 tests passed;
- exact Helm/Kustomize complete Application render passed;
- Helm 3.14.0 lint passed (expected generateName warning only);
- kubeconform 0.6.7 strict: both default and production renders 5/5 valid;
- `git diff --check` passed.

All hosted checks must pass on this exact head before merge and a new full overlay sync.

Follow-up to #437 and #436. Linear: CES-572, CES-538