### PR TITLE
Add cegarza-blog migration substrate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,6 +187,10 @@ jobs:
             path: helm/splattop-blog
             release: splattop-blog
             prod_values: helm/splattop-blog/values-prod.yaml
+          - name: cegarza-blog
+            path: helm/cegarza-blog
+            release: cegarza-blog
+            prod_values: helm/cegarza-blog/values-cegarza.yaml
           - name: garz-observability
             path: helm/garz-observability
             release: garz-observability
@@ -238,24 +242,14 @@ jobs:
           mkdir -p rendered
           helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" > "rendered/${{ matrix.chart.name }}-default.yaml"
           helm template "${{ matrix.chart.release }}" "${{ matrix.chart.path }}" -f "${{ matrix.chart.prod_values }}" > "rendered/${{ matrix.chart.name }}-prod.yaml"
-          if [[ "${{ matrix.chart.name }}" == "splattop-blog" ]]; then
-            helm lint helm/splattop-blog \
-              -f helm/splattop-blog/values.yaml \
-              -f helm/splattop-blog/values-cegarza.yaml
-            helm template cegarza-blog helm/splattop-blog \
-              --namespace cegarza-blog \
-              -f helm/splattop-blog/values.yaml \
-              -f helm/splattop-blog/values-cegarza.yaml \
-              > rendered/cegarza-blog-preview.yaml
-          fi
 
-      - name: Verify SplatTop Blog safety semantics
-        if: matrix.chart.name == 'splattop-blog'
+      - name: Verify cegarza.com chart safety semantics
+        if: matrix.chart.name == 'cegarza-blog'
         run: |
           set -euo pipefail
-          chart=helm/splattop-blog
-          default_render=rendered/splattop-blog-default.yaml
-          prod_render=rendered/splattop-blog-prod.yaml
+          chart=helm/cegarza-blog
+          default_render=rendered/cegarza-blog-default.yaml
+          prod_render=rendered/cegarza-blog-prod.yaml
 
           if grep -F '  strategy:' "$default_render" >/dev/null; then
             echo "Ephemeral media must retain the default Deployment strategy" >&2
@@ -337,54 +331,54 @@ jobs:
             exit 1
           fi
 
-          helm template splattop-blog "$chart" \
-            -f helm/splattop-blog/values-prod.yaml \
+          helm template cegarza-blog "$chart" \
+            -f helm/cegarza-blog/values-cegarza.yaml \
             --set ingress.tls.certificate.enabled=false \
             --show-only templates/ingress.yaml \
-            > rendered/splattop-blog-ingress-shim.yaml
+            > rendered/cegarza-blog-ingress-shim.yaml
           grep -F 'cert-manager.io/cluster-issuer: letsencrypt-prod' \
-            rendered/splattop-blog-ingress-shim.yaml >/dev/null
+            rendered/cegarza-blog-ingress-shim.yaml >/dev/null
 
-          helm template splattop-blog "$chart" \
+          helm template cegarza-blog "$chart" \
             --set blog.persistence.enabled=true \
             --set blog.strategy.type=Recreate \
             --set blog.strategy.rollingUpdate.maxSurge=1 \
             --show-only templates/deployment.yaml \
-            > rendered/splattop-blog-explicit-recreate.yaml
+            > rendered/cegarza-blog-explicit-recreate.yaml
           grep -F '    rollingUpdate: null' \
-            rendered/splattop-blog-explicit-recreate.yaml >/dev/null
+            rendered/cegarza-blog-explicit-recreate.yaml >/dev/null
           if grep -F 'maxSurge:' \
-            rendered/splattop-blog-explicit-recreate.yaml >/dev/null; then
+            rendered/cegarza-blog-explicit-recreate.yaml >/dev/null; then
             echo "Recreate must clear rollingUpdate settings" >&2
             exit 1
           fi
 
-          helm template splattop-blog "$chart" \
-            -f helm/splattop-blog/values-prod.yaml \
+          helm template cegarza-blog "$chart" \
+            -f helm/cegarza-blog/values-cegarza.yaml \
             --set blog.persistence.retainOnDelete=false \
             --show-only templates/media-pvc.yaml \
-            > rendered/splattop-blog-prunable-pvc.yaml
+            > rendered/cegarza-blog-prunable-pvc.yaml
           if grep -E 'argocd.argoproj.io/sync-options|helm.sh/resource-policy' \
-            rendered/splattop-blog-prunable-pvc.yaml >/dev/null; then
+            rendered/cegarza-blog-prunable-pvc.yaml >/dev/null; then
             echo "retainOnDelete=false must remove PVC retention annotations" >&2
             exit 1
           fi
 
           digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-          helm template splattop-blog "$chart" \
+          helm template cegarza-blog "$chart" \
             --set blog.migrations.enabled=true \
             --set-string blog.image.digest="$digest" \
-            > rendered/splattop-blog-digest.yaml
-          test "$(grep -Fc "registry.digitalocean.com/sendouq/splattop-blog@${digest}" \
-            rendered/splattop-blog-digest.yaml)" -eq 2
+            > rendered/cegarza-blog-digest.yaml
+          test "$(grep -Fc "registry.digitalocean.com/sendouq/cegarza-blog@${digest}" \
+            rendered/cegarza-blog-digest.yaml)" -eq 2
           grep -F -- '- /app/.venv/bin/python' \
