### PR TITLE
[bot] Deploy cegarza-blog v1.0.45

### DIFF
--- a/helm/cegarza-blog/values-cegarza.yaml
+++ b/helm/cegarza-blog/values-cegarza.yaml
@@ -16,8 +16,8 @@ blog:
     type: Recreate
   image:
     repository: registry.digitalocean.com/sendouq/cegarza-blog
-    tag: v1.0.44
-    digest: sha256:69ad66a24f405fe0e533e8f642e789aa721c7451933d5eab6858abbccf95b28b
+    tag: v1.0.45
+    digest: sha256:b519763bdd59b93a8c6e58efeb0656a357d2f149e2f22b541dafb0a2a7ad0a58
     pullPolicy: IfNotPresent
   secretKeys:
   - DATABASE_URL


### PR DESCRIPTION
Automated immutable release activation from cegarza.com.

**Source commit:** cesaregarza/cegarza.com@281541fa23324b4bfe8f34f41d46aa1b1a90d5cf
**Image tag:** v1.0.45
**Image digest:** sha256:b519763bdd59b93a8c6e58efeb0656a357d2f149e2f22b541dafb0a2a7ad0a58

This PR updates only the dedicated cegarza-blog values overlay.
The one-time Deployment replacement is enabled only when the old
immutable selector is still present.