### PR TITLE
CES-49: record rehearsed Postgres restore drill

### DIFF
--- a/docs/runbooks/postgres-restore.md
+++ b/docs/runbooks/postgres-restore.md
@@ -15,7 +15,7 @@ create, fork, delete, or repoint managed database clusters unattended.
 
 ## Current Posture
 
-Observed on 2026-06-24 with read-only `doctl` commands against the `cegarza`
+Observed on 2026-07-23 with read-only `doctl` commands against the `cegarza`
 DigitalOcean context:
 
 | Field | Value |
@@ -27,8 +27,8 @@ DigitalOcean context:
 | Nodes | 1 |
 | Plan | `db-amd-1vcpu-2gb` |
 | Status | online |
-| Latest observed daily backup | `2026-06-24T02:32:18Z` |
-| Observed backup range | `2026-06-17` through `2026-06-24` |
+| Latest observed daily backup | `2026-07-23T02:29:54Z` |
+| Observed backup range | `2026-07-16` through `2026-07-23` |
 | Live namespace | `agent-control-plane` |
 | Live Argo apps | `agent-control-plane`, `agent-control-plane-secrets` |
 | Runtime Kubernetes Secret | `agent-control-plane-secrets` |
@@ -273,9 +273,10 @@ audit hash chain is no longer automatically continuous. The expected behavior is
 | Date | Type | Operator | Restore point | Schema check | `/readyz` | Smoke task | Elapsed RTO | Cleanup |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2026-06-24 | Read-only posture check | Codex via `doctl` | No restore created; confirmed live cluster metadata and daily backups from 2026-06-17 through 2026-06-24. | Not run | Not run | Not run | Not measured | No scratch resource created |
+| 2026-07-23 | Rehearsed isolated PITR scratch restore | Codex with explicit operator approval from Cesar | Latest available PITR from `db-postgresql-nyc3-xscraper`; scratch cluster `mandate-restore-ces49-20260723t074131z` (`e97cbca4-fcc6-41d6-8d99-925702e19260`). | Passed: `mandate-postgres-schema-check` reported migrations current. | Passed on an isolated API copy: `{"ok":true,"environment":"prod"}`. | Passed: `mandate.deploy.smoke` job `job_3e5f312cdb3a4b2bb2340a64e3d2f684` reached `result.released` with accepted/progress/succeeded callbacks. | 21m51s from fork request to completed smoke; target is 4h. | Deleted the scratch database and all labeled temporary Kubernetes Deployments, Service, Secret, Jobs, and NetworkPolicy; production stayed ready and was never repointed. |
 
-Live scratch-restore drill status: pending operator approval. A completed drill
-must add a row above with the scratch cluster name, restore point, schema-check
+Live scratch-restore drill status: completed on 2026-07-23. Future rehearsals
+must add a new row with the scratch cluster name, restore point, schema-check
 result, `/readyz` result, smoke-task result, elapsed RTO, and cleanup outcome.
 
 ## References

--- a/tests/test_postgres_restore_runbook.py
+++ b/tests/test_postgres_restore_runbook.py
@@ -51,8 +51,8 @@ class PostgresRestoreRunbookTests(unittest.TestCase):
         self.assertIn("PostgreSQL 16", self.runbook)
         self.assertIn("nyc3", self.runbook)
         self.assertIn("db-amd-1vcpu-2gb", self.runbook)
-        self.assertIn("2026-06-17", self.runbook)
-        self.assertIn("2026-06-24T02:32:18Z", self.runbook)
+        self.assertIn("2026-07-16", self.runbook)
+        self.assertIn("2026-07-23T02:29:54Z", self.runbook)
 
         self.assertIn(hostname, self.runbook)
         self.assertIn(runtime_secret_name, self.runbook)
@@ -106,12 +106,24 @@ class PostgresRestoreRunbookTests(unittest.TestCase):
         for phrase in required_phrases:
             self.assertIn(phrase, self.normalized)
 
-    def test_runbook_does_not_claim_operator_drill_completed(self) -> None:
+    def test_runbook_records_completed_operator_drill(self) -> None:
         self.assertIn(
-            "Live scratch-restore drill status: pending operator approval",
+            "Live scratch-restore drill status: completed on 2026-07-23",
             self.runbook,
         )
-        self.assertIn("No scratch resource created", self.runbook)
+        self.assertIn(
+            "e97cbca4-fcc6-41d6-8d99-925702e19260",
+            self.runbook,
+        )
+        self.assertIn(
+            "job_3e5f312cdb3a4b2bb2340a64e3d2f684",
+            self.runbook,
+        )
+        self.assertIn("21m51s", self.runbook)
+        self.assertIn(
+            "Deleted the scratch database and all labeled temporary Kubernetes",
+            self.runbook,
+        )
         self.assertIn("Cost-bearing restore drills", self.runbook)
         self.assertIn("must not create, fork, delete, or repoint", self.normalized)
 


### PR DESCRIPTION
## Outcome

Records the completed CES-49 DigitalOcean Postgres scratch-restore rehearsal and refreshes the live backup posture.

## Evidence

- Forked the live managed Postgres cluster to disposable scratch cluster `e97cbca4-fcc6-41d6-8d99-925702e19260`.
- `mandate-postgres-schema-check` passed against the restored database.
- Isolated restored API returned `{"ok":true,"environment":"prod"}` from `/readyz`.
- `mandate.deploy.smoke` job `job_3e5f312cdb3a4b2bb2340a64e3d2f684` succeeded with `result.released`.
- Fork request through completed smoke took 21m51s versus the accepted four-hour RTO.
- All temporary Kubernetes resources and the scratch database were deleted; production was never repointed and remained ready.

## Source changes

- Refreshes the observed backup window through 2026-07-23.
- Adds the rehearsed-drill ledger row.
- Converts the runbook contract test from the old pending-drill assertion to durable evidence assertions.

## Validation

- Python 3.11: `python -m unittest discover -s tests` — 169 passed.
- Focused restore-runbook tests — 4 passed.
- Grant-ownership generation check passed against agent-workloads `51102759737c5e9a1c0d95adf1ae299a12e3cae1`.
- Control-plane release-pin check passed.
- `git diff --check` passed.

## Boundary

This PR records completed evidence only. It changes no secrets, database endpoints, Argo applications, runtime images, or production manifests.