### PR TITLE
chore(cegarza-blog): complete selector rollout

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -11,7 +11,7 @@ blog:
   enabled: true
   replicas: 1
   selectorName: cegarza-blog
-  replaceOnSync: true
+  replaceOnSync: false
   strategy:
     type: Recreate
   image:
@@ -96,7 +96,6 @@ ingress:
 networkPolicy:
   enabled: true
   selectorNames:
-  - splattop-blog
   - cegarza-blog
   ingress:
     namespace: ingress-nginx


### PR DESCRIPTION
## Summary
- remove the one-time Argo CD Deployment replacement flag after the canonical selector rollout succeeded
- remove the temporary `splattop-blog` endpoint match from the cegarza-blog Cilium policy
- preserve the exact v1.0.37 image digest, settings module, retained PVC, ingress, and all other runtime values

## Live prerequisite evidence
- Argo CD Synced/Healthy at activation commit `7e46a28e3e49552acfe6532e62c520f9815281c3`
- canonical v1.0.37 pod ready with zero restarts
- migration hook succeeded
- destination content import and idempotence verification passed
- PVC UID, PV UID/binding, and DigitalOcean volume handle remained unchanged

## Verification
- Python 3.11 CI parity: 178 tests passed
- Helm lint passed
- default and production renders passed kubeconform strict validation
- steady-state render contains only the canonical selector and no `Force=true,Replace=true` annotation