### PR TITLE
cegarza-blog: add LinkedIn to SITE_SAMEAS (JSON-LD)

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -37,6 +37,7 @@ blog:
     SITE_AUTHOR: Cesar Garza
     WAGTAILADMIN_BASE_URL: https://cegarza.com/admin/
     ALLOWED_EMBED_HOSTS: cesaregarza.github.io
+    SITE_SAMEAS: "https://github.com/cesaregarza,https://linkedin.com/in/cegarza"
     CSP_ENFORCE: "true"
   resources:
     requests:


### PR DESCRIPTION
Adds linkedin.com/in/cegarza to SITE_SAMEAS so Person + BlogPosting author.sameAs include LinkedIn (closes the CES-678 residue now that the URL is known). Env-only config change, no image rebuild.