### PR TITLE
[bot] Update splattop-blog image to v1.0.36

### DIFF
--- a/helm/splattop-blog/values-prod.yaml
+++ b/helm/splattop-blog/values-prod.yaml
@@ -5,7 +5,7 @@ global:
 blog:
   replicas: 1
   image:
-    tag: v1.0.32
+    tag: v1.0.36
     pullPolicy: IfNotPresent
   health:
     hostHeader: blog.splat.top


### PR DESCRIPTION
Automated update from SplatTopBlog repository.

**Source commit:** cesaregarza/SplatTopBlog@2394929236168038322e6bf0176e4dee8d51d472
**Image tag:** v1.0.36

This PR was created automatically by the CI/CD pipeline.