### PR TITLE
CES-96: re-pin agent-workloads sha-e902051a3e08

### DIFF
--- a/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
+++ b/apps/agent-control-plane-registry-overlay/registry/imports/agent-data.workspace_probe.json
@@ -12,7 +12,7 @@
     }
   },
   "code_digest": "sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02",
-  "digest": "sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f",
+  "digest": "sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca",
   "display_name": "Agent Workloads Data Worker",
   "evals": {
     "optional": [],
@@ -23,7 +23,7 @@
   },
   "id": "data.workspace_probe",
   "image": {
-    "digest": "sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed",
+    "digest": "sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936",
     "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
   },
   "loop": {

--- a/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
+++ b/apps/agent-control-plane-registry-overlay/registry/workload_imports.yaml
@@ -2,8 +2,8 @@ schema_version: workload-imports.v1
 imports:
 - id: data.workspace_probe
   manifest_path: registries/imports/agent-data.workspace_probe.json
-  manifest_digest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
-  image_digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
+  manifest_digest: sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca
+  image_digest: sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936
   expected_source:
     repo: agent-workloads
     repo_url: https://github.com/cesaregarza/agent-workloads
@@ -12,13 +12,18 @@ imports:
     execution_posture: capability_worker
     network_access: database_only
     service_account_ref: agent-workloads-worker
-    service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
+    service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-527e3ccb6cd966725de2
     identity_audience: mandate-api
     capacity_tier: 4
     concurrency: 1
     max_runtime_seconds: 120
     model_call: true
     readonly_sql_broker: true
+    previous_release:
+      service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
+      code_digest: sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02
+      manifest_digest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
+      image_digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
   capabilities:
     agent_workloads.db_probe:
       description: Imported reversible staging database workspace probe.

--- a/apps/agent-workloads/values.yaml
+++ b/apps/agent-workloads/values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: agent-workloads
 replicaCount: 2
 image:
   repository: registry.digitalocean.com/sendouq/agent-workloads-worker
-  tag: sha-51102759737c
-  digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
+  tag: sha-e902051a3e08
+  digest: sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936
   pullPolicy: IfNotPresent
 projectedWorkloadIdentity:
   enabled: true
@@ -22,7 +22,10 @@ projectedWorkloadIdentity:
     expirationSeconds: 3600
     mountPath: /var/run/mandate/workload-identity
     fileName: token
-  previousRelease: null
+  previousRelease:
+    codeDigest: sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02
+    manifestDigest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
+    imageDigest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
 env:
   MANDATE_WORKER_BASE_URL: http://agent-control-plane.agent-control-plane.svc.cluster.local
   AGENT_WORKLOADS_WORKER_ID: data.workspace_probe
@@ -295,8 +298,8 @@ opencodeApplyExecutor:
 mandateReleasePins:
   data.workspace_probe:
     codeDigest: sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02
-    manifestDigest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
-    imageDigest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
+    manifestDigest: sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca
+    imageDigest: sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936
   opencode.apply_executor:
     codeDigest: sha256:d11ad7afa0ded6cd81c03e6777fcbbc63a35f70d336a0fb994699bd98429d9e7
     manifestDigest: sha256:34103ec1c645b37d03ba9c85b6fe40bdc91a4ca9cc08cd87d28b75469054b544

--- a/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
+++ b/tests/fixtures/agent-control-plane-registry-overlay/configmap.golden.yaml
@@ -22,7 +22,7 @@ data:
         }
       },
       "code_digest": "sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02",
-      "digest": "sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f",
+      "digest": "sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca",
       "display_name": "Agent Workloads Data Worker",
       "evals": {
         "optional": [],
@@ -33,7 +33,7 @@ data:
       },
       "id": "data.workspace_probe",
       "image": {
-        "digest": "sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed",
+        "digest": "sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936",
         "repository": "registry.digitalocean.com/sendouq/agent-workloads-worker"
       },
       "loop": {
@@ -361,8 +361,8 @@ data:
     imports:
     - id: data.workspace_probe
       manifest_path: registries/imports/agent-data.workspace_probe.json
-      manifest_digest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
-      image_digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
+      manifest_digest: sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca
+      image_digest: sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936
       expected_source:
         repo: agent-workloads
         repo_url: https://github.com/cesaregarza/agent-workloads
@@ -371,13 +371,18 @@ data:
         execution_posture: capability_worker
         network_access: database_only
         service_account_ref: agent-workloads-worker
-        service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
+        service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-527e3ccb6cd966725de2
         identity_audience: mandate-api
         capacity_tier: 4
         concurrency: 1
         max_runtime_seconds: 120
         model_call: true
         readonly_sql_broker: true
+        previous_release:
+          service_account_subject: system:serviceaccount:agent-workloads:agent-workloads-data-workspace-probe-a3404f79b15b11b8b7f3
+          code_digest: sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02
+          manifest_digest: sha256:912222e0cf0adea2733166543213e6ff70aadff34f13815ca36038bdf30d123f
+          image_digest: sha256:9132f8e5d761f42947186041a9b28a6298533d22b0d286f55551dabc978531ed
       capabilities:
         agent_workloads.db_probe:
           description: Imported reversible staging database workspace probe.


### PR DESCRIPTION
## Summary
- Re-pin GarzAICluster to an immutable agent-workloads release.
- Apply generated registry overlay manifest/image pins and Helm values.
- Regenerate and validate grant ownership outputs in transaction staging.
- Roll the projected ServiceAccount subject while retaining one trusted previous release tuple for overlap.

## Provenance
- Source repo: `cesaregarza/agent-workloads`
- Source commit: `e902051a3e0821945b93bdb1bca06a03d2f02064`
- Publish run id: `30513292700`

## Digest Pins
| workload | image digest | manifest digest | code digest |
| --- | --- | --- | --- |
| `data.workspace_probe` | `sha256:d3ba0154fb18c59e2d993551aa5fd0f9dafb6e2627f9bd7d662a79bffdeb0936` | `sha256:d023bd0182c92ed06dcc8c22c4110d76a0a215a3b96f5bc3d4fec8ddbe749aca` | `sha256:a1eff6143142995fc1ca59644533e258650674e0ba0e0058ca747ee980fadf02` |

## Safety
- This PR does not mint workload identity tokens.
- ServiceAccount subjects are derived from reviewed full release bundle digests; workers do not self-assert the accepted release tuple.
- This release flow does not recompute or attest runtime workflow digests.
- No mutable `:latest` image tag is introduced.

Refs CES-96 and CES-573.