### PR TITLE
cegarza-blog: activate apex cegarza.com (replace Ghost)

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -25,8 +25,8 @@ blog:
   env:
     DJANGO_SETTINGS_MODULE: cegarza_site.settings
     DEBUG: "false"
-    ALLOWED_HOSTS: dev.cegarza.com
-    CSRF_TRUSTED_ORIGINS: https://dev.cegarza.com
+    ALLOWED_HOSTS: cegarza.com,www.cegarza.com,dev.cegarza.com
+    CSRF_TRUSTED_ORIGINS: https://cegarza.com,https://www.cegarza.com,https://dev.cegarza.com
     SECURE_HSTS_SECONDS: "31536000"
     SECURE_HSTS_INCLUDE_SUBDOMAINS: "false"
     SECURE_HSTS_PRELOAD: "false"
@@ -35,7 +35,7 @@ blog:
     SITE_NAME: Bringing Down The Gauss
     SITE_DESCRIPTION: Thoughts, stories and ideas.
     SITE_AUTHOR: Cesar Garza
-    WAGTAILADMIN_BASE_URL: https://dev.cegarza.com/admin/
+    WAGTAILADMIN_BASE_URL: https://cegarza.com/admin/
     ALLOWED_EMBED_HOSTS: cesaregarza.github.io
     CSP_ENFORCE: "true"
   resources:
@@ -80,6 +80,16 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "20m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
+  - host: cegarza.com
+    paths:
+    - path: /
+      pathType: Prefix
+      servicePort: 8000
+  - host: www.cegarza.com
+    paths:
+    - path: /
+      pathType: Prefix
+      servicePort: 8000
   - host: dev.cegarza.com
     paths:
     - path: /
@@ -91,6 +101,8 @@ ingress:
     certificate:
       enabled: true
       dnsNames:
+      - cegarza.com
+      - www.cegarza.com
       - dev.cegarza.com
 
 networkPolicy:


### PR DESCRIPTION
Activates the apex cegarza.com on the Wagtail cegarza-blog deployment, replacing the Ghost droplet.

**Changes (values-cegarza.yaml only):**
- ingress hosts += cegarza.com, www.cegarza.com (dev.cegarza.com retained)
- SAN cert (cegarza-dev-tls) dnsNames += cegarza.com, www.cegarza.com (cert-manager re-issues in place → no dev TLS gap)
- ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS += apex + www
- WAGTAILADMIN_BASE_URL → https://cegarza.com/admin/

**Mechanism:** external-dns (policy=sync, manages cegarza.com) creates the cegarza.com/www A records → cluster ingress (152.42.155.167). cert-manager issues the 3-SAN cert once the challenges resolve (~1-2 min apex TLS window). DNS-only (grey); proxying + Zero Trust admin gate are a separate change.

**Pre-done:** cegarza.com Wagtail Site record added (sole default, root = signpost index). LOOPR (building-public-rankings) stays password-gated; bingo-bango-bongo is public.

**After merge:** Argo manual sync → verify apex serves Wagtail over HTTPS → power off Ghost droplet (206.189.205.35), destroy after a few days.