### PR TITLE
Citrus: promote CES-682/683/684 to production

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -7,12 +7,12 @@ replicaCount: 2
 strategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 0
-    maxSurge: 1
+    maxUnavailable: 1
+    maxSurge: 0
 
 image:
   repository: registry.digitalocean.com/sendouq/citrus
-  tag: 765de6ad5187f6cc0a64becc33b611e7da2ab4b6 # allow-latest
+  tag: 0742d25e73b2c145860c63d89e7546940c678a19 # allow-latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -102,6 +102,11 @@ migrations:
 worker:
   enabled: true
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
   command: >-
     exec celery -A Mycore worker --loglevel=INFO --queues=media --concurrency=1
     --prefetch-multiplier=1 --max-tasks-per-child=20 --soft-time-limit=240


### PR DESCRIPTION
## Summary

- Pin production Citrus to source/image tag 0742d25e73b2c145860c63d89e7546940c678a19.
- Use the capacity-safe rollout strategy validated in dev: maxSurge 0 and maxUnavailable 1 for web and media worker.
- Preserve the dev override and all other production configuration.

## Validation

- helm lint helm/citrus
- Rendered production and dev manifests and verified the exact image tag and rollout strategy.
- Registry manifest digest: sha256:551b8d44cb76225c312d61e75eaa73a2d56b06038e554073d1ebad34c92d45a0.
- Dev acceptance and media recompression checks passed before promotion.

## Rollback

Previous production image tag: 765de6ad5187f6cc0a64becc33b611e7da2ab4b6.