### PR TITLE
[bot] Update splattop-blog image to v1.0.34

### DIFF
--- a/helm/splattop-blog/values-prod.yaml
+++ b/helm/splattop-blog/values-prod.yaml
@@ -5,7 +5,7 @@ global:
 blog:
   replicas: 1
   image:
-    tag: v1.0.32
+    tag: v1.0.34
     pullPolicy: IfNotPresent
   health:
     hostHeader: blog.splat.top


### PR DESCRIPTION
Automated update from SplatTopBlog repository.

**Source commit:** cesaregarza/SplatTopBlog@39ec5b1cdfde4cd897f0315251b92273c890001e
**Image tag:** v1.0.34

This PR was created automatically by the CI/CD pipeline.