### PR TITLE
Pin cegarza preview to Wagtail v1.0.34

### DIFF
--- a/helm/splattop-blog/values-cegarza.yaml
+++ b/helm/splattop-blog/values-cegarza.yaml
@@ -3,7 +3,7 @@ global:
   imagePullSecrets:
     - regcred
   databaseSecretName: cegarza-blog-secrets
-  appImageTag: v1.0.33
+  appImageTag: v1.0.34
 
 fullnameOverride: cegarza-blog
 
@@ -14,8 +14,8 @@ blog:
     type: Recreate
   image:
     repository: registry.digitalocean.com/sendouq/splattop-blog
-    tag: v1.0.33
-    digest: sha256:5e6a729e28197c75fe7cf7fe1cdf7b57a25ede3e7c468910751133731e88788d
+    tag: v1.0.34
+    digest: sha256:e0848936bb58c8764718c4b64fdc8fb451794a38dff26238eb8b35ea288c6b07
     pullPolicy: IfNotPresent
   secretKeys:
     - DATABASE_URL


### PR DESCRIPTION
## Summary

- pin only `helm/splattop-blog/values-cegarza.yaml` to `v1.0.34`
- use the registry-confirmed immutable digest `sha256:e0848936bb58c8764718c4b64fdc8fb451794a38dff26238eb8b35ea288c6b07`
- retain the existing one-replica `Recreate` rollout and `cegarza-blog-media` PVC

## Provenance

- source: `cesaregarza/SplatTopBlog@39ec5b1cdfde4cd897f0315251b92273c890001e`
- source PR: https://github.com/cesaregarza/SplatTopBlog/pull/7
- release workflow: https://github.com/cesaregarza/SplatTopBlog/actions/runs/30592691344
- release tag: `v1.0.34`
- digest was cross-checked in the DigitalOcean registry

## Verification

- 176 Python contract tests passed
- grant-ownership and control-plane pin checks passed
- Helm 3.14 lint passed for default and cegarza values
- default, production, and cegarza renders passed kubeconform 0.6.7
- no-latest, encrypted-secret, digest-count, dev-hostname, TLS-secret, and no-apex assertions passed
- independent GitOps review approved with no high/medium findings

This does not change `values-prod.yaml` (the separate automated PR #467 owns that), registry credentials, Secret manifests, DNS, the apex hostname, or the Ghost droplet. The previous v1.0.33 digest remains the rollback tuple.