### PR TITLE
CES-748: stage source-IP load balancer cutover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,6 +195,29 @@ jobs:
       - name: Check complete registry overlay Application render
         run: uv run python scripts/check_agent_control_plane_registry_overlay_render.py
 
+  operator-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install kubeconform
+        run: |
+          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+            --output kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          gzip -t kubeconform.tar.gz
+          tar -xzf kubeconform.tar.gz
+          sudo mv kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Validate operator-only infrastructure manifests
+        run: >-
+          kubeconform
+          -schema-location default
+          -strict -summary -exit-on-error
+          infra/ingress-nginx/citrus-source-ip-load-balancer.yaml
+
   helm-and-kubeconform:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 
 ## Quick links
 
-- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/runbooks/citrus-spaces-cors.md`, `docs/developer-cheat-sheet.md`
+- Bootstrap/runbooks: `docs/bootstrap.md`, `docs/argo-operations.md`, `docs/release-workflow.md`, `docs/cluster-identity.md`, `docs/secrets-strategy.md`, `docs/runbooks/postgres-restore.md`, `docs/runbooks/citrus-spaces-cors.md`, `infra/ingress-nginx/README.md`, `docs/developer-cheat-sheet.md`
 - KSOPS deep dive and CMP recipe: `docs/ksops-llm-response.md`
 - Argo objects: `argocd/` (AppProjects, Applications, AppSets)
 - Charts/values: `helm/` and `apps/`
@@ -19,6 +19,7 @@ Kubernetes + Argo CD source of truth for SplatTop. Charts, AppSets, secrets work
 - `helm/` – service charts and the umbrella chart; values files cover dev/default/prod overlays.
 - `k8s/` – legacy/standalone manifests (ingress, cert, repo-server patches, secrets templates).
 - `infra/spaces/` – checked-in Spaces bucket configuration payloads that must be applied by operators.
+- `infra/ingress-nginx/` – operator-only Citrus source-IP load-balancer payloads that are not reconciled by Argo CD.
 - `secrets/` – encrypted bot secrets (`secrets/bots/**`) with `kustomization.yaml` + `ksops.yaml` per bot.
 - `docs/` – runbooks and design notes; start with `docs/README.md` for the reading order.
 - `scripts/` – helpers like `scripts/validate_prometheus_config.py` (renders Helm, then promtool).

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,10 @@ Read them in roughly this order when contributing here:
    procedure for the live Mandate `agent-control-plane` deployment.
 9. `runbooks/citrus-spaces-cors.md` – DigitalOcean Spaces CORS procedure for
    Citrus Grace browser media uploads.
-10. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
-11. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
+10. `../infra/ingress-nginx/README.md` – operator-gated CES-748 blue/green
+    source-IP load-balancer activation and rollback.
+11. `developer-cheat-sheet.md` – quick reference for common commands/tasks after the split.
+12. `k8s/secrets.template.yaml` → `k8s/secrets.enc.yaml` – example flow for encrypted secrets.
 
 Supplemental references:
 

--- a/infra/ingress-nginx/README.md
+++ b/infra/ingress-nginx/README.md
@@ -1,0 +1,122 @@
+# Citrus source-IP load balancer
+
+This directory contains the operator-only CES-748 blue/green payload. It
+creates a second DigitalOcean `REGIONAL_NETWORK` load balancer in front of the
+existing legacy ingress-nginx pods. DigitalOcean network load balancers
+preserve the client source address natively, so neither NGINX nor the existing
+`REGIONAL` load balancer needs a risky one-sided PROXY-protocol transition.
+
+The payload is deliberately not referenced by Argo CD, Helm, or Kustomize.
+Merging it is inert. It does not modify the current Service/load balancer,
+Ingresses, controller ConfigMap or Deployment, DNS, or the Citrus payment flag.
+Applying it and changing DNS are separate production operations that require
+explicit approval.
+
+DigitalOcean currently labels `REGIONAL_NETWORK` as public preview and does not
+support IPv6 on it. This is not a current Citrus regression: the old load
+balancer has an IPv4-only network stack and all three Citrus hosts have A
+records but no AAAA records. Re-check those facts immediately before applying.
+
+## Activation gates
+
+1. Confirm the cluster is still DOKS 1.33.1-do.0 or later and the old route is
+   healthy at `143.244.222.41`.
+2. Confirm only `citrus-grace.com`, `www.citrus-grace.com`, and
+   `dev.citrus-grace.com` use ingress class `legacy-nginx`.
+3. Confirm each hostname has an A record and no AAAA record. Stop if IPv6 has
+   become part of the production contract.
+4. Scale the existing legacy controller to two ready replicas on distinct
+   nodes before using it as the sole backend for the new route:
+
+   ```bash
+   kubectl -n ingress-nginx scale deployment ingress-nginx-controller --replicas=2
+   kubectl -n ingress-nginx rollout status deployment/ingress-nginx-controller
+   kubectl -n ingress-nginx get pod \
+     -l app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/component=controller \
+     -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName,READY:.status.containerStatuses[0].ready
+   ```
+
+   Require two `READY=true` rows on different nodes. This legacy Deployment is
+   not Argo-owned; record the live replica count before changing it.
+5. Confirm both Citrus Certificates are Ready and at least seven days before
+   renewal. Stop rather than overlapping this migration with ACME renewal.
+6. Record the DOKS worker firewall. DigitalOcean documents that creating a
+   network load balancer adds inbound `0.0.0.0/0` access to kube-proxy health
+   port 10256. After creation, verify that this is the only new public worker
+   rule and that no ingress NodePort became public.
+
+## Create without cutting over
+
+Apply the checked-in payload:
+
+```bash
+kubectl apply -f infra/ingress-nginx/citrus-source-ip-load-balancer.yaml
+```
+
+This adds a PDB and a second Service. It does not alter the old Service named
+`ingress-nginx-controller`. Wait for the new Service to receive an external IP
+and for `doctl` to report a healthy `REGIONAL_NETWORK` load balancer named
+`citrus-source-ip`.
+
+Re-read the DOKS worker firewall and require the provider-created public rule
+to be limited to TCP port 10256. Stop if any workload or NodePort is exposed.
+
+The Service ports and numeric target ports intentionally match (80→80 and
+443→443), as DigitalOcean requires for a network load balancer. Its
+`externalTrafficPolicy: Local` health check sends traffic only to nodes with a
+ready controller pod.
+
+## Prove the new route before DNS
+
+For each Citrus hostname, use `curl --resolve` to send HTTPS directly to the
+new external IP. Require a valid existing certificate and HTTP 200 from prod
+and dev.
+
+From a client with a known public IPv4 address:
+
+1. Make a uniquely identifiable production request through the new IP.
+2. Confirm the legacy ingress access log records that public address exactly.
+3. Confirm the live application path using `get_client_ip` reports the same
+   address.
+4. Repeat with a forged `X-Forwarded-For` header and confirm the forged value
+   changes neither result.
+5. Confirm representative hosts on the unrelated `nginx` controller still
+   return 200.
+
+Do not change DNS unless every check passes. `DIRECT_ORDER_PAYMENT_SETUP_ENABLED`
+remains disabled until CES-748's live production identity gates have passed.
+
+## DNS cutover and observation
+
+Change the A records for all three Citrus hosts from `143.244.222.41` to the new
+network load balancer IP. Keep the old Service and load balancer intact. Verify
+public resolvers, access logs, prod/dev HTTP 200, the known-IP check, and the
+forged-header check throughout the observation window.
+
+Do not delete or disown the old load balancer in CES-748. Its continued health
+is the rollback control. Removal is a separately reviewed cleanup after the
+new route has remained healthy.
+
+## Rollback
+
+Restore the three DNS A records to `143.244.222.41`. Verify public resolution,
+prod/dev HTTP 200, and the old ingress access log. The old load balancer never
+changed, so rollback does not have a PROXY-protocol convergence window.
+
+Only after DNS is confirmed back on the old route may an operator remove the
+new resources:
+
+```bash
+kubectl delete -f infra/ingress-nginx/citrus-source-ip-load-balancer.yaml
+```
+
+Deletion destroys the new DigitalOcean load balancer. Enumerate its Service,
+public IP, and `doctl` load-balancer ID before deletion and obtain explicit
+cleanup approval. Restore the controller's recorded pre-cutover replica count
+only after the rollback route is stable. Confirm DigitalOcean also removed the
+network load balancer's public port-10256 health-check firewall rule.
+
+## Provider references
+
+- [DigitalOcean DOKS load-balancer configuration](https://docs.digitalocean.com/products/kubernetes/how-to/configure-load-balancers/)
+- [DigitalOcean load-balancer setting ownership](https://docs.digitalocean.com/support/why-do-my-doks-load-balancer-settings-keep-reverting/)

--- a/infra/ingress-nginx/citrus-source-ip-load-balancer.yaml
+++ b/infra/ingress-nginx/citrus-source-ip-load-balancer.yaml
@@ -1,0 +1,49 @@
+# CES-748 operator-only blue/green load balancer.
+#
+# This file is deliberately not referenced by Argo CD, Helm, or Kustomize.
+# It creates a second load balancer and leaves the current REGIONAL load
+# balancer and its Service unchanged for immediate rollback.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ingress-nginx-controller-source-ip-cutover
+  namespace: ingress-nginx
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller-source-ip
+  namespace: ingress-nginx
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-name: citrus-source-ip
+    service.beta.kubernetes.io/do-loadbalancer-type: REGIONAL_NETWORK
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - appProtocol: http
+      name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+    - appProtocol: https
+      name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: LoadBalancer

--- a/tests/test_citrus_source_ip_load_balancer.py
+++ b/tests/test_citrus_source_ip_load_balancer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA_DIR = REPO_ROOT / "infra" / "ingress-nginx"
+MANIFEST = INFRA_DIR / "citrus-source-ip-load-balancer.yaml"
+RUNBOOK = INFRA_DIR / "README.md"
+YAML_PARSER = YAML(typ="safe")
+CONTROLLER_SELECTOR = {
+    "app.kubernetes.io/component": "controller",
+    "app.kubernetes.io/instance": "ingress-nginx",
+    "app.kubernetes.io/name": "ingress-nginx",
+}
+
+
+class CitrusSourceIpLoadBalancerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.documents = [
+            document
+            for document in YAML_PARSER.load_all(MANIFEST.read_text(encoding="utf-8"))
+            if isinstance(document, dict) and document
+        ]
+        cls.by_kind = {document["kind"]: document for document in cls.documents}
+        cls.runbook = RUNBOOK.read_text(encoding="utf-8")
+
+    def test_payload_contains_only_pdb_and_parallel_service(self) -> None:
+        self.assertEqual(
+            [document["kind"] for document in self.documents],
+            ["PodDisruptionBudget", "Service"],
+        )
+        for document in self.documents:
+            metadata = document["metadata"]
+            self.assertEqual(metadata["namespace"], "ingress-nginx")
+            for server_field in ("creationTimestamp", "finalizers", "resourceVersion", "uid"):
+                self.assertNotIn(server_field, metadata)
+            self.assertNotIn("status", document)
+
+    def test_service_creates_a_distinct_source_ip_preserving_load_balancer(self) -> None:
+        service = self.by_kind["Service"]
+        self.assertEqual(service["metadata"]["name"], "ingress-nginx-controller-source-ip")
+        self.assertNotIn("kubernetes.digitalocean.com/load-balancer-id", service["metadata"]["annotations"])
+        self.assertEqual(
+            service["metadata"]["annotations"],
+            {
+                "service.beta.kubernetes.io/do-loadbalancer-name": "citrus-source-ip",
+                "service.beta.kubernetes.io/do-loadbalancer-type": "REGIONAL_NETWORK",
+            },
+        )
+        spec = service["spec"]
+        self.assertEqual(spec["type"], "LoadBalancer")
+        self.assertEqual(spec["externalTrafficPolicy"], "Local")
+        self.assertEqual(spec["selector"], CONTROLLER_SELECTOR)
+        self.assertEqual(
+            [(port["protocol"], port["port"], port["targetPort"]) for port in spec["ports"]],
+            [("TCP", 80, 80), ("TCP", 443, 443)],
+        )
+        self.assertNotIn("clusterIP", spec)
+        self.assertNotIn("nodePort", str(spec))
+
+    def test_pdb_preserves_a_controller_during_cutover(self) -> None:
+        pdb = self.by_kind["PodDisruptionBudget"]
+        self.assertEqual(pdb["metadata"]["name"], "ingress-nginx-controller-source-ip-cutover")
+        self.assertEqual(pdb["spec"]["minAvailable"], 1)
+        self.assertEqual(pdb["spec"]["selector"]["matchLabels"], CONTROLLER_SELECTOR)
+
+    def test_payload_is_not_wired_to_automatic_gitops_reconciliation(self) -> None:
+        self.assertFalse(list(INFRA_DIR.glob("kustomization.y*ml")))
+        manifest_reference = MANIFEST.relative_to(REPO_ROOT).as_posix()
+        for path in (REPO_ROOT / "argocd").rglob("*.yaml"):
+            self.assertNotIn(manifest_reference, path.read_text(encoding="utf-8"))
+
+    def test_runbook_freezes_blue_green_gates_and_rollback(self) -> None:
+        normalized_runbook = " ".join(self.runbook.split())
+        required_phrases = (
+            "Merging it is inert",
+            "public preview",
+            "no AAAA record",
+            "two `READY=true` rows on different nodes",
+            "at least seven days before",
+            "only new public worker rule",
+            "kubectl apply -f infra/ingress-nginx/citrus-source-ip-load-balancer.yaml",
+            "80→80 and 443→443",
+            "known public IPv4 address",
+            "get_client_ip",
+            "forged `X-Forwarded-For`",
+            "DIRECT_ORDER_PAYMENT_SETUP_ENABLED",
+            "Keep the old Service and load balancer intact",
+            "Restore the three DNS A records to `143.244.222.41`",
+            "obtain explicit cleanup approval",
+            "removed the network load balancer's public port-10256",
+        )
+        for phrase in required_phrases:
+            self.assertIn(phrase, normalized_runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Stages a blue/green DigitalOcean load balancer that can carry real Citrus client IPv4 addresses to the existing `legacy-nginx` controller without changing the active route.

This follows merged PR #524. Live verification of that PR proved the existing DigitalOcean `REGIONAL` load balancer SNATs every client to `10.108.0.16`, so Citrus still sees one constant address.

## What changed

- adds an operator-only `REGIONAL_NETWORK` Service selecting the existing legacy controller pods;
- adds a cutover PDB so one controller remains available during voluntary disruption;
- adds a gated activation, validation, DNS rollback, and cleanup runbook;
- adds exact contract tests and a strict kubeconform CI job for operator manifests.

DigitalOcean documents that `REGIONAL_NETWORK` preserves source IP natively. The old Service/load balancer remains unchanged as the rollback route.

## Security and non-goals

- No PROXY protocol or VPC-wide trusted PROXY CIDR is introduced.
- No Ingress, cert-manager, external-dns, controller ConfigMap, or Deployment ownership changes.
- No DNS records, live cluster resources, or DigitalOcean resources are changed by merging this PR.
- `DIRECT_ORDER_PAYMENT_SETUP_ENABLED` remains disabled.
- The new LB is IPv4-only/public preview; Citrus currently has A records and no AAAA records, and the runbook requires rechecking that contract.

An earlier duplicate-Ingress failover design was discarded before publication because a live server-side dry-run proved the cluster admission webhook rejects duplicate host/path ownership even across ingress classes.

## Validation

- `python -m unittest discover -s tests` — 203 passed
- focused source-IP LB tests — 5 passed
- kubeconform 0.6.7 strict validation — 2 resources valid
- Kubernetes 1.33 server-side dry-run — PDB and Service accepted
- grant ownership, control-plane pin, registry-overlay render, workflow YAML, mutable-image, and diff checks — passed
- independent adversarial review — clean

## Rollout order

1. Merge only; this is inert and operator-only.
2. With separate production authorization, scale the legacy controller to two ready pods on distinct nodes.
3. Apply the PDB/parallel Service and verify the provider-created firewall rule is limited to TCP 10256.
4. Before DNS, prove prod/dev HTTP 200, known public IP parity in ingress logs and live `get_client_ip`, and forged-XFF rejection through the new IP.
5. Cut all three Citrus A records to the new IP and observe.
6. Keep the old LB unchanged for DNS rollback; cleanup is a later destructive operation requiring separate approval.

CES-748 remains open until the live identity and spoofing gates pass.
