### PR TITLE
cegarza-blog: proxy through Cloudflare (SSL Full-strict, verified no loop)

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -72,7 +72,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
     external-dns.alpha.kubernetes.io/ttl: "60"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"


### PR DESCRIPTION
Re-enable cloudflare-proxied=true now that the cegarza.com zone SSL/TLS mode is Full (strict). Verified live before committing: cegarza.com + www + dev all proxied + HTTP 200 + valid TLS, no 308 loop. (Supersedes the reverted #479/#480 cycle.) Prerequisite for the Cloudflare Access app on /admin*.