### PR TITLE
Revert cegarza-blog proxying (Flexible SSL -> redirect loop)

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -72,7 +72,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
     external-dns.alpha.kubernetes.io/ttl: "60"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"


### PR DESCRIPTION
Reverts #479. Proxying caused a 308 loop (Cloudflare→origin over HTTP because zone SSL mode is Flexible + ingress force-ssl-redirect). Back to DNS-only. Re-proxy only after SSL/TLS mode = Full (strict). Live ingress already un-proxied to restore service.