### PR TITLE
[bot] Deploy cegarza-blog v1.0.39

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -16,8 +16,8 @@ blog:
     type: Recreate
   image:
     repository: registry.digitalocean.com/sendouq/cegarza-blog
-    tag: v1.0.38
-    digest: sha256:82d7865b251e3461c8e213067f34578ed7aad635a334076147d24cad470ce66d
+    tag: v1.0.39
+    digest: sha256:6a50e27c43ade34bff80dae2152e4e3c451ae393d5ca6c8d213c29d1dcf34ae3
     pullPolicy: IfNotPresent
   secretKeys:
   - DATABASE_URL


### PR DESCRIPTION
Automated immutable release activation from cegarza.com.

**Source commit:** cesaregarza/cegarza.com@f7e5c30cd2bf7ae829f3ecf849d4d1e0cc6c9665
**Image tag:** v1.0.39
**Image digest:** sha256:6a50e27c43ade34bff80dae2152e4e3c451ae393d5ca6c8d213c29d1dcf34ae3

This PR updates only the dedicated cegarza-blog values overlay.
The one-time Deployment replacement is enabled only when the old
immutable selector is still present.