### PR TITLE
cegarza-blog: proxy cegarza.com through Cloudflare (Zero Trust prep)

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -72,7 +72,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     external-dns.alpha.kubernetes.io/ttl: "60"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"


### PR DESCRIPTION
Flip external-dns cloudflare-proxied false→true so cegarza.com/www/dev become proxied (orange) durably — a dashboard toggle alone reverts on external-dns reconcile (annotation was false). Prerequisite for gating /admin* with Cloudflare Access. Zone SSL mode is already Full-strict (poetry.cegarza.com, same zone, is proxied + working). No app/selector/cert change.