### PR TITLE
[CES-573] Canary projected identity for workspace probe

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -12,6 +12,7 @@ imports:
     execution_posture: capability_worker
     network_access: database_only
     service_account_ref: agent-workloads-worker
+    service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
     identity_audience: mandate-api
     capacity_tier: 4
     concurrency: 1

--- a/apps/agent-control-plane-runtime-controls/tokenreview-rbac.yaml
+++ b/apps/agent-control-plane-runtime-controls/tokenreview-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-control-plane-tokenreview
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: api-tokenreview
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-control-plane-tokenreview
+  labels:
+    app.kubernetes.io/name: agent-control-plane
+    app.kubernetes.io/component: api-tokenreview
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-control-plane-tokenreview
+subjects:
+  - kind: ServiceAccount
+    name: agent-control-plane-tokenreview
+    namespace: agent-control-plane

--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -8,6 +8,22 @@ fullnameOverride: agent-control-plane
 
 replicaCount: 1
 
+apiServiceAccount:
+  create: true
+  name: agent-control-plane-tokenreview
+  automountServiceAccountToken: false
+  annotations: {}
+
+workloadIdentity:
+  kubernetesTokenReview:
+    enabled: true
+    apiServerUrl: https://kubernetes.default.svc
+    reviewerTokenAudience: ""
+    tokenMountPath: /var/run/mandate/tokenreview/token
+    caMountPath: /var/run/mandate/tokenreview/ca.crt
+    tokenExpirationSeconds: 3600
+    timeoutSeconds: 5.0
+
 apiPodAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "9090"
@@ -55,7 +71,7 @@ env:
   AGENT_PLATFORM_MODEL_GATEWAY_TIMEOUT_SECONDS: "90"
   AGENT_PLATFORM_MODEL_GATEWAY_KILL_SWITCH_FILE: /app/model-gateway-controls/kill-switch
   AGENT_PLATFORM_MODEL_GATEWAY_REVOCATION_FILE: /app/model-gateway-controls/revocations.txt
-  AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE: hmac
+  AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE: kubernetes_hybrid
   AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER: kubernetes
   AGENT_PLATFORM_WORKLOAD_IDENTITY_AUDIENCE: mandate-api
   AGENT_PLATFORM_WORKLOAD_IDENTITY_REQUIRED_SCOPES: worker_service

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -10,11 +10,23 @@ image:
   tag: sha-51102759737c
   digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
   pullPolicy: IfNotPresent
+projectedWorkloadIdentity:
+  enabled: true
+  workerId: data.workspace_probe
+  serviceAccountNamePrefix: agent-workloads
+  serviceAccount:
+    create: true
+    annotations: {}
+  token:
+    audience: mandate-api
+    expirationSeconds: 3600
+    mountPath: /var/run/mandate/workload-identity
+    fileName: token
+  previousRelease: null
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
   AGENT_WORKLOADS_WORKER_ID: data.workspace_probe
   AGENT_WORKLOADS_WORKER_CAPABILITIES: agent_workloads.db_probe,agent_workloads.readonly_query
-  MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE: /var/run/mandate/workload-identity/token
   AGENT_WORKLOADS_ENVIRONMENT: production
   AGENT_WORKLOADS_SCHEMA: agent_workloads
   AGENT_WORKLOADS_POLL_SECONDS: '2'
@@ -26,17 +38,6 @@ env:
 secretKeys:
 - AGENT_WORKLOADS_DATABASE_URL
 secretEnv: {}
-extraVolumes:
-- name: workload-identity-token
-  secret:
-    secretName: agent-workloads-workload-identity-tokens
-    items:
-    - key: MANDATE_WORKLOAD_IDENTITY_TOKEN
-      path: token
-extraVolumeMounts:
-- name: workload-identity-token
-  mountPath: /var/run/mandate/workload-identity
-  readOnly: true
 rolloutChecksums:
   workloadIdentityTokenSecret: sha256:11af48d70445c45732fb09cf141c083ba82df8bc79aa1da8c84c2f493473ce9f
 resources:

