### PR TITLE
[bot] Update splattop-blog image to v1.0.35

### DIFF
--- a/helm/splattop-blog/values-prod.yaml
+++ b/helm/splattop-blog/values-prod.yaml
@@ -5,7 +5,7 @@ global:
 blog:
   replicas: 1
   image:
-    tag: v1.0.32
+    tag: v1.0.35
     pullPolicy: IfNotPresent
   health:
     hostHeader: blog.splat.top


### PR DESCRIPTION
Automated update from SplatTopBlog repository.

**Source commit:** cesaregarza/SplatTopBlog@a136889c19f3eb09a18dd970b24df3709e3400c6
**Image tag:** v1.0.35

This PR was created automatically by the CI/CD pipeline.