-            rendered/splattop-blog-digest.yaml >/dev/null
-          if grep -F -- '- uv' rendered/splattop-blog-digest.yaml >/dev/null; then
+            rendered/cegarza-blog-digest.yaml >/dev/null
+          if grep -F -- '- uv' rendered/cegarza-blog-digest.yaml >/dev/null; then
             echo "The migration Job must not invoke uv or install development dependencies" >&2
             exit 1
           fi
 
-          cegarza_render=rendered/cegarza-blog-preview.yaml
+          cegarza_render="$prod_render"
           cegarza_digest=$(awk '
             /^[[:space:]]*digest:/ {
               value = $2
@@ -392,10 +386,97 @@ jobs:
               print value
               exit
             }
-          ' helm/splattop-blog/values-cegarza.yaml)
+          ' helm/cegarza-blog/values-cegarza.yaml)
+          cegarza_repository=$(sed -n 's/^    repository: //p' \
+            helm/cegarza-blog/values-cegarza.yaml)
+          cegarza_selector=$(sed -n 's/^  selectorName: //p' \
+            helm/cegarza-blog/values-cegarza.yaml)
+          cegarza_replace=$(sed -n 's/^  replaceOnSync: //p' \
+            helm/cegarza-blog/values-cegarza.yaml)
+          cegarza_settings=$(sed -n 's/^    DJANGO_SETTINGS_MODULE: //p' \
+            helm/cegarza-blog/values-cegarza.yaml)
           test -n "$cegarza_digest"
-          test "$(grep -Fc "registry.digitalocean.com/sendouq/splattop-blog@${cegarza_digest}" \
+          test -n "$cegarza_repository"
+          test -n "$cegarza_selector"
+          test -n "$cegarza_replace"
+          test -n "$cegarza_settings"
+
+          old_selector=splattop-blog
+          new_selector=cegarza-blog
+          old_repository=registry.digitalocean.com/sendouq/splattop-blog
+          new_repository=registry.digitalocean.com/sendouq/cegarza-blog
+          old_settings=splattopblog.settings
+          new_settings=cegarza_site.settings
+          case "${cegarza_repository}|${cegarza_settings}|${cegarza_selector}|${cegarza_replace}" in
+            "${old_repository}|${old_settings}|${old_selector}|false")
+              expected_replace_count=0
+              expect_old_network_selector=true
+              ;;
+            "${new_repository}|${new_settings}|${new_selector}|true")
+              expected_replace_count=1
+              expect_old_network_selector=true
+              ;;
+            "${new_repository}|${new_settings}|${new_selector}|false")
+              expected_replace_count=0
+              expect_old_network_selector=false
+              ;;
+            *)
+              echo "cegarza-blog values are not a safe rollout phase" >&2
+              exit 1
+              ;;
+          esac
+
+          test "$(grep -Fc "${cegarza_repository}@${cegarza_digest}" \
             "$cegarza_render")" -eq 2
+          test "$(grep -Fc "app.kubernetes.io/name: ${cegarza_selector}" \
+            "$cegarza_render")" -ge 1
+          actual_replace_count=$(grep -Fc \
+            'argocd.argoproj.io/sync-options: Force=true,Replace=true' \
+            "$cegarza_render" || true)
+          test "$actual_replace_count" -eq "$expected_replace_count"
+
+          helm template cegarza-blog "$chart" \
+            -f helm/cegarza-blog/values-cegarza.yaml \
+            --show-only templates/cilium-network-policy.yaml \
+            > rendered/cegarza-blog-network-policy.yaml
+          cegarza_network_render=rendered/cegarza-blog-network-policy.yaml
+          grep -F -- '- "cegarza-blog"' "$cegarza_network_render" >/dev/null
+          if [[ "$expect_old_network_selector" == true ]]; then
+            grep -F -- '- "splattop-blog"' "$cegarza_network_render" >/dev/null
+          elif grep -F -- '- "splattop-blog"' "$cegarza_network_render" >/dev/null; then
+            echo "Steady state must not retain the old endpoint label" >&2
+            exit 1
+          fi
+
+          helm template cegarza-blog "$chart" \
+            -f helm/cegarza-blog/values-cegarza.yaml \
+            --set blog.selectorName=cegarza-blog \
+            --set blog.replaceOnSync=true \
+            --set-json 'networkPolicy.selectorNames=["splattop-blog","cegarza-blog"]' \
+            > rendered/cegarza-blog-selector-activation.yaml
+          activation_render=rendered/cegarza-blog-selector-activation.yaml
+          test "$(grep -Fc 'argocd.argoproj.io/sync-options: Force=true,Replace=true' \
+            "$activation_render")" -eq 1
+          grep -F 'app.kubernetes.io/name: cegarza-blog' \
+            "$activation_render" >/dev/null
+          grep -F -- '- "splattop-blog"' "$activation_render" >/dev/null
+          grep -F -- '- "cegarza-blog"' "$activation_render" >/dev/null
+
+          helm template cegarza-blog "$chart" \
+            -f helm/cegarza-blog/values-cegarza.yaml \
+            --set blog.selectorName=cegarza-blog \
+            --set blog.replaceOnSync=false \
+            --set-json 'networkPolicy.selectorNames=["cegarza-blog"]' \
+            > rendered/cegarza-blog-selector-cleanup.yaml
+          cleanup_render=rendered/cegarza-blog-selector-cleanup.yaml
+          if grep -F 'Force=true,Replace=true' "$cleanup_render" >/dev/null; then
+            echo "The selector cleanup render must remove the replacement annotation" >&2
+            exit 1
+          fi
+          if grep -F -- '- "splattop-blog"' "$cleanup_render" >/dev/null; then
+            echo "The selector cleanup render must remove the old endpoint label" >&2
+            exit 1
+          fi
           grep -F 'name: cegarza-blog-secrets' "$cegarza_render" >/dev/null
           grep -F 'storageClassName: do-block-storage' "$cegarza_render" >/dev/null
           grep -F 'matchName: "private-db-postgresql-nyc3-xscraper-do-user-15543770-0.c.db.ondigitalocean.com"' \
