### PR TITLE
[bot] Deploy cegarza-blog v1.0.42

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -16,8 +16,8 @@ blog:
     type: Recreate
   image:
     repository: registry.digitalocean.com/sendouq/cegarza-blog
-    tag: v1.0.40
-    digest: sha256:03fdb644746052b9d4cd122eadf4f63682a7805a47b3a811eee28881f0d2a75b
+    tag: v1.0.42
+    digest: sha256:bc88644c46dc67a7d9eaf809370c56fb0c44f1d107139ad81bee0c85f812a23a
     pullPolicy: IfNotPresent
   secretKeys:
   - DATABASE_URL


### PR DESCRIPTION
Automated immutable release activation from cegarza.com.

**Source commit:** cesaregarza/cegarza.com@2d9befa1702460316f04d2d58eddcf03082dcfc6
**Image tag:** v1.0.42
**Image digest:** sha256:bc88644c46dc67a7d9eaf809370c56fb0c44f1d107139ad81bee0c85f812a23a

This PR updates only the dedicated cegarza-blog values overlay.
The one-time Deployment replacement is enabled only when the old
immutable selector is still present.