### PR TITLE
Disable outbound email in Citrus dev

### DIFF
--- a/helm/citrus/templates/deployment.yaml
+++ b/helm/citrus/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
         app: citrus-web
+      {{- if .Values.application.rolloutOnConfigChange }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+      {{- end }}
     spec:
       {{- include "citrus.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/helm/citrus/templates/worker-deployment.yaml
+++ b/helm/citrus/templates/worker-deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         app: citrus-media-worker
         app.kubernetes.io/component: media-worker
+      {{- if .Values.application.rolloutOnConfigChange }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+      {{- end }}
     spec:
       {{- include "citrus.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}

--- a/helm/citrus/values-dev.yaml
+++ b/helm/citrus/values-dev.yaml
@@ -11,6 +11,7 @@ application:
   # Standalone generated-secret file (KSOPS: secrets/citrus-dev/django-app-key.enc.yaml)
   # holding a real DJANGO_SECRET_KEY, encrypted with the public age recipient only.
   generatedSecretName: citrus-dev-app-key
+  rolloutOnConfigChange: true
   configData:
     DJANGO_DEBUG: "False"
     SITE_NAME: "Citrus Grace Dev"
@@ -22,6 +23,9 @@ application:
     HELP_EMAIL: "help@citrus-grace.com"
     ORDERS_EMAIL: "orders@citrus-grace.com"
     BUSINESS_TIME_ZONE: "America/Chicago"
+    # Never deliver mail from dev. Synthetic customers intentionally use
+    # reserved domains and must not generate bounces in real shared inboxes.
+    EMAIL_BACKEND: "django.core.mail.backends.dummy.EmailBackend"
     EMAIL_HOST: "smtp-relay.gmail.com"
     EMAIL_PORT: "587"
     EMAIL_USE_TLS: "True"

--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -34,6 +34,7 @@ application:
   # dev overrides this with citrus-dev-app-key in values-dev.yaml.
   generatedSecretName: citrus-app-key
   spacesSecretName: django-spaces-secrets
+  rolloutOnConfigChange: false
   command: >-
     exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout
     120 --access-logfile -

--- a/tests/test_citrus_dev_mail_safety.py
+++ b/tests/test_citrus_dev_mail_safety.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART_PATH = REPO_ROOT / "helm" / "citrus"
+DEV_VALUES = CHART_PATH / "values-dev.yaml"
+YAML_PARSER = YAML(typ="safe")
+DUMMY_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
+
+
+def _render(*, dev: bool) -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    command = [
+        "helm",
+        "template",
+        "citrus-dev" if dev else "citrus",
+        str(CHART_PATH),
+        "--namespace",
+        "citrus-dev" if dev else "default",
+    ]
+    if dev:
+        command.extend(["-f", str(DEV_VALUES)])
+
+    result = subprocess.run(
+        command,
+        check=True,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    return [
+        document
+        for document in YAML_PARSER.load_all(result.stdout)
+        if isinstance(document, dict) and document
+    ]
+
+
+def _config_map(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    return next(
+        document
+        for document in documents
+        if document.get("kind") == "ConfigMap"
+        and document.get("metadata", {}).get("name") == "django-config"
+    )
+
+
+def _deployments(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        document
+        for document in documents
+        if document.get("kind") == "Deployment"
+        and document.get("metadata", {}).get("name")
+        in {"citrus", "citrus-media-worker", "citrus-dev", "citrus-dev-media-worker"}
+    ]
+
+
+class CitrusDevMailSafetyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dev_documents = _render(dev=True)
+        cls.prod_documents = _render(dev=False)
+
+    def test_dev_discards_outbound_mail(self) -> None:
+        self.assertEqual(
+            _config_map(self.dev_documents)["data"]["EMAIL_BACKEND"],
+            DUMMY_BACKEND,
+        )
+
+    def test_production_mail_backend_is_not_overridden(self) -> None:
+        self.assertNotIn(
+            "EMAIL_BACKEND",
+            _config_map(self.prod_documents)["data"],
+        )
+
+    def test_dev_config_changes_roll_web_and_worker_pods(self) -> None:
+        deployments = _deployments(self.dev_documents)
+        self.assertEqual(len(deployments), 2)
+        for deployment in deployments:
+            checksum = (
+                deployment["spec"]["template"]["metadata"]
+                ["annotations"]["checksum/config"]
+            )
+            self.assertRegex(checksum, re.compile(r"^[0-9a-f]{64}$"))
+
+    def test_production_pod_templates_are_not_given_dev_rollout_annotations(self) -> None:
+        deployments = _deployments(self.prod_documents)
+        self.assertEqual(len(deployments), 2)
+        for deployment in deployments:
+            annotations = (
+                deployment["spec"]["template"]["metadata"]
+                .get("annotations", {})
+            )
+            self.assertNotIn("checksum/config", annotations)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Configure Citrus dev to use Django's dummy email backend, which discards all outbound messages.
- Add an opt-in ConfigMap checksum to the Citrus web and worker pod templates so dev configuration changes trigger a rollout.
- Keep the production render unchanged.
- Add a Helm-rendered contract test for the dev/production separation.

## Root cause

Citrus dev used the same real Gmail SMTP relay and `orders@citrus-grace.com` sender as production. Synthetic dev customers intentionally use reserved domains such as `.invalid`; normal dev order or payment actions therefore produced real non-delivery notices in the shared orders mailbox.

## Impact

After this change reconciles, no Citrus dev code path can deliver mail through SMTP. Production continues to use its existing email backend and configuration.

## Verification

- `helm lint helm/citrus`
- `helm lint helm/citrus -f helm/citrus/values-dev.yaml`
- strict kubeconform: 10/10 dev resources valid
- strict kubeconform: 10/10 production resources valid
- focused Citrus mail-safety tests: 4/4 pass
- full Python contract suite: 189/189 pass
- control-plane release pin and grant ownership checks: pass
- no-latest gate: pass
- modified production render is byte-for-byte identical to the `main` baseline
