### PR TITLE
CES-572: preserve hook authentication across deadlines

### DIFF
--- a/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
+++ b/apps/agent-control-plane-registry-overlay/templates/restart-hook.yaml
@@ -88,7 +88,11 @@ spec:
                   return 1
                 fi
 
-                if kubectl --request-timeout="${remaining_seconds}s" "$@"; then
+                # alpine/k8s 1.33.4 loses its in-cluster client configuration
+                # when kubectl's native request-timeout flag is set. Keep the
+                # same hard deadline outside kubectl so projected
+                # ServiceAccount auth is retained.
+                if timeout "${remaining_seconds}s" kubectl "$@"; then
                   return 0
                 else
                   kubectl_status="$?"

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -433,12 +433,10 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         result, calls = self._run_restart_script()
         self.assertEqual(result.returncode, 0, result.stderr)
         expected_calls = []
-        request_timeout = "--request-timeout=1s "
         for deployment in REGISTRY_OVERLAY_RESTART_ORDER:
             component = REGISTRY_OVERLAY_COMPONENTS[deployment]
             pod_list = (
-                request_timeout
-                + "-n agent-control-plane get pods -l "
+                "-n agent-control-plane get pods -l "
                 "app.kubernetes.io/name=agent-control-plane,"
                 "app.kubernetes.io/instance=agent-control-plane,"
                 f"app.kubernetes.io/component={component} -o "
@@ -448,13 +446,11 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
                 [
                     pod_list,
                     (
-                        request_timeout
-                        + "-n agent-control-plane rollout restart "
+                        "-n agent-control-plane rollout restart "
                         f"deployment/{deployment}"
                     ),
                     (
-                        request_timeout
-                        + "-n agent-control-plane get "
+                        "-n agent-control-plane get "
                         f"deployment/{deployment} -o "
                         "jsonpath={.metadata.generation}|"
                         "{.status.observedGeneration}|{.spec.replicas}|"
@@ -474,6 +470,8 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
             '"$old_pods" "$deadline"',
             restart_script,
         )
+        self.assertIn('timeout "${remaining_seconds}s" kubectl "$@"', restart_script)
+        self.assertNotIn("--request-timeout=", restart_script)
         self.assertEqual(
             restart_script.count(
                 'deadline="$(( $(date +%s) + rollout_timeout_seconds ))"'
@@ -519,8 +517,7 @@ class AgentControlPlaneRegistryOverlayTests(unittest.TestCase):
         )
         self.assertTrue(
             any(
-                call.startswith("--request-timeout=1s ")
-                and "app.kubernetes.io/component=model-gateway" in call
+                "app.kubernetes.io/component=model-gateway" in call
                 for call in calls
             )
         )
@@ -578,16 +575,6 @@ fi
             fake_kubectl.write_text(
                 """#!/bin/sh
 printf '%s\\n' "$*" >> "$KUBECTL_LOG"
-case "$1" in
-  --request-timeout=*s)
-    request_timeout_seconds="${1#--request-timeout=}"
-    request_timeout_seconds="${request_timeout_seconds%s}"
-    shift
-    ;;
-  *)
-    exit 65
-    ;;
-esac
 case "$3" in
   rollout)
     deployment="${5#deployment/}"
@@ -618,8 +605,8 @@ case "$3" in
         fi
         if [ "$component" = "$HANG_CAPTURE_COMPONENT" ] \
           && [ "$pod_list_count" -eq 0 ]; then
-          sleep "$request_timeout_seconds"
-          : > "$DEADLINE_EXPIRED_FILE"
+          trap ': > "$DEADLINE_EXPIRED_FILE"; exit 28' TERM
+          sleep 5
           exit 28
         fi
         pod_list_count="$((pod_list_count + 1))"


### PR DESCRIPTION
## Summary

- replace kubectl's native `--request-timeout` flag with the pinned image's BusyBox `timeout`
- preserve the existing per-deployment hard deadline without altering RBAC or projected ServiceAccount credentials
- add a regression assertion that the native request-timeout flag cannot return

## Live diagnosis

Using the exact pinned image, ServiceAccount, UID, and security context:

- `kubectl get pods ...` authenticated successfully in-cluster
- `kubectl --request-timeout=240s get pods ...` fell back to `localhost:8080`
- `timeout 240s kubectl get pods ...` authenticated successfully

That reproduces the e4202f9 hook failure and validates this correction directly.

## Validation

- 162 Python contract tests
- 22 focused overlay/restart tests
- complete registry-overlay Helm Application render contract
- Helm lint
- strict kubeconform: 5/5 resources valid

Follow-up to #439.