@@ -407,8 +488,8 @@ jobs:
             expected=$2
             helm template cegarza-blog "$chart" \
               --namespace cegarza-blog \
-              -f helm/splattop-blog/values.yaml \
-              -f helm/splattop-blog/values-cegarza.yaml \
+              -f helm/cegarza-blog/values.yaml \
+              -f helm/cegarza-blog/values-cegarza.yaml \
               --show-only "$template" |
               grep -F "$expected" >/dev/null
           }
@@ -446,24 +527,24 @@ jobs:
           grep -F '"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded' \
             "$cegarza_render" >/dev/null
           if grep -F 'host: cegarza.com' "$cegarza_render" >/dev/null; then
-            echo "The preview release must not claim the apex hostname" >&2
+            echo "The dev release must not claim the apex hostname" >&2
             exit 1
           fi
 
-      - name: Verify SplatTop Blog unsafe persistence fails closed
-        if: matrix.chart.name == 'splattop-blog'
+      - name: Verify cegarza.com unsafe persistence fails closed
+        if: matrix.chart.name == 'cegarza-blog'
         run: |
           set -euo pipefail
-          chart=helm/splattop-blog
+          chart=helm/cegarza-blog
           expect_failure() {
             expected=$1
             shift
-            if helm template splattop-blog "$chart" "$@" \
-              >/dev/null 2>rendered/splattop-blog-negative.err; then
+            if helm template cegarza-blog "$chart" "$@" \
+              >/dev/null 2>rendered/cegarza-blog-negative.err; then
               echo "Expected Helm render to fail: $expected" >&2
               exit 1
             fi
-            grep -F "$expected" rendered/splattop-blog-negative.err >/dev/null
+            grep -F "$expected" rendered/cegarza-blog-negative.err >/dev/null
           }
           expect_failure \
             "blog.replicas must be 1 when blog.persistence.enabled=true and blog.persistence.accessMode=ReadWriteOnce" \

--- a/argocd/applications/cegarza-blog.yaml
+++ b/argocd/applications/cegarza-blog.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/cesaregarza/GarzAICluster
     targetRevision: main
-    path: helm/splattop-blog
+    path: helm/cegarza-blog
     helm:
       releaseName: cegarza-blog
       valueFiles:

--- a/docs/domains-and-hostnames.md
+++ b/docs/domains-and-hostnames.md
@@ -18,7 +18,8 @@ Use this checklist when adding a new public hostname or rolling out another DNS 
 
 ## App-specific follow-up
 
-- `helm/splattop-blog/values-prod.yaml`: update `blog.health.hostHeader`, `blog.env.ALLOWED_HOSTS`, and `blog.env.CSRF_TRUSTED_ORIGINS` when the new hostname is canonical.
+- `helm/cegarza-blog/values-cegarza.yaml`: update `blog.health.hostHeader`, `blog.env.ALLOWED_HOSTS`, and `blog.env.CSRF_TRUSTED_ORIGINS` when the cegarza.com hostname changes.
+- `helm/splattop-blog/values-prod.yaml`: legacy `blog.splat.top` settings; do not reuse this release for cegarza.com.
 - `helm/splattop/values-prod.yaml`: update `monitoring.grafana.serverDomain` and `monitoring.grafana.serverRootUrl` only if the new Grafana host becomes canonical. If it should just redirect, use vanity hosts.
 - `helm/garz-ai`: serves FastAPI-backed garz.ai pages, including JustFlip/Habit Taper legal pages at `justflip.garz.ai` and `habit-taper.garz.ai`.
 - Citrus (new): DNS is outside Cloudflare for this cluster, so update app ingress and application settings only (do not change `external-dns` filters) and provision the following records manually:

--- a/helm/cegarza-blog/Chart.yaml
+++ b/helm/cegarza-blog/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cegarza-blog
+description: Helm chart for the cegarza.com Wagtail site
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/helm/cegarza-blog/templates/_helpers.tpl
+++ b/helm/cegarza-blog/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cegarza-blog.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "cegarza-blog.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cegarza-blog.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cegarza-blog.labels" -}}
+helm.sh/chart: {{ include "cegarza-blog.chart" . }}
+{{ include "cegarza-blog.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Resolve the immutable pod-selector name. A release may temporarily preserve
+the previous selector while its Deployment is replaced in a later revision.
+*/}}
+{{- define "cegarza-blog.selectorName" -}}
+{{- $name := default (include "cegarza-blog.name" .) .Values.blog.selectorName -}}
+{{- if or (gt (len $name) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $name)) -}}
+{{- fail "blog.selectorName must be a valid Kubernetes label value of at most 63 characters" -}}
+{{- end -}}
+{{- $name -}}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cegarza-blog.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cegarza-blog.selectorName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image pull secrets
+*/}}
+{{- define "cegarza-blog.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve image tag with fallback to global
+*/}}
+{{- define "cegarza-blog.imageTag" -}}
+{{- .Values.blog.image.tag | default .Values.global.appImageTag | default "latest" }}
+{{- end }}
+
+{{/*
+Resolve the complete image reference. An immutable digest takes precedence.
+*/}}
+{{- define "cegarza-blog.image" -}}
+{{- $repository := required "blog.image.repository is required" .Values.blog.image.repository -}}
+{{- if .Values.blog.image.digest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.blog.image.digest) -}}
+{{- fail "blog.image.digest must be a lowercase sha256:<64 hex> digest" -}}
+{{- end -}}
+{{- printf "%s@%s" $repository .Values.blog.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repository (include "cegarza-blog.imageTag" .) -}}
+{{- end -}}
+{{- end }}