--- a/docs/ces-573-projected-workload-identity-canary.md
+++ b/docs/ces-573-projected-workload-identity-canary.md
@@ -1,0 +1,74 @@
+# CES-573 projected workload identity canary
+
+This change canaries Kubernetes-native workload identity for
+`data.workspace_probe`. It removes the per-release HMAC/SOPS mint from that
+worker's normal re-pin path while preserving the existing HMAC credential,
+ciphertext, metadata, and rollout checksum as an unchanged rollback input.
+OpenCode proposer and apply remain distinct HMAC identities.
+
+## Security boundary
+
+- Kubernetes TokenReview authenticates the exact projected ServiceAccount
+  subject and the `mandate-api` audience.
+- The reviewed registry maps that subject to one immutable
+  code/manifest/image release tuple; worker-requested names or digests do not
+  authorize a release.
+- The reviewed GitOps merge and ordered manual Argo sync remain the operator
+  authorization events.
+- This phase does not recompute runtime workflow digests or attest
+  source-to-image integrity. That remains CES-576.
+
+The immutable inputs for this canary are:
+
+- Core: `5efddce6841756aa8f5b4f770cc9a64c17bcd68e`
+- agent-workloads: `51102759737c5e9a1c0d95adf1ae299a12e3cae1`
+- `data.workspace_probe` code:
+  `sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02`
+- manifest:
+  `sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f`
+- image:
+  `sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed`
+- ServiceAccount subject:
+  `system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3`
+
+## Operator sequence
+
+All affected Argo applications are manual-sync. After review and merge:
+
+1. Sync `agent-control-plane` first. Confirm the dedicated
+   `agent-control-plane-tokenreview` ServiceAccount has only
+   `authentication.k8s.io/tokenreviews/create`, the API becomes healthy, and
+   non-API control-plane pods do not receive the reviewer token.
+2. Sync `agent-control-plane-registry-overlay`. Wait for the registry restart
+   hook and confirm Core has loaded the exact ServiceAccount subject and release
+   tuple above.
+3. Sync `agent-workloads`. Confirm the workspace-probe Deployment uses the
+   release-scoped ServiceAccount, has no legacy token Secret volume, and
+   projects only the `mandate-api` token.
+4. Run a workspace-probe claim through completion. Confirm the
+   workload-identity metric records `mode=kubernetes,outcome=accepted` and that
+   no HMAC mint command or SOPS edit occurred.
+5. Replace the projected token file atomically while the worker remains
+   running, then prove a later request succeeds with the rotated token.
+6. Exercise wrong subject, wrong worker, wrong audience, expired token,
+   ambiguous subject, and TokenReview unavailable/error cases; each must fail
+   closed without an HMAC retry.
+
+Do not migrate another worker or remove the rollback credential until this
+canary is accepted.
+
+## Rollback
+
+If the Core substrate is unhealthy, revert its values to `hmac`, disable
+`workloadIdentity.kubernetesTokenReview`, and remove the dedicated RBAC in one
+reviewed GitOps change.
+
+If only the worker canary is unhealthy, leave Core in hybrid mode, remove the
+workspace-probe `service_account_subject` registry binding, disable
+`projectedWorkloadIdentity`, and restore the existing read-only Secret volume
+and `MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE`. The retained HMAC ciphertext,
+metadata, checksum, and release tuple must remain unchanged. Never mount static
+and projected credentials into the same worker.
+
+No merge, sync, production cutover, HMAC rotation, legacy-secret deletion, or
+CES-576 runtime-attestation implementation is authorized by this document.

--- a/scripts/check_agent_workloads_identity_digests.py
+++ b/scripts/check_agent_workloads_identity_digests.py
@@ -131,6 +131,12 @@ def check_agent_workloads_identity_digests(
             values,
             release_pins[agent_id],
         )
