### PR TITLE
citrus-dev: make rollouts capacity-safe

### DIFF
--- a/helm/citrus/templates/worker-deployment.yaml
+++ b/helm/citrus/templates/worker-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: {{ .Values.syncWaves.worker | quote }}
 spec:
+  {{- with .Values.worker.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   replicas: {{ .Values.worker.replicas }}
   selector:
     matchLabels:

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -1,6 +1,12 @@
 image:
   tag: 0742d25e73b2c145860c63d89e7546940c678a19 # allow-latest
 
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+
 application:
   # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)
   # holding a real DJANGO_SECRET_KEY, encrypted with the public age recipient only.
@@ -26,6 +32,11 @@ application:
 
 worker:
   enabled: true
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
 
 mediaRequeue:
   enabled: true


### PR DESCRIPTION
The merged Citrus dev release cannot schedule surge pods on the fixed two-node pool because both web and worker currently require zero unavailable replicas. This change makes only the dev rollout capacity-safe: web keeps one replica available while replacing the other, and the single media worker is replaced without surge. Production defaults remain unchanged.\n\nValidated with Helm lint, default/dev render inspection, and strict kubeconform validation (10/10 resources for each render).