### PR TITLE
CES-572: fix in-cluster API discovery for registry hook

### DIFF
--- a/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
@@ -32,11 +32,17 @@ spec:
           # snapshot; an overlay sync without a rollout leaves stale authority.
           image: alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
           # The image defaults HOME to /root, but this container runs as UID
-          # 65534. Give kubectl an accessible home so it falls back to the
-          # projected in-cluster ServiceAccount configuration.
+          # 65534. Give kubectl an accessible home and explicitly identify the
+          # stable in-cluster API endpoint. Some clusters omit the legacy
+          # KUBERNETES_SERVICE_* environment variables even though the
+          # projected ServiceAccount token and CA are mounted correctly.
           env:
             - name: HOME
               value: /tmp
+            - name: KUBERNETES_SERVICE_HOST
+              value: kubernetes.default.svc
+            - name: KUBERNETES_SERVICE_PORT
+              value: "443"
           command:
             - /bin/sh
             - -ec

--- a/scripts/check_agent_control_plane_registry_overlay_render.py
+++ b/scripts/check_agent_control_plane_registry_overlay_render.py
@@ -287,10 +287,15 @@ def _assert_complete_application_resources(documents: list[dict[str, Any]]) -> N
             "generated PostSync Job must contain exactly one container"
         )
     restart_container = containers[0]
-    expected_env = [{"name": "HOME", "value": "/tmp"}]
+    expected_env = [
+        {"name": "HOME", "value": "/tmp"},
+        {"name": "KUBERNETES_SERVICE_HOST", "value": "kubernetes.default.svc"},
+        {"name": "KUBERNETES_SERVICE_PORT", "value": "443"},
+    ]
     if restart_container.get("env") != expected_env:
         raise RegistryOverlayRenderError(
-            "generated PostSync Job must give non-root kubectl an accessible HOME:\n"
+            "generated PostSync Job must give non-root kubectl an accessible HOME "
+            "and explicit in-cluster API endpoint:\n"
             + _json_diff(expected_env, restart_container.get("env"))
         )
     expected_mounts = [{"name": "tmp", "mountPath": "/tmp"}]

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -337,7 +337,14 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         restart_container = pod_spec["containers"][0]
         self.assertEqual(
             restart_container["env"],
-            [{"name": "HOME", "value": "/tmp"}],
+            [
+                {"name": "HOME", "value": "/tmp"},
+                {
+                    "name": "KUBERNETES_SERVICE_HOST",
+                    "value": "kubernetes.default.svc",
+                },
+                {"name": "KUBERNETES_SERVICE_PORT", "value": "443"},
+            ],
         )
         self.assertEqual(
             restart_container["volumeMounts"],


### PR DESCRIPTION
## Summary

- set the stable in-cluster Kubernetes API DNS endpoint explicitly for the registry-overlay PostSync hook
- retain the projected ServiceAccount token/CA and non-root read-only runtime
- enforce the exact environment in unit and complete-render contract tests

## Live diagnosis

A temporary pod using the exact hook image, ServiceAccount, UID, and security context had a valid projected token/CA but no `KUBERNETES_SERVICE_HOST` or `KUBERNETES_SERVICE_PORT`, causing kubectl to fall back to `localhost:8080`. Supplying `kubernetes.default.svc:443` made `kubectl auth can-i list pods` and pod listing succeed with the projected credentials.

## Validation

- 162 Python contract tests
- complete registry-overlay Helm Application render contract
- Helm lint
- strict kubeconform: 5/5 resources valid

Follow-up to #437 and #438.