### PR TITLE
CES-748: trust ingress client IP forwarding

### DIFF
--- a/helm/citrus/values.yaml
+++ b/helm/citrus/values.yaml
@@ -34,7 +34,7 @@ application:
   # dev overrides this with citrus-dev-app-key in values-dev.yaml.
   generatedSecretName: citrus-app-key
   spacesSecretName: django-spaces-secrets
-  rolloutOnConfigChange: false
+  rolloutOnConfigChange: true
   command: >-
     exec gunicorn Mycore.wsgi:application --bind 0.0.0.0:8000 --workers 2 --timeout
     120 --access-logfile -
@@ -61,6 +61,12 @@ application:
     MEDIA_COMPRESSION_ENABLED: "True"
     MEDIA_GALLERY_MAX_BATCH: "25"
     RATELIMIT_USE_CACHE: "default"
+    # ingress-nginx reaches Citrus from the DOKS pod network and replaces any
+    # client-supplied X-Forwarded-For value with the source address it observes.
+    # Citrus still walks the chain from right to left and trusts it only when
+    # REMOTE_ADDR belongs to this managed cluster pod CIDR.
+    TRUST_X_FORWARDED_FOR: "True"
+    TRUSTED_PROXY_IPS: "10.244.0.0/16"
     EMAIL_HOST: "smtp-relay.gmail.com"
     EMAIL_PORT: "587"
     EMAIL_USE_TLS: "True"

--- a/tests/test_citrus_dev_mail_safety.py
+++ b/tests/test_citrus_dev_mail_safety.py
@@ -92,15 +92,15 @@ class CitrusDevMailSafetyTests(unittest.TestCase):
             )
             self.assertRegex(checksum, re.compile(r"^[0-9a-f]{64}$"))
 
-    def test_production_pod_templates_are_not_given_dev_rollout_annotations(self) -> None:
+    def test_production_config_changes_roll_web_and_worker_pods(self) -> None:
         deployments = _deployments(self.prod_documents)
         self.assertEqual(len(deployments), 2)
         for deployment in deployments:
-            annotations = (
+            checksum = (
                 deployment["spec"]["template"]["metadata"]
-                .get("annotations", {})
+                ["annotations"]["checksum/config"]
             )
-            self.assertNotIn("checksum/config", annotations)
+            self.assertRegex(checksum, re.compile(r"^[0-9a-f]{64}$"))
 
 
 if __name__ == "__main__":

--- a/tests/test_citrus_forwarded_for_trust.py
+++ b/tests/test_citrus_forwarded_for_trust.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART_PATH = REPO_ROOT / "helm" / "citrus"
+DEV_VALUES = CHART_PATH / "values-dev.yaml"
+YAML_PARSER = YAML(typ="safe")
+TRUSTED_DOKS_POD_CIDR = "10.244.0.0/16"
+
+
+def _render(*, dev: bool) -> list[dict[str, Any]]:
+    if shutil.which("helm") is None:
+        raise unittest.SkipTest("helm is required for chart render tests")
+
+    command = [
+        "helm",
+        "template",
+        "citrus-dev" if dev else "citrus",
+        str(CHART_PATH),
+        "--namespace",
+        "citrus-dev" if dev else "default",
+    ]
+    if dev:
+        command.extend(["-f", str(DEV_VALUES)])
+
+    result = subprocess.run(
+        command,
+        check=True,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    return [
+        document
+        for document in YAML_PARSER.load_all(result.stdout)
+        if isinstance(document, dict) and document
+    ]
+
+
+def _config_map(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    return next(
+        document
+        for document in documents
+        if document.get("kind") == "ConfigMap"
+        and document.get("metadata", {}).get("name") == "django-config"
+    )
+
+
+class CitrusForwardedForTrustTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dev_config = _config_map(_render(dev=True))["data"]
+        cls.prod_config = _config_map(_render(dev=False))["data"]
+
+    def test_prod_and_dev_trust_only_the_doks_pod_network(self) -> None:
+        for config in (self.prod_config, self.dev_config):
+            self.assertEqual(config["TRUST_X_FORWARDED_FOR"], "True")
+            self.assertEqual(
+                config["TRUSTED_PROXY_IPS"],
+                TRUSTED_DOKS_POD_CIDR,
+            )
+
+    def test_payment_setup_feature_is_not_activated_by_proxy_fix(self) -> None:
+        for config in (self.prod_config, self.dev_config):
+            self.assertNotIn("DIRECT_ORDER_PAYMENT_SETUP_ENABLED", config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Fixes the CES-748 GitOps gap that made Citrus record the ingress pod address instead of the real client address for deferred-charge consent evidence and rate limits.

## Root cause

Citrus already has a fail-closed `get_client_ip()` boundary, but both deployed ConfigMaps left `TRUST_X_FORWARDED_FOR` disabled and did not define a trusted proxy network. Production also did not roll pods when ConfigMap data changed, so a values-only fix would not have reached running processes.

## Changes

- Enable trusted `X-Forwarded-For` processing for prod and dev.
- Trust only the DOKS pod network, `10.244.0.0/16`, which contains the ingress controller source address seen by Citrus.
- Roll prod and dev web/worker Deployments when the rendered ConfigMap changes.
- Add render regression tests for the exact proxy settings, both environments, rollout checksums, and the non-activation of `DIRECT_ORDER_PAYMENT_SETUP_ENABLED`.

## Security boundary

- The public legacy ingress Service uses `externalTrafficPolicy: Local`, preserving the address observed by NGINX.
- The running NGINX config sets `X-Forwarded-For` to `$remote_addr`, replacing client-supplied values.
- Citrus accepts the header only when `REMOTE_ADDR` is in the trusted DOKS pod CIDR and walks the chain from right to left.
- Consent evidence and account rate limiting both use `Accounts.request_meta.get_client_ip`.
- A compromised workload already inside the cluster pod network remains able to call the ClusterIP directly and claim an address; restricting east-west access is a separate NetworkPolicy hardening concern. The Citrus Service is not public.

## Validation

- Python 3.11.13 CI contract: `198 tests` passed.
- Focused Citrus render contract: `6 tests` passed.
- `helm lint helm/citrus` passed for prod and dev values.
- Kubeconform v0.6.7: prod `10/10` resources valid; dev `10/10` resources valid.
- Exact `no-latest`, grant-ownership, and release-pin checks passed.
- Live read-only preflight confirmed:
  - DOKS cluster subnet: `10.244.0.0/16`
  - serving legacy ingress pod: `10.244.0.85`
  - Citrus public ingress address: `143.244.222.41`
  - NGINX replaces `X-Forwarded-For` with `$remote_addr`
  - Citrus dev has `0` existing deferred-charge consent rows

## Rollout and verification

Merging allows automated Argo sync to update both ConfigMaps and roll web/worker pods through the checksum change. This PR does **not** enable `DIRECT_ORDER_PAYMENT_SETUP_ENABLED`.

After the dev rollout, verify an external setup request records the caller's real address before enabling the feature in production. Existing consent evidence is not migrated or rewritten.

Linear: https://linear.app/cegarza/issue/CES-748/fix-ingress-xff-before-enabling-deferred-charge-consent-consent