+    _assert_workspace_release_subject_binding(
+        values=values,
+        overlay_pins=overlay_pins,
+        overlay_imports=overlay_imports,
+        workload_namespace=workload_namespace,
+    )
     _assert_opencode_release_subject_bindings(
         values=values,
         overlay_pins=overlay_pins,
@@ -228,6 +234,118 @@ def _load_overlay_release_state(
             "imageDigest": image_digest,
         }
     return pins, imports_by_id
+
+
+def _assert_workspace_release_subject_binding(
+    *,
+    values: dict[str, Any],
+    overlay_pins: dict[str, dict[str, str]],
+    overlay_imports: dict[str, dict[str, Any]],
+    workload_namespace: str,
+) -> None:
+    agent_id = "data.workspace_probe"
+    identity = values.get("projectedWorkloadIdentity")
+    import_entry = overlay_imports[agent_id]
+    agent = import_entry.get("agent")
+    actual_subject = agent.get("service_account_subject") if isinstance(agent, dict) else None
+    imported_previous = agent.get("previous_release") if isinstance(agent, dict) else None
+
+    if not isinstance(identity, dict) or identity.get("enabled") is not True:
+        if actual_subject is not None or imported_previous is not None:
+            raise DriftGateError(
+                "data.workspace_probe HMAC identity must not declare projected release subjects"
+            )
+        return
+    if not isinstance(workload_namespace, str) or not workload_namespace.strip():
+        raise DriftGateError("workload namespace must be non-empty")
+    if not isinstance(agent, dict):
+        raise DriftGateError("data.workspace_probe import agent must be a mapping")
+
+    worker_id = _required_str(
+        identity,
+        "workerId",
+        "projectedWorkloadIdentity",
+    )
+    if worker_id != agent_id:
+        raise DriftGateError(
+            "projectedWorkloadIdentity.workerId must equal data.workspace_probe"
+        )
+    prefix = _required_str(
+        identity,
+        "serviceAccountNamePrefix",
+        "projectedWorkloadIdentity",
+    )
+    current_subject = _release_service_account_subject(
+        namespace=workload_namespace,
+        prefix=prefix,
+        worker_id=agent_id,
+        release=overlay_pins[agent_id],
+    )
+    if actual_subject != current_subject:
+        raise DriftGateError(
+            "data.workspace_probe service_account_subject differs from projected render: "
+            f"expected {current_subject}, got {actual_subject}"
+        )
+
+    token = _required_mapping(
+        identity,
+        "token",
+        "projectedWorkloadIdentity",
+    )
+    expected_audience = _required_str(
+        token,
+        "audience",
+        "projectedWorkloadIdentity.token",
+    )
+    if agent.get("identity_audience") != expected_audience:
+        raise DriftGateError(
+            "data.workspace_probe identity_audience differs from projected render: "
+            f"expected {expected_audience}, got {agent.get('identity_audience')}"
+        )
+
+    configured_previous = identity.get("previousRelease")
+    if configured_previous is None:
+        if imported_previous is not None:
+            raise DriftGateError(
+                "data.workspace_probe registry previous_release is not rendered by Helm values"
+            )
+        return
+    if not isinstance(configured_previous, dict):
+        raise DriftGateError(
+            "projectedWorkloadIdentity.previousRelease must be a mapping"
+        )
+    if not isinstance(imported_previous, dict):
+        raise DriftGateError(
+            "data.workspace_probe registry previous_release is required for rollout overlap"
+        )
+    previous_subject = _release_service_account_subject(
+        namespace=workload_namespace,
+        prefix=prefix,
+        worker_id=agent_id,
+        release=configured_previous,
+    )
+    expected_previous = {
+        "service_account_subject": previous_subject,
+        "code_digest": _required_str(
+            configured_previous,
+            "codeDigest",
+            "projectedWorkloadIdentity.previousRelease",
+        ),
+        "manifest_digest": _required_str(
+            configured_previous,
+            "manifestDigest",
+            "projectedWorkloadIdentity.previousRelease",
+        ),
+        "image_digest": _required_str(
+            configured_previous,
+            "imageDigest",
+            "projectedWorkloadIdentity.previousRelease",
+        ),
+    }
+    if imported_previous != expected_previous:
+        raise DriftGateError(
+            "data.workspace_probe registry previous_release differs from projected render"
+        )
 
 
 def _assert_opencode_release_subject_bindings(
@@ -375,6 +493,34 @@ def _retained_hmac_release_pins(
         agent_id: dict(release)
         for agent_id, release in overlay_pins.items()
     }
+    workspace_identity = values.get("projectedWorkloadIdentity")
+    if (
+        isinstance(workspace_identity, dict)
+        and workspace_identity.get("enabled") is True
+    ):
+        previous_release = workspace_identity.get("previousRelease")
+        if previous_release is not None:
+            if not isinstance(previous_release, dict):
+                raise DriftGateError(
+                    "projectedWorkloadIdentity.previousRelease must be a mapping"
+                )
+            retained_pins["data.workspace_probe"] = {
+                "codeDigest": _required_str(
+                    previous_release,
+                    "codeDigest",
+                    "projectedWorkloadIdentity.previousRelease",
+                ),
+                "manifestDigest": _required_str(
+                    previous_release,
+                    "manifestDigest",
+                    "projectedWorkloadIdentity.previousRelease",
+                ),
+                "imageDigest": _required_str(
+                    previous_release,
+                    "imageDigest",
+                    "projectedWorkloadIdentity.previousRelease",
+                ),
+            }
     handoff = values.get("opencodeArtifactHandoff")
     if not isinstance(handoff, dict) or handoff.get("mode") != "governedCore":
         return retained_pins

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -371,6 +371,7 @@ data:
         execution_posture: capability_worker
         network_access: database_only
         service_account_ref: agent-workloads-worker
+        service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
         identity_audience: mandate-api
         capacity_tier: 4
         concurrency: 1

--- a/tests/test_agent_control_plane_postgres_sweep.py
+++ b/tests/test_agent_control_plane_postgres_sweep.py
@@ -98,13 +98,17 @@ class AgentControlPlanePostgresSweepTests(unittest.TestCase):
 
         for name in (
             "AGENT_PLATFORM_ENVIRONMENT",
-            "AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE",
             "AGENT_PLATFORM_WORKLOAD_IDENTITY_ISSUER",
             "AGENT_PLATFORM_WORKLOAD_IDENTITY_AUDIENCE",
             "AGENT_PLATFORM_WORKLOAD_IDENTITY_REQUIRED_SCOPES",
             "AGENT_PLATFORM_WORKLOAD_IDENTITY_ALLOWED_SUBJECTS_JSON",
         ):
             self.assertEqual(env[name], self.values["env"][name])
+        self.assertEqual(env["AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE"], "hmac")
+        self.assertEqual(
+            self.values["env"]["AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE"],
+            "kubernetes_hybrid",
+        )
 
     def test_cronjob_is_non_root_and_covered_by_control_plane_egress(self) -> None:
         pod_spec = _pod_spec(self.cronjob)

--- a/tests/test_agent_workloads_identity_digests.py
+++ b/tests/test_agent_workloads_identity_digests.py
@@ -188,6 +188,65 @@ class AgentWorkloadsIdentityDigestGateTests(unittest.TestCase):
 
         self.assertIn("match release pins", result)
 
+    def test_gate_accepts_workspace_projected_subject_with_current_hmac_rollback(
+        self,
+    ) -> None:
+        root = _fixture_repo()
+        _configure_workspace_projected_identity(root)
+
+        result = _check(root)
+
+        self.assertIn("retained rollback tuples", result)
+
+    def test_gate_rejects_workspace_projected_subject_drift(self) -> None:
+        root = _fixture_repo()
+        _configure_workspace_projected_identity(root)
+        configmap_path = (
+            root
+            / "apps"
+            / "agent-control-plane-registry-overlay"
+            / "configmap.yaml"
+        )
+        configmap = YAML_PARSER.load(configmap_path.read_text())
+        imports = YAML_PARSER.load(configmap["data"]["workload_imports.yaml"])
+        workspace = next(
+            entry for entry in imports["imports"] if entry["id"] == "data.workspace_probe"
+        )
+        workspace["agent"]["service_account_subject"] = (
+            "system:serviceaccount:agent-workloads:wrong-release"
+        )
+        configmap["data"]["workload_imports.yaml"] = _yaml_text(imports)
+        _write_yaml(configmap_path, configmap)
+
+        with self.assertRaisesRegex(
+            DriftGateError,
+            "service_account_subject differs from projected render",
+        ):
+            _check(root)
+
+    def test_gate_accepts_workspace_previous_tuple_hmac_during_projected_overlap(
+        self,
+    ) -> None:
+        previous_release = {
+            "codeDigest": "sha256:" + "4" * 64,
+            "manifestDigest": "sha256:" + "5" * 64,
+            "imageDigest": "sha256:" + "6" * 64,
+        }
+        root = _fixture_repo()
+        _configure_workspace_projected_identity(
+            root,
+            previous_release=previous_release,
+        )
+        _configure_retained_hmac_token(
+            root,
+            agent_id="data.workspace_probe",
+            release=previous_release,
+        )
+
+        result = _check(root)
+
+        self.assertIn("retained rollback tuples", result)
+
     def test_gate_accepts_previous_tuple_hmac_during_projected_overlap(self) -> None:
         previous_release = {
             "codeDigest": "sha256:" + "4" * 64,
@@ -642,6 +701,51 @@ def _configure_governed_release_subjects(
                 "manifest_digest": previous["manifestDigest"],
                 "image_digest": previous["imageDigest"],
             }
+    configmap["data"]["workload_imports.yaml"] = _yaml_text(imports)
+    _write_yaml(configmap_path, configmap)
+
+
+def _configure_workspace_projected_identity(
+    root: Path,
+    *,
+    previous_release: dict[str, str] | None = None,
+) -> None:
+    agent_id = "data.workspace_probe"
+    values_path = root / "apps" / "agent-workloads" / "values.yaml"
+    values = YAML_PARSER.load(values_path.read_text())
+    values["projectedWorkloadIdentity"] = {
+        "enabled": True,
+        "workerId": agent_id,
+        "serviceAccountNamePrefix": "agent-workloads",
+        "token": {"audience": "mandate-api"},
+        "previousRelease": previous_release,
+    }
+    _write_yaml(values_path, values)
+
+    configmap_path = (
+        root / "apps" / "agent-control-plane-registry-overlay" / "configmap.yaml"
+    )
+    configmap = YAML_PARSER.load(configmap_path.read_text())
+    imports = YAML_PARSER.load(configmap["data"]["workload_imports.yaml"])
+    workspace = next(
+        entry for entry in imports["imports"] if entry["id"] == agent_id
+    )
+    agent = workspace.setdefault("agent", {})
+    agent["identity_audience"] = "mandate-api"
+    agent["service_account_subject"] = _release_subject(
+        agent_id,
+        DIGESTS[agent_id],
+    )
+    if previous_release is not None:
+        agent["previous_release"] = {
+            "service_account_subject": _release_subject(
+                agent_id,
+                previous_release,
+            ),
+            "code_digest": previous_release["codeDigest"],
+            "manifest_digest": previous_release["manifestDigest"],
+            "image_digest": previous_release["imageDigest"],
+        }
     configmap["data"]["workload_imports.yaml"] = _yaml_text(imports)
     _write_yaml(configmap_path, configmap)
 

--- a/tests/test_agent_workloads_networkpolicy.py
+++ b/tests/test_agent_workloads_networkpolicy.py
@@ -131,7 +131,7 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
         self.assertIn((53, "UDP"), ports)
         self.assertIn((53, "TCP"), ports)
 
-    def test_workspace_probe_workload_identity_uses_dedicated_token_secret(self) -> None:
+    def test_workspace_probe_workload_identity_uses_projected_token(self) -> None:
         deployment = _find_doc(
             self.docs,
             kind="Deployment",
@@ -142,15 +142,19 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
             for volume in deployment["spec"]["template"]["spec"]["volumes"]
         }
 
-        token_volume = volumes["workload-identity-token"]["secret"]
+        self.assertNotIn("workload-identity-token", volumes)
+        token_volume = volumes["projected-workload-identity-token"]["projected"]
         self.assertEqual(
             token_volume,
             {
-                "secretName": "agent-workloads-workload-identity-tokens",
-                "items": [
+                "defaultMode": 0o440,
+                "sources": [
                     {
-                        "key": "MANDATE_WORKLOAD_IDENTITY_TOKEN",
-                        "path": "token",
+                        "serviceAccountToken": {
+                            "audience": "mandate-api",
+                            "expirationSeconds": 3600,
+                            "path": "token",
+                        }
                     }
                 ],
             },
@@ -187,12 +191,26 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
         ]
         expected_release_checksum = _release_pins_checksum(self.values)
 
-        for deployment in deployments.values():
-            annotations = deployment["spec"]["template"]["metadata"]["annotations"]
+        workspace_annotations = deployments["agent-workloads"]["spec"]["template"][
+            "metadata"
+        ]["annotations"]
+        self.assertNotIn(
+            "checksum.garz.ai/agent-workloads-token-secret",
+            workspace_annotations,
+        )
+        for name in (
+            "agent-workloads-opencode-proposer",
+            "agent-workloads-opencode-apply-executor",
+        ):
+            annotations = deployments[name]["spec"]["template"]["metadata"][
+                "annotations"
+            ]
             self.assertEqual(
                 annotations["checksum.garz.ai/agent-workloads-token-secret"],
                 expected_token_checksum,
             )
+        for deployment in deployments.values():
+            annotations = deployment["spec"]["template"]["metadata"]["annotations"]
             self.assertEqual(
                 annotations["checksum.garz.ai/agent-workloads-release-pins"],
                 expected_release_checksum,
@@ -216,11 +234,9 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
             changed_token_annotations = changed_token_deployment["spec"]["template"][
                 "metadata"
             ]["annotations"]
-            self.assertNotEqual(
-                changed_token_annotations[
-                    "checksum.garz.ai/agent-workloads-token-secret"
-                ],
-                expected_token_checksum,
+            self.assertEqual(
+                changed_token_annotations,
+                workspace_annotations,
             )
             self.assertEqual(
                 changed_token_annotations[
@@ -245,11 +261,9 @@ class AgentWorkloadsNetworkPolicyTests(unittest.TestCase):
             changed_pins_annotations = changed_pins_deployment["spec"]["template"][
                 "metadata"
             ]["annotations"]
-            self.assertEqual(
-                changed_pins_annotations[
-                    "checksum.garz.ai/agent-workloads-token-secret"
-                ],
-                expected_token_checksum,
+            self.assertNotIn(
+                "checksum.garz.ai/agent-workloads-token-secret",
+                changed_pins_annotations,
             )
             self.assertNotEqual(
                 changed_pins_annotations[

--- a/tests/test_agent_workloads_projected_identity_chart.py
+++ b/tests/test_agent_workloads_projected_identity_chart.py
@@ -118,7 +118,19 @@ def _opencode_service_account_name(
     worker_id: str,
     worker_key: str,
 ) -> str:
-    release = values["mandateReleasePins"][worker_id]
+    return _release_service_account_name(
+        worker_id,
+        values["mandateReleasePins"][worker_id],
+        prefix=values[worker_key]["identity"]["serviceAccountNamePrefix"],
+    )
+
+
+def _release_service_account_name(
+    worker_id: str,
+    release: dict[str, str],
+    *,
+    prefix: str,
+) -> str:
     payload = {
         "schema_version": "workload_identity_bundle.v1",
         "code_digest": release["codeDigest"],
@@ -128,7 +140,6 @@ def _opencode_service_account_name(
     suffix = hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     ).hexdigest()[:20]
-    prefix = values[worker_key]["identity"]["serviceAccountNamePrefix"]
     normalized_worker = worker_id.replace(".", "-").replace("_", "-")
     return f"{prefix}-{normalized_worker}-{suffix}"
 
@@ -160,12 +171,12 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
             CURRENT_RELEASE
         )
         values["image"]["digest"] = CURRENT_RELEASE["imageDigest"]
-        values["env"].pop("MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE")
+        values["env"].pop("MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE", None)
         values["extraVolumes"] = []
         values["extraVolumeMounts"] = []
         return values
 
-    def test_production_values_render_workspace_hmac_and_opencode_canary(
+    def test_production_values_render_workspace_projected_and_opencode_hmac(
         self,
     ) -> None:
         documents = _render()
@@ -176,12 +187,31 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
         )
         worker_pod = worker["spec"]["template"]["spec"]
         worker_volumes = {volume["name"]: volume for volume in worker_pod["volumes"]}
+        workspace_account = _release_service_account_name(
+            "data.workspace_probe",
+            self.production_values["mandateReleasePins"]["data.workspace_probe"],
+            prefix=self.production_values["projectedWorkloadIdentity"][
+                "serviceAccountNamePrefix"
+            ],
+        )
 
         self.assertIs(worker_pod["automountServiceAccountToken"], False)
-        self.assertEqual(worker_pod["serviceAccountName"], "agent-workloads")
+        self.assertEqual(worker_pod["serviceAccountName"], workspace_account)
+        self.assertNotIn("workload-identity-token", worker_volumes)
         self.assertEqual(
-            worker_volumes["workload-identity-token"]["secret"]["secretName"],
-            "agent-workloads-workload-identity-tokens",
+            worker_volumes["projected-workload-identity-token"]["projected"],
+            {
+                "defaultMode": 0o440,
+                "sources": [
+                    {
+                        "serviceAccountToken": {
+                            "audience": "mandate-api",
+                            "expirationSeconds": 3600,
+                            "path": "token",
+                        }
+                    }
+                ],
+            },
         )
         self.assertEqual(
             _environment(_container(worker, "worker"))[
@@ -189,7 +219,7 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
             ]["value"],
             "/var/run/mandate/workload-identity/token",
         )
-        self.assertIn(
+        self.assertNotIn(
             "checksum.garz.ai/agent-workloads-token-secret",
             worker["spec"]["template"]["metadata"]["annotations"],
         )
@@ -212,7 +242,7 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
         }
         self.assertEqual(
             {account["metadata"]["name"] for account in service_accounts},
-            {"agent-workloads", *opencode_accounts.values()},
+            {"agent-workloads", workspace_account, *opencode_accounts.values()},
         )
 
         for worker_id, deployment_name, container_name in (

--- a/tests/test_agent_workloads_tokenreview_canary.py
+++ b/tests/test_agent_workloads_tokenreview_canary.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+YAML_PARSER = YAML(typ="safe")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    value = YAML_PARSER.load(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"{path} must contain a mapping")
+    return value
+
+
+def _workspace_service_account_subject(values: dict[str, Any]) -> str:
+    worker_id = "data.workspace_probe"
+    release = values["mandateReleasePins"][worker_id]
+    payload = {
+        "schema_version": "workload_identity_bundle.v1",
+        "code_digest": release["codeDigest"],
+        "manifest_digest": release["manifestDigest"],
+        "image_digest": release["imageDigest"],
+    }
+    suffix = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:20]
+    return (
+        "system:serviceaccount:agent-workloads:"
+        f"agent-workloads-data-workspace-probe-{suffix}"
+    )
+
+
+class AgentWorkloadsTokenReviewCanaryTests(unittest.TestCase):
+    def test_core_tokenreview_substrate_is_api_only_and_fail_closed(self) -> None:
+        values = _load_yaml(
+            REPO_ROOT / "apps" / "agent-control-plane" / "values.yaml"
+        )
+        reviewer = values["workloadIdentity"]["kubernetesTokenReview"]
+        api_account = values["apiServiceAccount"]
+
+        self.assertEqual(
+            values["env"]["AGENT_PLATFORM_WORKLOAD_IDENTITY_MODE"],
+            "kubernetes_hybrid",
+        )
+        self.assertEqual(
+            reviewer,
+            {
+                "enabled": True,
+                "apiServerUrl": "https://kubernetes.default.svc",
+                "reviewerTokenAudience": "",
+                "tokenMountPath": "/var/run/mandate/tokenreview/token",
+                "caMountPath": "/var/run/mandate/tokenreview/ca.crt",
+                "tokenExpirationSeconds": 3600,
+                "timeoutSeconds": 5.0,
+            },
+        )
+        self.assertEqual(
+            api_account,
+            {
+                "create": True,
+                "name": "agent-control-plane-tokenreview",
+                "automountServiceAccountToken": False,
+                "annotations": {},
+            },
+        )
+
+    def test_tokenreview_rbac_grants_only_create_to_api_service_account(
+        self,
+    ) -> None:
+        documents = [
+            document
+            for document in YAML_PARSER.load_all(
+                (
+                    REPO_ROOT
+                    / "apps"
+                    / "agent-control-plane-runtime-controls"
+                    / "tokenreview-rbac.yaml"
+                ).read_text(encoding="utf-8")
+            )
+            if isinstance(document, dict)
+        ]
+        role = next(
+            document for document in documents if document["kind"] == "ClusterRole"
+        )
+        binding = next(
+            document
+            for document in documents
+            if document["kind"] == "ClusterRoleBinding"
+        )
+
+        self.assertEqual(
+            role["rules"],
+            [
+                {
+                    "apiGroups": ["authentication.k8s.io"],
+                    "resources": ["tokenreviews"],
+                    "verbs": ["create"],
+                }
+            ],
+        )
+        self.assertEqual(
+            binding["roleRef"],
+            {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "agent-control-plane-tokenreview",
+            },
+        )
+        self.assertEqual(
+            binding["subjects"],
+            [
+                {
+                    "kind": "ServiceAccount",
+                    "name": "agent-control-plane-tokenreview",
+                    "namespace": "agent-control-plane",
+                }
+            ],
+        )
+
+    def test_workspace_subject_matches_release_and_retains_hmac_rollback(
+        self,
+    ) -> None:
+        values = _load_yaml(
+            REPO_ROOT / "apps" / "agent-workloads" / "values.yaml"
+        )
+        imports = _load_yaml(
+            REPO_ROOT
+            / "apps"
+            / "agent-control-plane-registry-overlay"
+            / "registry"
+            / "workload_imports.yaml"
+        )
+        workspace = next(
+            entry
+            for entry in imports["imports"]
+            if entry["id"] == "data.workspace_probe"
+        )
+        projected = values["projectedWorkloadIdentity"]
+
+        self.assertIs(projected["enabled"], True)
+        self.assertEqual(projected["workerId"], "data.workspace_probe")
+        self.assertEqual(projected["token"]["audience"], "mandate-api")
+        self.assertIsNone(projected["previousRelease"])
+        self.assertEqual(
+            workspace["agent"]["service_account_subject"],
+            _workspace_service_account_subject(values),
+        )
+        self.assertEqual(
+            workspace["agent"]["identity_audience"],
+            "mandate-api",
+        )
+        self.assertNotIn("previous_release", workspace["agent"])
+
+        self.assertNotIn("MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE", values["env"])
+        self.assertNotIn("extraVolumes", values)
+        self.assertNotIn("extraVolumeMounts", values)
+        self.assertTrue(
+            values["rolloutChecksums"]["workloadIdentityTokenSecret"].startswith(
+                "sha256:"
+            )
+        )
+
+        for key in ("opencodeProposer", "opencodeApplyExecutor"):
+            self.assertEqual(values[key]["identity"]["mode"], "hmac")
+            self.assertTrue(
+                values[key]["secretEnv"]["MANDATE_WORKLOAD_IDENTITY_TOKEN"]
+            )
+
+    def test_affected_argo_applications_remain_manual_sync(self) -> None:
+        for application_name in (
+            "agent-control-plane",
+            "agent-control-plane-registry-overlay",
+            "agent-workloads",
+        ):
+            application = _load_yaml(
+                REPO_ROOT / "argocd" / "applications" / f"{application_name}.yaml"
+            )
+            self.assertNotIn(
+                "automated",
+                application["spec"].get("syncPolicy", {}),
+            )


### PR DESCRIPTION
## Summary

- enable Kubernetes TokenReview on the Mandate API with a dedicated, non-automounted ServiceAccount and `tokenreviews/create`-only RBAC
- move only `data.workspace_probe` to a release-scoped projected ServiceAccount token and bind its exact subject to the reviewed immutable release tuple
- extend identity drift checks for workspace current/previous release subjects while retaining the existing encrypted HMAC material unchanged as rollback input
- add render/contract coverage and an ordered manual-sync, proof, and rollback runbook

## Why

CES-573's merged Core and worker support was not activated in GitOps: production still ran HMAC-only and workspace-probe still mounted a static token Secret. This candidate supplies the missing reviewable canary without starting CES-576 runtime attestation.

## Authorization boundary

**Review-only candidate. Do not merge or sync without explicit operator approval.**

This PR does not delete legacy credentials, edit SOPS ciphertext, rotate an HMAC seed, migrate OpenCode identities, perform a cluster cutover, or claim runtime/source attestation. All affected Argo applications remain manual-sync.

## Validation

- 169 Python contract tests pass
- pinned Core registry compatibility passes at `5efddce6841756aa8f5b4f770cc9a64c17bcd68e`
- grant-ownership and control-plane pin gates pass
- Helm lint/render and kubeconform pass for Core, agent-workloads, registry overlay, and the new TokenReview RBAC
- upstream audit suites pass: Core identity tests (48) and worker identity/client/bridge tests (75)

Hosted broker-backed digest, provider-image, and registry gates must pass on this exact commit before review completes.

## Operator acceptance still required

After explicit merge/sync approval, prove in-cluster that:

- a normal reviewed workspace re-pin reaches `mode=kubernetes,outcome=accepted` with no HMAC mint or SOPS edit
- wrong subject, wrong worker, wrong audience, wrong release, ambiguity, expiry, and TokenReview verifier failures all fail closed without HMAC downgrade
- projected-token rotation succeeds on a later request without restarting the worker
- rollback can restore the retained HMAC path without deleting or rotating credentials

Linear: CES-573