### PR TITLE
CES-574 align readonly synthetic runtime budget

### DIFF
--- a/apps/agent-control-plane/values.yaml
+++ b/apps/agent-control-plane/values.yaml
@@ -310,6 +310,15 @@ postgresSweep:
 syntheticLiveVerify:
   enabled: true
   schedule: "*/5 * * * *"
+  # Journeys run sequentially: 120s + 210s polling, 60s of bounded
+  # control/evidence calls per journey, and 30s of Job startup headroom.
+  # At 480s the chart's Forbid policy skips at most the next five-minute tick.
+  activeDeadlineSeconds: 480
+  # Make the HTTP bound explicit so the deadline budget cannot drift from the
+  # pinned verifier's current default without this values contract changing.
+  args:
+    - --http-timeout-seconds
+    - "15"
   baseUrl: http://agent-control-plane:80
   principal:
     issuer: synthetic
@@ -361,8 +370,9 @@ syntheticLiveVerify:
       capability_id: agent_workloads.readonly_query
       text: Show 3 recent X Power schedule windows from xscraper.schedules.
       max_cost_usd: 1.0
-      max_runtime_seconds: 60
-      timeout_seconds: 180
+      max_runtime_seconds: 180
+      # Keep queueing and result-settlement time outside the requested runtime.
+      timeout_seconds: 210
       poll_seconds: 5
       expected_status: succeeded
       required_result_fields:

--- a/tests/test_agent_control_plane_registry_overlay.py
+++ b/tests/test_agent_control_plane_registry_overlay.py
@@ -39,6 +39,8 @@ REGISTRY_OVERLAY_COMPONENTS = {
 }
 SKILL_BUNDLE_DIR = REPO_ROOT / "apps" / "agent-control-plane-skills"
 YAML_PARSER = YAML(typ="safe")
+SYNTHETIC_LIVE_VERIFY_MIN_SETTLEMENT_MARGIN_SECONDS = 30
+SYNTHETIC_LIVE_VERIFY_JOB_STARTUP_HEADROOM_SECONDS = 30
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -1032,6 +1034,69 @@ exit 64
             ["xscraper-schema", "xscraper-glossary"],
         )
         self.assertIn("tool.started", readonly_query["required_event_types"])
+
+    def test_synthetic_live_verify_runtime_budgets_and_deadline_are_coherent(
+        self,
+    ) -> None:
+        policy = YAML_PARSER.load(self.data["policy.prod.yaml"])
+        defaults = policy["defaults"]
+        synthetic = self.control_plane_values["syntheticLiveVerify"]
+        journey_specs = synthetic["journeys"]
+        journeys = {
+            journey["capability_id"]: journey
+            for journey in journey_specs
+        }
+
+        global_runtime = defaults["max_runtime_seconds_per_job"]
+        readonly_runtime = defaults["max_runtime_seconds_per_capability"][
+            "agent_workloads.readonly_query"
+        ]
+        self.assertEqual(global_runtime, 60)
+        self.assertEqual(
+            journeys["mandate.deploy.smoke"]["max_runtime_seconds"],
+            global_runtime,
+        )
+        self.assertEqual(readonly_runtime, 180)
+        self.assertEqual(
+            journeys["agent_workloads.readonly_query"]["max_runtime_seconds"],
+            readonly_runtime,
+        )
+
+        for journey in journey_specs:
+            self.assertGreaterEqual(
+                journey["timeout_seconds"] - journey["max_runtime_seconds"],
+                SYNTHETIC_LIVE_VERIFY_MIN_SETTLEMENT_MARGIN_SECONDS,
+            )
+        sequential_timeout_budget = sum(
+            journey["timeout_seconds"] for journey in journey_specs
+        )
+
+        args = synthetic["args"]
+        http_timeout_index = args.index("--http-timeout-seconds") + 1
+        http_timeout_seconds = int(args[http_timeout_index])
+        control_evidence_budget = 0
+        for journey in journey_specs:
+            # Submission and one status request can sit outside the journey's
+            # polling deadline. Worker dispatch, callbacks, and audit evidence
+            # each add another bounded request when that stage is configured.
+            bounded_requests = 2
+            bounded_requests += int(journey.get("run_local_worker", False))
+            bounded_requests += int(
+                bool(journey.get("required_callback_types", ("runtime-default",)))
+            )
+            bounded_requests += int(
+                bool(journey.get("required_event_types", ("runtime-default",)))
+            )
+            control_evidence_budget += bounded_requests * http_timeout_seconds
+
+        required_deadline = (
+            sequential_timeout_budget
+            + control_evidence_budget
+            + SYNTHETIC_LIVE_VERIFY_JOB_STARTUP_HEADROOM_SECONDS
+        )
+        active_deadline = synthetic["activeDeadlineSeconds"]
+        self.assertEqual(active_deadline, 480)
+        self.assertGreaterEqual(active_deadline, required_deadline)
 
     def test_prometheus_alerts_on_failed_synthetic_live_verify_job(self) -> None:
         rules_template = (


### PR DESCRIPTION
## Outcome

Aligns the production synthetic readonly-query journey with the existing 180-second capability override without weakening Mandate's fail-closed attenuation.

- request 180 seconds for `agent_workloads.readonly_query` while keeping deployment smoke and the global default at 60 seconds
- allow 210 seconds for readonly queueing and result settlement
- make the verifier HTTP timeout explicit at 15 seconds
- set the sequential CronJob deadline to 480 seconds with `concurrencyPolicy: Forbid`
- add a regression that parses the production policy and values and derives the deadline invariant

## Root cause

The production policy already allowed 180 seconds for `agent_workloads.readonly_query`, but the synthetic journey explicitly requested only 60 seconds. Mandate correctly attenuated the lease to the narrower request. The per-capability override was not dropped, so Core attenuation remains unchanged.

## Validation

Validated on head `39a461f` after rebasing onto current `main`:

- focused agent-control-plane contracts: 23 passed
- full Python contract suite: 170 passed
- grant-ownership generation check
- control-plane release-pin check
- registry-overlay Helm/Kustomize/golden render check
- Helm 3.14.0 lint and exact render against pinned agent-platform `a7a5a116d60c`
- kubeconform 0.6.7 validation of the rendered synthetic CronJob
- mutable `:latest` scan and `git diff --check`

Hosted OIDC-backed compatibility and digest gates are left to this PR's GitHub Actions run.

## Boundary

This PR changes no Core attenuation behavior, credentials, image pins, or live resources. Merge, Argo sync, and live verification remain separately authorized actions.

Linear: https://linear.app/cegarza/issue/CES-574/synthetic-readonly-query-verification-requests-60s-and-masks-the-180s