### PR TITLE
CES-573: make projected identity tests overlap-aware

### DIFF
--- a/tests/test_agent_workloads_projected_identity_chart.py
+++ b/tests/test_agent_workloads_projected_identity_chart.py
@@ -240,9 +240,27 @@ class AgentWorkloadsProjectedIdentityChartTests(unittest.TestCase):
                 ("opencode.apply_executor", "opencodeApplyExecutor"),
             )
         }
+        expected_service_accounts = {
+            "agent-workloads",
+            workspace_account,
+            *opencode_accounts.values(),
+        }
+        previous_release = self.production_values["projectedWorkloadIdentity"][
+            "previousRelease"
+        ]
+        if previous_release is not None:
+            expected_service_accounts.add(
+                _release_service_account_name(
+                    "data.workspace_probe",
+                    previous_release,
+                    prefix=self.production_values["projectedWorkloadIdentity"][
+                        "serviceAccountNamePrefix"
+                    ],
+                )
+            )
         self.assertEqual(
             {account["metadata"]["name"] for account in service_accounts},
-            {"agent-workloads", workspace_account, *opencode_accounts.values()},
+            expected_service_accounts,
         )
 
         for worker_id, deployment_name, container_name in (

--- a/tests/test_agent_workloads_tokenreview_canary.py
+++ b/tests/test_agent_workloads_tokenreview_canary.py
@@ -20,9 +20,14 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return value
 
 
-def _workspace_service_account_subject(values: dict[str, Any]) -> str:
+def _workspace_service_account_subject(
+    values: dict[str, Any],
+    *,
+    release: dict[str, str] | None = None,
+) -> str:
     worker_id = "data.workspace_probe"
-    release = values["mandateReleasePins"][worker_id]
+    if release is None:
+        release = values["mandateReleasePins"][worker_id]
     payload = {
         "schema_version": "workload_identity_bundle.v1",
         "code_digest": release["codeDigest"],
@@ -148,7 +153,6 @@ class AgentWorkloadsTokenReviewCanaryTests(unittest.TestCase):
         self.assertIs(projected["enabled"], True)
         self.assertEqual(projected["workerId"], "data.workspace_probe")
         self.assertEqual(projected["token"]["audience"], "mandate-api")
-        self.assertIsNone(projected["previousRelease"])
         self.assertEqual(
             workspace["agent"]["service_account_subject"],
             _workspace_service_account_subject(values),
@@ -157,7 +161,26 @@ class AgentWorkloadsTokenReviewCanaryTests(unittest.TestCase):
             workspace["agent"]["identity_audience"],
             "mandate-api",
         )
-        self.assertNotIn("previous_release", workspace["agent"])
+        previous_release = projected["previousRelease"]
+        if previous_release is None:
+            self.assertNotIn("previous_release", workspace["agent"])
+        else:
+            self.assertEqual(
+                workspace["agent"]["previous_release"],
+                {
+                    "service_account_subject": _workspace_service_account_subject(
+                        values,
+                        release=previous_release,
+                    ),
+                    "code_digest": previous_release["codeDigest"],
+                    "manifest_digest": previous_release["manifestDigest"],
+                    "image_digest": previous_release["imageDigest"],
+                },
+            )
+            self.assertNotEqual(
+                workspace["agent"]["service_account_subject"],
+                workspace["agent"]["previous_release"]["service_account_subject"],
+            )
 
         self.assertNotIn("MANDATE_WORKLOAD_IDENTITY_TOKEN_FILE", values["env"])
         self.assertNotIn("extraVolumes", values)


### PR DESCRIPTION
## Summary

- update only the two stale projected-identity tests that assumed the initial no-overlap state
- preserve coverage for `previousRelease: null` while validating a current/previous overlap when present
- derive and assert the previous ServiceAccount subject and exact previous registry tuple

## Why this is separate from #457

PR #457 is the generated four-file, non-secret release/re-pin diff. Its intended first normal rollover adds a bounded previous release and second projected ServiceAccount. Putting the test repair in #457 would widen that release PR to six files, so this prerequisite keeps #457's audited release scope intact.

## Validation

- focused chart tests: 8 passed
- focused TokenReview canary tests: 4 passed
- full Config Repo Python contracts: 170 passed
- grant ownership, control-plane pin, and diff checks passed
- simulated this commit plus exact #457 head `c100db0b574d3e5d98a80f4e79258365f5af8137`: 170 Python contracts passed; both agent-workloads chart lint/render paths passed
- exact remote #457 SOPS drift gate is already green; no local secret access was used

## Boundary

This PR changes only two test files. It changes no release pin, workload path, SOPS, Secret, HMAC, token, credential, or identity state. It does not authorize merge, #457 merge, GitOps sync, restart, production probing, token rotation, or rollback.

After separately authorized review and merge, update #457 onto the accepted main commit, reconfirm its exact four-file scope, and require all checks green at one recorded head.

Refs CES-573.