--- a/helm/cegarza-blog/templates/certificate.yaml
+++ b/helm/cegarza-blog/templates/certificate.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled .Values.ingress.tls.certificate.enabled }}
+{{- $dnsNames := .Values.ingress.tls.certificate.dnsNames | default (list) -}}
+{{- if eq (len $dnsNames) 0 -}}
+{{- range .Values.ingress.hosts -}}
+{{- if .host -}}
+{{- $dnsNames = append $dnsNames .host -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}-cert
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.ingress.tls.secretName }}
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  {{- if gt (len $dnsNames) 0 }}
+  dnsNames:
+    {{- range $dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/cegarza-blog/templates/cilium-network-policy.yaml
+++ b/helm/cegarza-blog/templates/cilium-network-policy.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $databaseHost := required "networkPolicy.egress.database.host is required when networkPolicy.enabled=true" .Values.networkPolicy.egress.database.host -}}
+{{- if contains "*" $databaseHost }}
+{{- fail "networkPolicy.egress.database.host must be an exact hostname without wildcards" }}
+{{- end }}
+{{- if or (contains ".." $databaseHost) (not (regexMatch "^[a-z0-9][a-z0-9.-]*[a-z0-9]$" $databaseHost)) }}
+{{- fail "networkPolicy.egress.database.host must be a lowercase exact DNS hostname" }}
+{{- end }}
+{{- $databasePort := int .Values.networkPolicy.egress.database.port -}}
+{{- if or (lt $databasePort 1) (gt $databasePort 65535) }}
+{{- fail "networkPolicy.egress.database.port must be between 1 and 65535" }}
+{{- end }}
+{{- $selectorNames := .Values.networkPolicy.selectorNames }}
+{{- if not $selectorNames }}
+{{- $selectorNames = list (include "cegarza-blog.selectorName" .) }}
+{{- end }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          {{- range $selectorName := $selectorNames }}
+          - {{ $selectorName | quote }}
+          {{- end }}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": {{ .Values.networkPolicy.ingress.namespace | quote }}
+            {{- range $key, $value := .Values.networkPolicy.ingress.podLabels }}
+            {{ printf "k8s:%s" $key | quote }}: {{ $value | quote }}
+            {{- end }}
+      toPorts:
+        - ports:
+            - port: {{ .Values.networkPolicy.ingress.port | quote }}
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": {{ .Values.networkPolicy.egress.dns.namespace | quote }}
+            {{- range $key, $value := .Values.networkPolicy.egress.dns.podLabels }}
+            {{ printf "k8s:%s" $key | quote }}: {{ $value | quote }}
+            {{- end }}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchName: {{ $databaseHost | quote }}
+      toPorts:
+        - ports:
+            - port: {{ $databasePort | quote }}
+              protocol: TCP
+{{- end }}

--- a/helm/cegarza-blog/templates/deployment.yaml
+++ b/helm/cegarza-blog/templates/deployment.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.blog.enabled }}
+{{- $strategy := default (dict) .Values.blog.strategy -}}
+{{- $strategyType := get $strategy "type" | default "" -}}
+{{- if .Values.blog.persistence.enabled }}
+{{- if and (eq .Values.blog.persistence.accessMode "ReadWriteOnce") (ne (int .Values.blog.replicas) 1) }}
+{{- fail "blog.replicas must be 1 when blog.persistence.enabled=true and blog.persistence.accessMode=ReadWriteOnce" }}
+{{- end }}
+{{- if and $strategy (ne $strategyType "Recreate") }}
+{{- fail "blog.strategy.type must be Recreate when blog.persistence.enabled=true" }}
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    {{- if .Values.blog.replaceOnSync }}
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+    {{- end }}
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+    app.kubernetes.io/component: blog
+spec:
+  {{- if $strategy }}
+  {{- if eq $strategyType "Recreate" }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  {{- else }}
+  strategy:
+    {{- toYaml $strategy | nindent 4 }}
+  {{- end }}
+  {{- else if .Values.blog.persistence.enabled }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  {{- end }}
+  replicas: {{ .Values.blog.replicas }}
+  selector:
+    matchLabels:
+      {{- include "cegarza-blog.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: blog
+  template:
+    metadata:
+      labels:
+        {{- include "cegarza-blog.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: blog
+    spec:
+      automountServiceAccountToken: false
+      {{- include "cegarza-blog.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: blog
+          image: {{ include "cegarza-blog.image" . | quote }}
+          imagePullPolicy: {{ .Values.blog.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            {{- range $key := .Values.blog.secretKeys }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.databaseSecretName }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- range $key, $value := .Values.blog.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.blog.health.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.blog.health.path }}
+              port: {{ .Values.blog.health.port }}
+              {{ if .Values.blog.health.hostHeader }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.blog.health.hostHeader | quote }}
+              {{ end }}
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.blog.health.path }}
+              port: {{ .Values.blog.health.port }}
+              {{ if .Values.blog.health.hostHeader }}
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.blog.health.hostHeader | quote }}
+              {{ end }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- end }}
+          resources:
+            {{- toYaml .Values.blog.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: media
+              mountPath: /app/src/media
+            {{- if .Values.blog.databaseTLS.enabled }}
+            - name: database-ca
+              mountPath: {{ .Values.blog.databaseTLS.caMountPath }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: media
+          {{- if and .Values.blog.persistence.enabled .Values.blog.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.blog.persistence.existingClaim }}
+          {{- else if .Values.blog.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "cegarza-blog.fullname" . }}-media
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.blog.databaseTLS.enabled }}
+        - name: database-ca
+          secret:
+            secretName: {{ required "blog.databaseTLS.secretName is required when blog.databaseTLS.enabled=true" .Values.blog.databaseTLS.secretName }}
+            items:
+              - key: {{ .Values.blog.databaseTLS.secretKey }}
+                path: {{ .Values.blog.databaseTLS.caFileName }}
+        {{- end }}
+{{- end }}

--- a/helm/cegarza-blog/templates/ingress.yaml
+++ b/helm/cegarza-blog/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+{{- $annotations := omit (default (dict) .Values.ingress.annotations) "argocd.argoproj.io/sync-wave" -}}
+{{- if .Values.ingress.tls.certificate.enabled }}
+{{- $annotations = omit $annotations "cert-manager.io/cluster-issuer" "cert-manager.io/issuer" -}}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  {{- with $annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ .host }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "cegarza-blog.fullname" $ }}
+                port:
+                  number: {{ .servicePort | default 8000 }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/cegarza-blog/templates/media-pvc.yaml
+++ b/helm/cegarza-blog/templates/media-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.blog.enabled .Values.blog.persistence.enabled (not .Values.blog.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}-media
+  {{- if .Values.blog.persistence.retainOnDelete }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+    app.kubernetes.io/component: media
+spec:
+  accessModes:
+    - {{ .Values.blog.persistence.accessMode }}
+  {{- if .Values.blog.persistence.storageClass }}
+  storageClassName: {{ .Values.blog.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.blog.persistence.size }}
+{{- end }}

--- a/helm/cegarza-blog/templates/migrations-job.yaml
+++ b/helm/cegarza-blog/templates/migrations-job.yaml
@@ -1,0 +1,73 @@
+{{- if and .Values.blog.enabled .Values.blog.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}-migrate-{{ .Release.Revision }}
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": {{ .Values.blog.migrations.hook }}
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: {{ .Values.blog.migrations.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "cegarza-blog.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrations
+    spec:
+      automountServiceAccountToken: false
+      {{- include "cegarza-blog.imagePullSecrets" . | nindent 6 }}
+      restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: {{ include "cegarza-blog.image" . | quote }}
+          imagePullPolicy: {{ .Values.blog.image.pullPolicy }}
+          command:
+            - /app/.venv/bin/python
+            - manage.py
+            - migrate
+            - --noinput
+          env:
+            {{- range $key := .Values.blog.secretKeys }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.databaseSecretName }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- range $key, $value := .Values.blog.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+          {{- if .Values.blog.databaseTLS.enabled }}
+          volumeMounts:
+            - name: database-ca
+              mountPath: {{ .Values.blog.databaseTLS.caMountPath }}
+              readOnly: true
+          {{- end }}
+      {{- if .Values.blog.databaseTLS.enabled }}
+      volumes:
+        - name: database-ca
+          secret:
+            secretName: {{ required "blog.databaseTLS.secretName is required when blog.databaseTLS.enabled=true" .Values.blog.databaseTLS.secretName }}
+            items:
+              - key: {{ .Values.blog.databaseTLS.secretKey }}
+                path: {{ .Values.blog.databaseTLS.caFileName }}
+      {{- end }}
+{{- end }}

--- a/helm/cegarza-blog/templates/service.yaml
+++ b/helm/cegarza-blog/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.blog.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cegarza-blog.fullname" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    {{- include "cegarza-blog.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.blog.service.type }}
+  ports:
+    - port: {{ .Values.blog.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cegarza-blog.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: blog
+{{- end }}

--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -10,6 +10,8 @@ fullnameOverride: cegarza-blog
 blog:
   enabled: true
   replicas: 1
+  selectorName: splattop-blog
+  replaceOnSync: false
   strategy:
     type: Recreate
   image:
@@ -93,6 +95,9 @@ ingress:
 
 networkPolicy:
   enabled: true
+  selectorNames:
+    - splattop-blog
+    - cegarza-blog
   ingress:
     namespace: ingress-nginx
     podLabels:

--- a/helm/cegarza-blog/values.yaml
+++ b/helm/cegarza-blog/values.yaml
@@ -1,0 +1,128 @@
+global:
+  environment: development
+  imagePullSecrets:
+    - regcred
+  databaseSecretName: blog-db-secrets
+  appImageTag: v1.0.1
+
+nameOverride: ""
+fullnameOverride: ""
+
+blog:
+  enabled: true
+  replicas: 1
+
+  # Pod selectors are immutable after Deployment creation. Keep empty for the
+  # canonical chart name; set only during a bounded selector migration.
+  selectorName: ""
+  # Argo CD resource-scoped replacement for one immutable-selector rollout.
+  # Remove immediately after the replacement succeeds.
+  replaceOnSync: false
+
+  # Optional Kubernetes Deployment strategy override. Persistent media defaults
+  # to, and only accepts, Recreate; Recreate also clears any live rollingUpdate
+  # state. With persistence disabled, empty retains Kubernetes' RollingUpdate.
+  strategy: {}
+
+  image:
+    repository: registry.digitalocean.com/sendouq/cegarza-blog
+    tag: v1.0.1
+    # Optional immutable digest. When set, it takes precedence over tag.
+    digest: ""
+    pullPolicy: Always
+
+  service:
+    type: ClusterIP
+    port: 8000
+
+  # Keys to inject from external database secret
+  secretKeys:
+    - DATABASE_URL
+    - DJANGO_SECRET_KEY
+    - SPACES_ACCESS_KEY
+    - SPACES_SECRET_KEY
+    - SPACES_BUCKET_NAME
+
+  # Plain environment variables
+  env:
+    DJANGO_SETTINGS_MODULE: cegarza_site.settings
+    DEBUG: "false"
+    ALLOWED_HOSTS: "localhost,127.0.0.1"
+    CSRF_TRUSTED_ORIGINS: "http://localhost:8000"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  persistence:
+    enabled: false
+    existingClaim: ""
+    accessMode: ReadWriteOnce
+    size: 5Gi
+    storageClass: ""
+    # Protect chart-managed media from Helm uninstall and Argo CD pruning.
+    retainOnDelete: true
+
+  health:
+    enabled: true
+    path: /health/
+    port: 8000
+    hostHeader: ""
+
+  migrations:
+    enabled: false
+    hook: pre-install,pre-upgrade
+    backoffLimit: 3
+
+  # Mount a database CA from the workload Secret when DATABASE_URL uses
+  # sslmode=verify-full and sslrootcert points at caMountPath/caFileName.
+  databaseTLS:
+    enabled: false
+    secretName: ""
+    secretKey: DB_CA_CERT
+    caMountPath: /etc/database-ca
+    caFileName: ca.crt
+
+ingress:
+  enabled: false
+  className: nginx
+  # cert-manager issuer annotations drive ingress-shim only when the explicit
+  # ingress.tls.certificate resource below is disabled.
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+  hosts: []
+  tls:
+    enabled: false
+    secretName: blog-tls-secret
+    certificate:
+      enabled: false
+      # Defaults to ingress hostnames when empty.
+      dnsNames: []
+
+# Optional Cilium policy for releases that use only local media plus one
+# managed PostgreSQL endpoint. Enabling this isolates both the web Deployment
+# and migration Job by their shared release label.
+networkPolicy:
+  enabled: false
+  # Endpoint selector names. Keep empty to select only blog.selectorName.
+  # During an immutable selector transition, list both old and new names.
+  selectorNames: []
+  ingress:
+    namespace: ingress-nginx
+    podLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/instance: nginx-ingress
+    port: 8000
+  egress:
+    dns:
+      namespace: kube-system
+      podLabels:
+        k8s-app: kube-dns
+    database:
+      host: ""
+      port: 25060

--- a/tests/test_cegarza_blog.py
+++ b/tests/test_cegarza_blog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import unittest
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -10,14 +11,23 @@ from ruamel.yaml import YAML
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 YAML_PARSER = YAML(typ="safe")
-VALUES_PATH = REPO_ROOT / "helm/splattop-blog/values-cegarza.yaml"
+VALUES_PATH = REPO_ROOT / "helm/cegarza-blog/values-cegarza.yaml"
 SECRET_DIRECTORY = REPO_ROOT / "secrets/cegarza-blog"
 EXPECTED_SECRET_FILES = {
     "cegarza-blog-secrets.enc.yaml",
     "cegarza-apex-tls.enc.yaml",
     "regcred.enc.yaml",
 }
-IMAGE_REPOSITORY = "registry.digitalocean.com/sendouq/splattop-blog"
+LEGACY_SELECTOR = "splattop-blog"
+CANONICAL_SELECTOR = "cegarza-blog"
+LEGACY_IMAGE_REPOSITORY = (
+    f"registry.digitalocean.com/sendouq/{LEGACY_SELECTOR}"
+)
+CANONICAL_IMAGE_REPOSITORY = (
+    f"registry.digitalocean.com/sendouq/{CANONICAL_SELECTOR}"
+)
+LEGACY_SETTINGS_MODULE = "splattopblog.settings"
+CANONICAL_SETTINGS_MODULE = "cegarza_site.settings"
 PRIVATE_DATABASE_HOST = (
     "private-db-postgresql-nyc3-xscraper-do-user-15543770-0.c."
     "db.ondigitalocean.com"
@@ -39,13 +49,13 @@ def _render_cegarza() -> list[dict[str, Any]]:
             "helm",
             "template",
             "cegarza-blog",
-            "helm/splattop-blog",
+            "helm/cegarza-blog",
             "--namespace",
             "cegarza-blog",
             "-f",
-            "helm/splattop-blog/values.yaml",
+            "helm/cegarza-blog/values.yaml",
             "-f",
-            "helm/splattop-blog/values-cegarza.yaml",
+            "helm/cegarza-blog/values-cegarza.yaml",
         ],
         check=True,
         cwd=str(REPO_ROOT),
@@ -76,9 +86,80 @@ def _document(
     return matches[0]
 
 
+def _rollout_phase(values: dict[str, Any]) -> str:
+    blog = values["blog"]
+    signature = (
+        blog["image"]["repository"],
+        blog["env"]["DJANGO_SETTINGS_MODULE"],
+        blog["selectorName"],
+        blog["replaceOnSync"],
+        tuple(values["networkPolicy"]["selectorNames"]),
+    )
+    phases = {
+        (
+            LEGACY_IMAGE_REPOSITORY,
+            LEGACY_SETTINGS_MODULE,
+            LEGACY_SELECTOR,
+            False,
+            (LEGACY_SELECTOR, CANONICAL_SELECTOR),
+        ): "substrate",
+        (
+            CANONICAL_IMAGE_REPOSITORY,
+            CANONICAL_SETTINGS_MODULE,
+            CANONICAL_SELECTOR,
+            True,
+            (LEGACY_SELECTOR, CANONICAL_SELECTOR),
+        ): "activation",
+        (
+            CANONICAL_IMAGE_REPOSITORY,
+            CANONICAL_SETTINGS_MODULE,
+            CANONICAL_SELECTOR,
+            False,
+            (CANONICAL_SELECTOR,),
+        ): "steady-state",
+    }
+    try:
+        return phases[signature]
+    except KeyError as exc:
+        raise AssertionError(
+            "cegarza-blog values must be exactly one safe rollout phase; "
+            f"got {signature!r}"
+        ) from exc
+
+
 class CegarzaBlogContractTests(unittest.TestCase):
+    def test_rollout_phase_state_machine_is_explicit(self) -> None:
+        substrate = _load_yaml(VALUES_PATH)
+        self.assertEqual(_rollout_phase(substrate), "substrate")
+
+        activation = deepcopy(substrate)
+        activation["blog"]["image"]["repository"] = CANONICAL_IMAGE_REPOSITORY
+        activation["blog"]["env"]["DJANGO_SETTINGS_MODULE"] = (
+            CANONICAL_SETTINGS_MODULE
+        )
+        activation["blog"]["selectorName"] = CANONICAL_SELECTOR
+        activation["blog"]["replaceOnSync"] = True
+        self.assertEqual(_rollout_phase(activation), "activation")
+
+        steady_state = deepcopy(activation)
+        steady_state["blog"]["replaceOnSync"] = False
+        steady_state["networkPolicy"]["selectorNames"] = [CANONICAL_SELECTOR]
+        self.assertEqual(_rollout_phase(steady_state), "steady-state")
+
+        unordered = deepcopy(steady_state)
+        unordered["networkPolicy"]["selectorNames"] = [
+            LEGACY_SELECTOR,
+            CANONICAL_SELECTOR,
+        ]
+        with self.assertRaisesRegex(AssertionError, "safe rollout phase"):
+            _rollout_phase(unordered)
+
     def test_values_are_dedicated_dev_configuration(self) -> None:
         values = _load_yaml(VALUES_PATH)
+        self.assertIn(
+            _rollout_phase(values),
+            {"substrate", "activation", "steady-state"},
+        )
         self.assertEqual(values["global"]["environment"], "production")
         self.assertEqual(values["global"]["databaseSecretName"], "cegarza-blog-secrets")
         self.assertEqual(values["global"]["imagePullSecrets"], ["regcred"])
@@ -86,12 +167,20 @@ class CegarzaBlogContractTests(unittest.TestCase):
 
         blog = values["blog"]
         image = blog["image"]
-        self.assertEqual(image["repository"], IMAGE_REPOSITORY)
+        self.assertIn(
+            image["repository"],
+            {LEGACY_IMAGE_REPOSITORY, CANONICAL_IMAGE_REPOSITORY},
+        )
         self.assertRegex(image["tag"], r"^v\d+\.\d+\.\d+$")
         self.assertRegex(image["digest"], r"^sha256:[a-f0-9]{64}$")
         self.assertNotEqual(image["digest"], f"sha256:{'0' * 64}")
         self.assertEqual(image["pullPolicy"], "IfNotPresent")
         self.assertEqual(blog["replicas"], 1)
+        self.assertIn(
+            blog["selectorName"],
+            {LEGACY_SELECTOR, CANONICAL_SELECTOR},
+        )
+        self.assertIsInstance(blog["replaceOnSync"], bool)
         self.assertEqual(blog["strategy"], {"type": "Recreate"})
         self.assertEqual(blog["secretKeys"], ["DATABASE_URL", "DJANGO_SECRET_KEY"])
 
@@ -156,6 +245,13 @@ class CegarzaBlogContractTests(unittest.TestCase):
 
         network_policy = values["networkPolicy"]
         self.assertTrue(network_policy["enabled"])
+        self.assertIn(
+            network_policy["selectorNames"],
+            [
+                [LEGACY_SELECTOR, CANONICAL_SELECTOR],
+                [CANONICAL_SELECTOR],
+            ],
+        )
         self.assertEqual(
             network_policy["egress"]["database"],
             {"host": PRIVATE_DATABASE_HOST, "port": 25060},
@@ -181,6 +277,7 @@ class CegarzaBlogContractTests(unittest.TestCase):
             workload["spec"]["source"]["helm"]["valueFiles"],
             ["values.yaml", "values-cegarza.yaml"],
         )
+        self.assertEqual(workload["spec"]["source"]["path"], "helm/cegarza-blog")
         workload_options = workload["spec"]["syncPolicy"]["syncOptions"]
         self.assertIn("CreateNamespace=false", workload_options)
         secret_options = secrets["spec"]["syncPolicy"]["syncOptions"]
@@ -237,7 +334,9 @@ class CegarzaBlogContractTests(unittest.TestCase):
 
     def test_render_is_isolated_and_digest_pinned(self) -> None:
         values = _load_yaml(VALUES_PATH)
-        expected_image = f"{IMAGE_REPOSITORY}@{values['blog']['image']['digest']}"
+        _rollout_phase(values)
+        blog = values["blog"]
+        expected_image = f"{blog['image']['repository']}@{blog['image']['digest']}"
         documents = _render_cegarza()
 
         deployment = _document(documents, kind="Deployment", name="cegarza-blog")
@@ -248,6 +347,17 @@ class CegarzaBlogContractTests(unittest.TestCase):
         self.assertFalse(pod_spec["automountServiceAccountToken"])
         self.assertEqual(pod_spec["imagePullSecrets"], [{"name": "regcred"}])
         self.assertEqual(container["image"], expected_image)
+        self.assertEqual(
+            deployment["spec"]["selector"]["matchLabels"]["app.kubernetes.io/name"],
+            blog["selectorName"],
+        )
+        sync_options = deployment["metadata"]["annotations"].get(
+            "argocd.argoproj.io/sync-options"
+        )
+        if blog["replaceOnSync"]:
+            self.assertEqual(sync_options, "Force=true,Replace=true")
+        else:
+            self.assertIsNone(sync_options)
         self.assertTrue(container["securityContext"]["runAsNonRoot"])
         self.assertEqual(container["securityContext"]["runAsUser"], 1000)
 
@@ -323,6 +433,21 @@ class CegarzaBlogContractTests(unittest.TestCase):
             kind="CiliumNetworkPolicy",
             name="cegarza-blog",
         )
+        self.assertEqual(
+            cilium_policy["spec"]["endpointSelector"],
+            {
+                "matchLabels": {
+                    "app.kubernetes.io/instance": "cegarza-blog",
+                },
+                "matchExpressions": [
+                    {
+                        "key": "app.kubernetes.io/name",
+                        "operator": "In",
+                        "values": values["networkPolicy"]["selectorNames"],
+                    }
+                ],
+            },
+        )
         dns_egress = cilium_policy["spec"]["egress"][0]
         self.assertEqual(
             dns_egress["toEndpoints"],
@@ -341,6 +466,76 @@ class CegarzaBlogContractTests(unittest.TestCase):
         )
         fqdn_rules = cilium_policy["spec"]["egress"][1]["toFQDNs"]
         self.assertEqual(fqdn_rules, [{"matchName": PRIVATE_DATABASE_HOST}])
+
+    def test_selector_activation_replaces_only_the_deployment(self) -> None:
+        if shutil.which("helm") is None:
+            raise unittest.SkipTest("helm is required for chart render tests")
+        result = subprocess.run(
+            [
+                "helm",
+                "template",
+                "cegarza-blog",
+                "helm/cegarza-blog",
+                "--namespace",
+                "cegarza-blog",
+                "-f",
+                "helm/cegarza-blog/values.yaml",
+                "-f",
+                "helm/cegarza-blog/values-cegarza.yaml",
+                "--set",
+                "blog.selectorName=cegarza-blog",
+                "--set",
+                "blog.replaceOnSync=true",
+                "--set-json",
+                'networkPolicy.selectorNames=["splattop-blog","cegarza-blog"]',
+            ],
+            check=True,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+        )
+        documents = [
+            document
+            for document in YAML_PARSER.load_all(result.stdout)
+            if isinstance(document, dict) and document
+        ]
+        deployment = _document(
+            documents,
+            kind="Deployment",
+            name="cegarza-blog",
+        )
+        self.assertEqual(
+            deployment["metadata"]["annotations"][
+                "argocd.argoproj.io/sync-options"
+            ],
+            "Force=true,Replace=true",
+        )
+        self.assertEqual(
+            deployment["spec"]["selector"]["matchLabels"]["app.kubernetes.io/name"],
+            "cegarza-blog",
+        )
+
+        for document in documents:
+            if document is deployment:
+                continue
+            self.assertNotEqual(
+                document.get("metadata", {})
+                .get("annotations", {})
+                .get("argocd.argoproj.io/sync-options"),
+                "Force=true,Replace=true",
+            )
+
+        cilium_policy = _document(
+            documents,
+            kind="CiliumNetworkPolicy",
+            name="cegarza-blog",
+        )
+        self.assertEqual(
+            cilium_policy["spec"]["endpointSelector"]["matchExpressions"][0][
+                "values"
+            ],
+            ["splattop-blog", "cegarza-blog"],
+        )
 
     def test_render_orders_policy_migration_and_serving_resources(self) -> None:
         documents = _render_cegarza()


### PR DESCRIPTION
## Summary

Adds the inert GitOps substrate for the SplatTopBlog → cegarza.com migration.

- introduces a dedicated `helm/cegarza-blog` chart and moves the existing cegarza overlay to it
- leaves the current production chart and values intact
- preserves the current Deployment/Service selector during substrate rollout
- allows both legacy and canonical pod labels in Cilium during the handoff
- keeps the child Argo CD application on manual sync
- teaches CI and the release updater to validate the substrate, one-time activation, and steady-state phases without reintroducing Force/Replace later

## Rollout position

This is PR 2 in the ordered migration train, after the credential-broker policy. Merging this PR updates repository state only; it does not sync or restart the live workload.

## Verification

- 178 Python tests passed on Python 3.11
- Helm lint passed
- exact GitHub Actions shell validation passed for substrate, generated activation, and cleanup states
- kubeconform passed for rendered manifests with the repository's CI flags
- independent adversarial review: no blockers
