### PR TITLE
cegarza-blog: activate apex cegarza.com (retire Ghost)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -526,8 +526,10 @@ jobs:
             "$cegarza_render" >/dev/null
           grep -F '"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded' \
             "$cegarza_render" >/dev/null
-          if grep -F 'host: cegarza.com' "$cegarza_render" >/dev/null; then
-            echo "The dev release must not claim the apex hostname" >&2
+          # Apex activated: the release now serves cegarza.com. Guard inverted from
+          # the dev-phase block so the apex hostname must be present and intentional.
+          if ! grep -F 'host: cegarza.com' "$cegarza_render" >/dev/null; then
+            echo "Activated release must serve the apex hostname cegarza.com" >&2
             exit 1
           fi
 

--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -25,8 +25,8 @@ blog:
   env:
     DJANGO_SETTINGS_MODULE: cegarza_site.settings
     DEBUG: "false"
-    ALLOWED_HOSTS: dev.cegarza.com
-    CSRF_TRUSTED_ORIGINS: https://dev.cegarza.com
+    ALLOWED_HOSTS: cegarza.com,www.cegarza.com,dev.cegarza.com
+    CSRF_TRUSTED_ORIGINS: https://cegarza.com,https://www.cegarza.com,https://dev.cegarza.com
     SECURE_HSTS_SECONDS: "31536000"
     SECURE_HSTS_INCLUDE_SUBDOMAINS: "false"
     SECURE_HSTS_PRELOAD: "false"
@@ -35,7 +35,7 @@ blog:
     SITE_NAME: Bringing Down The Gauss
     SITE_DESCRIPTION: Thoughts, stories and ideas.
     SITE_AUTHOR: Cesar Garza
-    WAGTAILADMIN_BASE_URL: https://dev.cegarza.com/admin/
+    WAGTAILADMIN_BASE_URL: https://cegarza.com/admin/
     ALLOWED_EMBED_HOSTS: cesaregarza.github.io
     CSP_ENFORCE: "true"
   resources:
@@ -80,6 +80,16 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "20m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
+  - host: cegarza.com
+    paths:
+    - path: /
+      pathType: Prefix
+      servicePort: 8000
+  - host: www.cegarza.com
+    paths:
+    - path: /
+      pathType: Prefix
+      servicePort: 8000
   - host: dev.cegarza.com
     paths:
     - path: /
@@ -91,6 +101,8 @@ ingress:
     certificate:
       enabled: true
       dnsNames:
+      - cegarza.com
+      - www.cegarza.com
       - dev.cegarza.com
 
 networkPolicy:


### PR DESCRIPTION
Operator-authorized activation of the apex cegarza.com on the Wagtail cegarza-blog deployment, replacing Ghost.

**Changes:**
- `values-cegarza.yaml`: ingress hosts += cegarza.com, www.cegarza.com; SAN cert (cegarza-dev-tls) dnsNames += apex + www; ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS += apex + www; WAGTAILADMIN_BASE_URL → https://cegarza.com/admin/
- `.github/workflows/ci.yaml`: invert the deliberate apex guard ("dev release must not claim the apex hostname" → "activated release must serve cegarza.com"). Explicitly operator-authorized break-glass.

**Safety framework verified intact (rendered locally):** steady-state rollout phase (cegarza-blog selector, replaceOnSync=false), zero Force=true,Replace=true, no splattop-blog netpol label; exactly 1 Certificate, no ingress-shim issuer annotation, cegarza-dev-tls retained; sync-waves -2/-1/0 = 1/1/3; migrations Sync hook intact. SAN-cert approach leaves cegarza-apex-tls unused (no cert-ownership handoff).

**Mechanism:** external-dns (manages cegarza.com) creates apex + www A records → ingress 152.42.155.167; cert-manager re-issues the SAN cert in place (no dev TLS gap; ~1-2 min apex window). DNS-only.

**After merge:** re-add cegarza.com Wagtail Site record (default, root=index) → Argo manual sync → verify apex over HTTPS → power off Ghost 206.189.205.35.