### PR TITLE
test(cegarza-blog): decouple rollout phase fixtures

### DIFF
--- a/tests/test_cegarza_blog.py
+++ b/tests/test_cegarza_blog.py
@@ -129,7 +129,17 @@ def _rollout_phase(values: dict[str, Any]) -> str:
 
 class CegarzaBlogContractTests(unittest.TestCase):
     def test_rollout_phase_state_machine_is_explicit(self) -> None:
-        substrate = _load_yaml(VALUES_PATH)
+        substrate = deepcopy(_load_yaml(VALUES_PATH))
+        substrate["blog"]["image"]["repository"] = LEGACY_IMAGE_REPOSITORY
+        substrate["blog"]["env"]["DJANGO_SETTINGS_MODULE"] = (
+            LEGACY_SETTINGS_MODULE
+        )
+        substrate["blog"]["selectorName"] = LEGACY_SELECTOR
+        substrate["blog"]["replaceOnSync"] = False
+        substrate["networkPolicy"]["selectorNames"] = [
+            LEGACY_SELECTOR,
+            CANONICAL_SELECTOR,
+        ]
         self.assertEqual(_rollout_phase(substrate), "substrate")
 
         activation = deepcopy(substrate)


### PR DESCRIPTION
## Summary
- make the cegarza-blog rollout state-machine test construct an explicit substrate fixture
- keep activation and steady-state coverage independent of whichever safe phase is checked into the values overlay
- unblock the generated activation PR while preserving its overlay-only diff

## Verification
- Python 3.11 CI job parity passed on the current substrate: 178 tests
- Python 3.11 CI job parity passed with the v1.0.37 activation overlay applied: 178 tests
- grant ownership and control-plane release-pin checks passed in both states