### PR TITLE
Deploy garz-ai v0.1.3

### DIFF
--- a/helm/garz-ai/values.yaml
+++ b/helm/garz-ai/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: registry.digitalocean.com/sendouq/garz-ai
-  tag: v0.1.2
+  tag: v0.1.3
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
## Outcome

Deploy the public JustFlip legal/support site image `v0.1.3` by updating the single Helm value consumed by the `garz-ai` Argo CD Application.

## Release tuple

- Source PR: https://github.com/cesaregarza/garz-ai/pull/2
- Source commit: `a0f6a44ec85a17c0de866a7a2c6fbefdcde4272d`
- Image: `registry.digitalocean.com/sendouq/garz-ai:v0.1.3`
- Immutable digest: `sha256:2760f1da895a19f83d29f74a9a1c4445b5fb90514c0edc2f9643fa97ea95bf35`
- Previous/rollback tag: `v0.1.2`

## Scope and security boundary

This PR changes only `helm/garz-ai/values.yaml`. It does not modify secrets, ingress, DNS, TLS, service configuration, replicas, resource limits, or Argo policy.

## Validation

- `helm lint helm/garz-ai`
- `helm template garz-ai helm/garz-ai --namespace garz-ai`
- Rendered Deployment image: `registry.digitalocean.com/sendouq/garz-ai:v0.1.3`
- `git diff --check`

## Rollout

After merge, the automated `garz-ai` Argo application should reconcile main. Verify the expected config revision, `Synced`/`Healthy`, the live Deployment image and ready replica, Service endpoints, and both public HTTPS pages. Roll back by restoring `v0.1.2` if live acceptance fails.

Release context: CES-666 / CES-667.
