### PR TITLE
[bot] Deploy cegarza-blog v1.0.38

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -16,8 +16,8 @@ blog:
     type: Recreate
   image:
     repository: registry.digitalocean.com/sendouq/cegarza-blog
-    tag: v1.0.37
-    digest: sha256:ce9b2863eb08684656e4435a825c6b8d7e659aae6839f37e755e5c2b34cc2724
+    tag: v1.0.38
+    digest: sha256:82d7865b251e3461c8e213067f34578ed7aad635a334076147d24cad470ce66d
     pullPolicy: IfNotPresent
   secretKeys:
   - DATABASE_URL


### PR DESCRIPTION
Automated immutable release activation from cegarza.com.

**Source commit:** cesaregarza/cegarza.com@cce2ea6bda75348b6ded7941086bfbe310dbfd20
**Image tag:** v1.0.38
**Image digest:** sha256:82d7865b251e3461c8e213067f34578ed7aad635a334076147d24cad470ce66d

This PR updates only the dedicated cegarza-blog values overlay.
The one-time Deployment replacement is enabled only when the old
immutable selector is still present.